### PR TITLE
feat: Add logic to mark internal member cluster joined/ unknown

### DIFF
--- a/pkg/controllers/memberinternalmembercluster/member_controller_test.go
+++ b/pkg/controllers/memberinternalmembercluster/member_controller_test.go
@@ -10,11 +10,36 @@ import (
 	v12 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/apis/core"
 
 	"go.goms.io/fleet/apis/v1alpha1"
 	"go.goms.io/fleet/pkg/controllers/common"
 	"go.goms.io/fleet/pkg/utils"
 )
+
+func TestMarkInternalMemberClusterJoined(t *testing.T) {
+	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
+	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+
+	r.markInternalMemberClusterJoined(internalMemberCluster)
+
+	// check that the correct event is emitted
+	event := <-r.recorder.(*record.FakeRecorder).Events
+	expected := utils.GetEventString(internalMemberCluster, v12.EventTypeNormal, eventReasonInternalMemberClusterJoined, "internal member cluster joined")
+
+	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterJoined")
+
+	// Check expected conditions.
+	expectedConditions := []metav1.Condition{
+		{Type: v1alpha1.ConditionTypeInternalMemberClusterJoin, Status: metav1.ConditionTrue, Reason: eventReasonInternalMemberClusterJoined},
+		{Type: common.ConditionTypeSynced, Status: metav1.ConditionTrue, Reason: common.ReasonReconcileSuccess},
+	}
+
+	for _, expectedCondition := range expectedConditions {
+		actualCondition := internalMemberCluster.GetCondition(expectedCondition.Type)
+		assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterJoined")
+	}
+}
 
 func TestMarkInternalMemberClusterLeft(t *testing.T) {
 	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
@@ -37,5 +62,28 @@ func TestMarkInternalMemberClusterLeft(t *testing.T) {
 	for _, expectedCondition := range expectedConditions {
 		actualCondition := internalMemberCluster.GetCondition(expectedCondition.Type)
 		assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterLeft")
+	}
+}
+
+func TestMarkInternalMemberClusterUnknown(t *testing.T) {
+	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
+
+	r.markInternalMemberClusterUnknown(internalMemberCluster)
+
+	// check that the correct event is emitted
+	event := <-r.recorder.(*record.FakeRecorder).Events
+	expected := utils.GetEventString(internalMemberCluster, core.EventTypeNormal, eventReasonInternalMemberClusterUnknown, "internal member cluster unknown")
+
+	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterUnknown")
+
+	// Check expected conditions.
+	expectedConditions := []metav1.Condition{
+		{Type: v1alpha1.ConditionTypeMembershipJoin, Status: metav1.ConditionUnknown, Reason: eventReasonInternalMemberClusterUnknown},
+		{Type: common.ConditionTypeSynced, Status: metav1.ConditionTrue, Reason: common.ReasonReconcileSuccess},
+	}
+	for _, expectedCondition := range expectedConditions {
+		actualCondition := internalMemberCluster.GetCondition(expectedCondition.Type)
+		assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterUnknown")
 	}
 }


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Add logic to mark internal member cluster join as succeed/ unknown

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

UT

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
