### PR TITLE
feat: Add logic to mark internal member cluster heartbeat condition

### DIFF
--- a/pkg/controllers/memberinternalmembercluster/member_controller_test.go
+++ b/pkg/controllers/memberinternalmembercluster/member_controller_test.go
@@ -87,3 +87,50 @@ func TestMarkInternalMemberClusterUnknown(t *testing.T) {
 		assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterUnknown")
 	}
 }
+
+func TestMarkInternalMemberClusterHeartbeatReceived(t *testing.T) {
+	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
+	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+
+	r.markInternalMemberClusterHeartbeatReceived(internalMemberCluster)
+
+	// check that the correct event is emitted
+	event := <-r.recorder.(*record.FakeRecorder).Events
+	expected := utils.GetEventString(internalMemberCluster, v12.EventTypeNormal, eventReasonInternalMemberClusterHBReceived, "internal member cluster heartbeat received")
+
+	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterHeartbeatReceived")
+
+	// Check expected conditions.
+	expectedConditions := []metav1.Condition{
+		{Type: v1alpha1.ConditionTypeInternalMemberClusterHeartbeat, Status: metav1.ConditionTrue, Reason: eventReasonInternalMemberClusterHBReceived},
+		{Type: common.ConditionTypeSynced, Status: metav1.ConditionTrue, Reason: common.ReasonReconcileSuccess},
+	}
+
+	for _, expectedCondition := range expectedConditions {
+		actualCondition := internalMemberCluster.GetCondition(expectedCondition.Type)
+		assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterHeartbeatReceived")
+	}
+}
+
+func TestMarkInternalMemberClusterHeartbeatUnknown(t *testing.T) {
+	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
+
+	r.markInternalMemberClusterHeartbeatUnknown(internalMemberCluster)
+
+	// check that the correct event is emitted
+	event := <-r.recorder.(*record.FakeRecorder).Events
+	expected := utils.GetEventString(internalMemberCluster, core.EventTypeNormal, eventReasonInternalMemberClusterHBUnknown, "internal member cluster heartbeat unknown")
+
+	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterHeartbeatUnknown")
+
+	// Check expected conditions.
+	expectedConditions := []metav1.Condition{
+		{Type: v1alpha1.ConditionTypeInternalMemberClusterHeartbeat, Status: metav1.ConditionUnknown, Reason: eventReasonInternalMemberClusterHBUnknown},
+		{Type: common.ConditionTypeSynced, Status: metav1.ConditionTrue, Reason: common.ReasonReconcileSuccess},
+	}
+	for _, expectedCondition := range expectedConditions {
+		actualCondition := internalMemberCluster.GetCondition(expectedCondition.Type)
+		assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterHeartbeatUnknown")
+	}
+}


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Add logic to mark internal member cluster heartbeat condition as received/ unknown. For the context of how these fns would be used, please see #18 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

UT


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
