### PR TITLE
feat: Minor refactors for suite-test

### DIFF
--- a/pkg/controllers/internalmembercluster/member_suite_test.go
+++ b/pkg/controllers/internalmembercluster/member_suite_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -28,35 +28,35 @@ var (
 )
 
 func TestInternalMemberCluster(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Internal Member Cluster Controller Integration Test Suite")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Member Cluster Controller Integration Test Suite")
 }
 
-var _ = ginkgo.BeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	done := make(chan interface{})
 	go func() {
-		klog.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
+		klog.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-		ginkgo.By("bootstrapping test environment")
+		By("bootstrapping test environment")
 		testEnv = &envtest.Environment{
 			CRDDirectoryPaths:     []string{filepath.Join("../../../", "config", "crd", "bases")},
 			ErrorIfCRDPathMissing: true,
 		}
 		var err error
 		cfg, err = testEnv.Start()
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(cfg).NotTo(gomega.BeNil())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg).NotTo(BeNil())
 
 		err = v1alpha1.AddToScheme(scheme.Scheme)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		//+kubebuilder:scaffold:scheme
-		ginkgo.By("construct the k8s client")
+		By("construct the k8s client")
 		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(k8sClient).NotTo(gomega.BeNil())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient).NotTo(BeNil())
 
-		ginkgo.By("Starting the controller manager")
+		By("Starting the controller manager")
 		klog.InitFlags(flag.CommandLine)
 		mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 			Scheme:             scheme.Scheme,
@@ -64,15 +64,15 @@ var _ = ginkgo.BeforeSuite(func() {
 			Logger:             klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)),
 			Port:               4848,
 		})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		close(done)
 	}()
-	gomega.Eventually(done, 60).Should(gomega.BeClosed())
+	Eventually(done, 60).Should(BeClosed())
 })
 
-var _ = ginkgo.AfterSuite(func() {
-	ginkgo.By("tearing down the test environment")
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
 	err := testEnv.Stop()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 })

--- a/pkg/controllers/membership/membership_suite_test.go
+++ b/pkg/controllers/membership/membership_suite_test.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/onsi/ginkgo/v2"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -28,35 +28,35 @@ var (
 )
 
 func TestMembership(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Membership Controller Integration Test Suite")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Membership Controller Integration Test Suite")
 }
 
-var _ = ginkgo.BeforeSuite(func() {
+var _ = BeforeSuite(func() {
 	done := make(chan interface{})
 	go func() {
-		klog.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
+		klog.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-		ginkgo.By("bootstrapping test environment")
+		By("bootstrapping test environment")
 		testEnv = &envtest.Environment{
-			CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+			CRDDirectoryPaths:     []string{filepath.Join("../../../", "config", "crd", "bases")},
 			ErrorIfCRDPathMissing: true,
 		}
 		var err error
 		cfg, err = testEnv.Start()
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(cfg).NotTo(gomega.BeNil())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg).NotTo(BeNil())
 
 		err = v1alpha1.AddToScheme(scheme.Scheme)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		//+kubebuilder:scaffold:scheme
-		ginkgo.By("construct the k8s client")
+		By("construct the k8s client")
 		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(k8sClient).NotTo(gomega.BeNil())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient).NotTo(BeNil())
 
-		ginkgo.By("Starting the controller manager")
+		By("Starting the controller manager")
 		klog.InitFlags(flag.CommandLine)
 		mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 			Scheme:             scheme.Scheme,
@@ -64,15 +64,15 @@ var _ = ginkgo.BeforeSuite(func() {
 			Logger:             klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)),
 			Port:               4848,
 		})
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 
 		close(done)
 	}()
-	gomega.Eventually(done, 60).Should(gomega.BeClosed())
+	Eventually(done, 60).Should(BeClosed())
 })
 
-var _ = ginkgo.AfterSuite(func() {
-	ginkgo.By("tearing down the test environment")
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
 	err := testEnv.Stop()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I decided to move to using dot-import for ginkgo and gomega. I have considered:
* Golang team guideline on using dot-import
* Ginkgo stand on dot-import https://onsi.github.io/ginkgo/
* Usage of this in Azure repo

Since the convention is following ginkgo stand, I want to follow this convention since I don't want to import package every time if the owners allow not to and everyone is not doing it.

Examples:
* In `aks-rp` https://msazure.visualstudio.com/CloudNativeCompute/_git/aks-rp?path=/admissionsenforcer/client/suite_test.go&_a=contents&version=GBmaster
* `caravel` repo
I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
