### PR TITLE
fix: Use klog.FlushAndExit instead of os.Exit

### DIFF
--- a/cmd/hubagent/main.go
+++ b/cmd/hubagent/main.go
@@ -44,6 +44,7 @@ func init() {
 
 func main() {
 	flag.Parse()
+	defer klog.Flush()
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -55,6 +55,7 @@ func init() {
 func main() {
 	flag.Parse()
 
+	defer klog.Flush()
 	hubURL := os.Getenv("HUB_SERVER_URL")
 
 	if hubURL == "" {


### PR DESCRIPTION
### Description of your changes
We should add klog.Flush() func 
```
Log output is buffered and written periodically using Flush. Programs should call Flush before exiting to guarantee all log output is written.
``` 
https://pkg.go.dev/k8s.io/klog/v2#pkg-overview


I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested


### Special notes for your reviewer

//@zhiying-lin
