### PR TITLE
fix: unkown flag: --v

### DIFF
--- a/cmd/authtoken/main.go
+++ b/cmd/authtoken/main.go
@@ -6,9 +6,11 @@ package main
 
 import (
 	"context"
+	"flag"
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 
 	"go.goms.io/fleet/pkg/authtoken"
@@ -69,6 +71,10 @@ func parseArgs() (interfaces.AuthTokenProvider, error) {
 
 func main() {
 	klog.InitFlags(nil)
+
+	// Add go flags (e.g., --v) to pflag.
+	// Reference: https://github.com/spf13/pflag#supporting-go-flags-when-using-pflag
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	tokenProvider, err := parseArgs()
 	if err != nil {


### PR DESCRIPTION
Fix the code to support go flags.

[before]
~/github/fleet/cmd/authtoken liqian/v ❯ go run main.go azure --v 3 --clientid 1
Error: unknown flag: --v

[after]
~/github/fleet/cmd/authtoken liqian/v !1 ❯ go run main.go azure --v 3 --clientid 1                                                                                  3s
I0708 09:17:28.894725   64380 main.go:87] "creating token refresher"
I0708 09:17:28.895018   64380 token_refresher.go:42] "start refresh token"