### PR TITLE
Address comments from Ryan.

### DIFF
--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -50,7 +50,9 @@ func (a *azureAuthTokenProvider) FetchToken(ctx context.Context) (interfaces.Aut
 			azToken, err = credential.GetToken(ctx, policy.TokenRequestOptions{
 				Scopes: []string{aksScope},
 			})
-			klog.ErrorS(err, "Failed to GetToken")
+			if err != nil {
+				klog.ErrorS(err, "Failed to GetToken")
+			}
 			return err
 		})
 	if err != nil {

--- a/pkg/authtoken/token_refresher.go
+++ b/pkg/authtoken/token_refresher.go
@@ -48,7 +48,7 @@ func (at *Refresher) callFetchToken(ctx context.Context) (interfaces.AuthToken, 
 }
 
 func (at *Refresher) RefreshToken(ctx context.Context) error {
-	klog.V(5).InfoS("RefreshToken start")
+	klog.V(2).InfoS("RefreshToken start")
 	refreshDuration := DefaultRefreshDuration
 
 	for ; ; <-at.createTicker(refreshDuration) {


### PR DESCRIPTION
Test output:

~/github/fleet/cmd/authtoken liqian/refresh2 ❯ go run main.go azure --v 5 --clientid d58772ec-ff68-444e-8c29-386ecdacea19                                       6m 18s
I0708 13:00:48.369502   69229 main.go:87] "creating token refresher"
I0708 13:00:48.369848   69229 token_refresher.go:51] "RefreshToken start"
I0708 13:00:48.369857   69229 token_refresher.go:43] "FetchToken start"
I0708 13:00:48.369878   69229 azure_msi.go:39] "FetchToken" client ID="d58772ec-ff68-444e-8c29-386ecdacea19"
I0708 13:00:48.369913   69229 azure_msi.go:49] "GetToken start" credential=&{id:d58772ec-ff68-444e-8c29-386ecdacea19 client:0xc0003fceb0}
E0708 13:01:18.370181   69229 azure_msi.go:54] "Failed to GetToken" err="context deadline exceeded"
E0708 13:01:18.370255   69229 token_refresher.go:61] "Failed to FetchToken" err="failed to get a token: context deadline exceeded"
I0708 13:01:48.371381   69229 token_refresher.go:43] "FetchToken start"
I0708 13:01:48.371445   69229 azure_msi.go:39] "FetchToken" client ID="d58772ec-ff68-444e-8c29-386ecdacea19"
I0708 13:01:48.371569   69229 azure_msi.go:49] "GetToken start" credential=&{id:d58772ec-ff68-444e-8c29-386ecdacea19 client:0xc0000a44b0}