### PR TITLE
feat: introduce networking-agents-enabled flag

### DIFF
--- a/cmd/hubagent/main.go
+++ b/cmd/hubagent/main.go
@@ -29,8 +29,8 @@ var (
 	metricsAddr          = flag.String("metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	enableLeaderElection = flag.Bool("leader-elect", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
-	networkingAgentsRequired = flag.Bool("networking-agents-required", false,
-		"Whether the networking agents are required. Enabling this will ensure networking agents unjoin first then cleanup the resources before leaving")
+	networkingAgentsEnabled = flag.Bool("networking-agents-enabled", false,
+		"Whether the networking agents are enabled or not.")
 )
 
 func init() {
@@ -64,8 +64,8 @@ func main() {
 	klog.V(2).InfoS("starting hubagent")
 
 	if err = (&membercluster.Reconciler{
-		Client:                   mgr.GetClient(),
-		NetworkingAgentsRequired: *networkingAgentsRequired,
+		Client:                  mgr.GetClient(),
+		NetworkingAgentsEnabled: *networkingAgentsEnabled,
 	}).SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "MemberCluster")
 		os.Exit(1)

--- a/pkg/controllers/membercluster/membercluster_controller.go
+++ b/pkg/controllers/membercluster/membercluster_controller.go
@@ -46,8 +46,8 @@ const (
 // Reconciler reconciles a MemberCluster object
 type Reconciler struct {
 	client.Client
-	recorder                 record.EventRecorder
-	NetworkingAgentsRequired bool // whether it needs to handle networking agents join/unjoin
+	recorder                record.EventRecorder
+	NetworkingAgentsEnabled bool // if networking agents are enabled, need to handle unjoin before leave
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION

### Description of your changes

The flag is introduced to handle networking controllers join/unjoin to unblock RP chart changes.
In the RP side, we need to update the fleet charts to set the flag as true.

How to handle networking agents join/unjoin will be in a separate PR.

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

