### PR TITLE
fix: leader election config should be in the hubOpts of memberagent

### DIFF
--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -135,6 +135,7 @@ func main() {
 		LeaderElection:          *enableLeaderElection,
 		LeaderElectionNamespace: *leaderElectionNamespace,
 		LeaderElectionID:        "3111024923.hub.fleet.azure.com",
+		LeaderElectionConfig:    memberConfig,
 		Namespace:               mcNamespace,
 	}
 
@@ -145,7 +146,6 @@ func main() {
 		HealthProbeBindAddress:  *probeAddr,
 		LeaderElection:          hubOpts.LeaderElection,
 		LeaderElectionNamespace: *leaderElectionNamespace,
-		LeaderElectionConfig:    memberConfig,
 		LeaderElectionID:        "136224848560.member.fleet.azure.com",
 	}
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
### Description of your changes

Hub manager should use memberConfig for the leader election.

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

integration test

### Special notes for your reviewer

Context/original PR: https://github.com/Azure/fleet/pull/250
