### PR TITLE
fix: Remove work name format

### DIFF
--- a/pkg/controllers/clusterresourceplacement/work_propagation.go
+++ b/pkg/controllers/clusterresourceplacement/work_propagation.go
@@ -40,7 +40,7 @@ func (r *Reconciler) scheduleWork(ctx context.Context, placement *fleetv1alpha1.
 	manifests []workv1alpha1.Manifest) error {
 	var allErr []error
 	memberClusterNames := placement.Status.TargetClusters
-	workName := fmt.Sprintf(utils.WorkNameFormat, placement.Name)
+	workName := placement.Name
 	workerOwnerRef := metav1.OwnerReference{
 		APIVersion:         placement.GroupVersionKind().GroupVersion().String(),
 		Kind:               placement.GroupVersionKind().Kind,
@@ -128,7 +128,7 @@ func (r *Reconciler) scheduleWork(ctx context.Context, placement *fleetv1alpha1.
 // removeStaleWorks removes all the work objects from the clusters that are no longer selected.
 func (r *Reconciler) removeStaleWorks(ctx context.Context, placementName string, existingClusters, newClusters []string) (int, error) {
 	var allErr []error
-	workName := fmt.Sprintf(utils.WorkNameFormat, placementName)
+	workName := placementName
 	clusterMap := make(map[string]bool)
 	for _, cluster := range newClusters {
 		clusterMap[cluster] = true
@@ -160,7 +160,7 @@ func (r *Reconciler) removeStaleWorks(ctx context.Context, placementName string,
 func (r *Reconciler) collectAllManifestsStatus(placement *fleetv1alpha1.ClusterResourcePlacement) (bool, error) {
 	hasPending := false
 	placement.Status.FailedResourcePlacements = make([]fleetv1alpha1.FailedResourcePlacement, 0)
-	workName := fmt.Sprintf(utils.WorkNameFormat, placement.GetName())
+	workName := placement.GetName()
 	for _, cluster := range placement.Status.TargetClusters {
 		memberClusterNsName := fmt.Sprintf(utils.NamespaceNameFormat, cluster)
 		work, err := r.getResourceBinding(memberClusterNsName, workName)

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -42,8 +42,6 @@ const (
 	PlacementFieldManagerName = "cluster-placement-controller"
 
 	MCControllerFieldManagerName = "member-cluster-controller"
-
-	WorkNameFormat = "work-%s"
 )
 
 const (

--- a/test/e2e/work_load_test.go
+++ b/test/e2e/work_load_test.go
@@ -66,7 +66,7 @@ var _ = Describe("workload orchestration testing", func() {
 	})
 
 	It("Apply CRP and check if work gets propagated", func() {
-		workName := fmt.Sprintf(utils.WorkNameFormat, "resource-label-selector")
+		workName := "resource-label-selector"
 		labelKey := "fleet.azure.com/name"
 		labelValue := "test"
 		By("create the resources to be propagated")

--- a/test/integration/cluster_placement_test.go
+++ b/test/integration/cluster_placement_test.go
@@ -295,7 +295,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			waitForPlacementScheduleStopped(crp.Name)
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 			By(fmt.Sprintf("validate work resource for cluster %s. It should contain %d manifests", clusterA.Name, len(namespacedResource)+1))
@@ -422,7 +422,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			waitForPlacementScheduleStopped(crp.Name)
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 
@@ -457,7 +457,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			By("Verify that we pick up the role change")
 			waitForPlacementScheduleStopped(crp.Name)
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 			Expect(len(clusterWork.Spec.Workload.Manifests)).Should(BeIdenticalTo(len(namespacedResource) + 1))
@@ -486,7 +486,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			By("Verify that we pick up the role delete")
 			waitForPlacementScheduleStopped(crp.Name)
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 			verifyWorkObjects(crp, namespacedResource, []*fleetv1alpha1.MemberCluster{&clusterA, &clusterB})
@@ -600,7 +600,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			waitForPlacementScheduleStopped(crp.Name)
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 			By(fmt.Sprintf("validate work resource for cluster %s. It should contain %d manifests", clusterA.Name, 2))
@@ -631,7 +631,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			By("Verify that we pick up the clusterRole change")
 			waitForPlacementScheduleStopped(crp.Name)
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 			Expect(len(clusterWork.Spec.Workload.Manifests)).Should(BeIdenticalTo(2))
@@ -660,7 +660,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			By("Verify that we pick up the clusterRole delete")
 			waitForPlacementScheduleStopped(crp.Name)
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 			verifyWorkObjects(crp, []string{ClusterRoleKind}, []*fleetv1alpha1.MemberCluster{&clusterA, &clusterB})
@@ -715,11 +715,11 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			By("Verify that work is not created in any cluster")
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterB.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 		})
@@ -761,7 +761,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			By("Verify that work is not created in cluster B")
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterB.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 		})
@@ -850,7 +850,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			By("Verify that work is not created in cluster A")
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 
@@ -870,7 +870,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			verifyWorkObjects(crp, namespacedResource, []*fleetv1alpha1.MemberCluster{&clusterB})
 			By("Verify that work is removed from cluster A")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 			By("Verified that the work is removed from cluster A")
@@ -924,7 +924,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterB.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 			By("Verified that the work is not scheduled to cluster B")
@@ -941,7 +941,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			verifyWorkObjects(crp, namespacedResource, []*fleetv1alpha1.MemberCluster{&clusterA})
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterB.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 			By("Verified that the work is removed from cluster C")
@@ -1024,7 +1024,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 			waitForPlacementScheduleStopped(crp.Name)
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 			Expect(len(clusterWork.Spec.Workload.Manifests)).Should(BeIdenticalTo(1))
@@ -1038,7 +1038,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 
 			waitForPlacementScheduleStopped(crp2.Name)
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp2.Name),
+				Name:      crp2.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(Succeed())
 			Expect(len(clusterWork.Spec.Workload.Manifests)).Should(BeIdenticalTo(1))
@@ -1102,7 +1102,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 			By("Verified that the work is removed from cluster A")
@@ -1145,7 +1145,7 @@ var _ = Describe("Test Cluster Resource Placement Controller", func() {
 
 			var clusterWork workv1alpha1.Work
 			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+				Name:      crp.Name,
 				Namespace: fmt.Sprintf(utils.NamespaceNameFormat, clusterA.Name),
 			}, &clusterWork)).Should(utils.NotFoundMatcher{})
 			By("Verified that the deleted clusterRole is removed from the work")

--- a/test/integration/utils_test.go
+++ b/test/integration/utils_test.go
@@ -263,7 +263,7 @@ func verifyPartialWorkObjects(crp *fleetv1alpha1.ClusterResourcePlacement, expec
 	// check each work object in the cluster namespace
 	for _, cluster := range clusters {
 		Expect(k8sClient.Get(ctx, types.NamespacedName{
-			Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+			Name:      crp.Name,
 			Namespace: fmt.Sprintf(utils.NamespaceNameFormat, cluster.Name),
 		}, &clusterWork)).Should(Succeed())
 		Expect(clusterWork.GetLabels()[utils.LabelWorkPlacementName]).Should(Equal(crp.Name))
@@ -345,7 +345,7 @@ func markInternalMCJoined(mc fleetv1alpha1.MemberCluster) {
 func markWorkAppliedStatusSuccess(crp *fleetv1alpha1.ClusterResourcePlacement, cluster *fleetv1alpha1.MemberCluster) {
 	var clusterWork workv1alpha1.Work
 	Expect(k8sClient.Get(ctx, types.NamespacedName{
-		Name:      fmt.Sprintf(utils.WorkNameFormat, crp.Name),
+		Name:      crp.Name,
 		Namespace: fmt.Sprintf(utils.NamespaceNameFormat, cluster.Name),
 	}, &clusterWork)).Should(Succeed())
 	clusterWork.Status.Conditions = []metav1.Condition{


### PR DESCRIPTION
### Description of your changes


Currently the work name has a prefix, we need to remove this prefix as it can lead to work name overflow when the CRP name is too long

Removed all occurrences of WorkNameFormat specifier in the repo

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

The existing E2E test for workload orchestration passed

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
