### PR TITLE
fix: Fix kubebuilder annotations

### DIFF
--- a/apis/v1alpha1/membercluster_types.go
+++ b/apis/v1alpha1/membercluster_types.go
@@ -45,8 +45,8 @@ type MemberClusterSpec struct {
 	Identity rbacv1.Subject `json:"identity"`
 
 	// +kubebuilder:default=60
-	// +kubebuilder:validation:Minimum:1
-	// +kubebuilder:validation:Maximum:600
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=600
 
 	// How often (in seconds) for the member cluster to send a heartbeat to the hub cluster. Default: 60 seconds. Min: 1 second. Max: 10 minutes.
 	// +optional

--- a/config/crd/bases/fleet.azure.com_memberclusters.yaml
+++ b/config/crd/bases/fleet.azure.com_memberclusters.yaml
@@ -53,6 +53,8 @@ spec:
                   a heartbeat to the hub cluster. Default: 60 seconds. Min: 1 second.
                   Max: 10 minutes.'
                 format: int32
+                maximum: 600
+                minimum: 1
                 type: integer
               identity:
                 description: The identity used by the member cluster to access the


### PR DESCRIPTION
### Description of your changes
- min and max validation of heartbeatPeriodSeconds doesn't exist in CRD due to typos in kubebuilder annotatinos

Fixes #267

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
make test
