### PR TITLE
docs: Fixed incorrect namespace within Kind cluster demo steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Events:
 </details><br/>
 
 ```shell
-$ kubectl describe internalmembercluster kind-member-testing -n fleet-kind-member-testing
+$ kubectl describe internalmembercluster kind-member-testing -n fleet-member-kind-member-testing
 ```
 
 <details>


### PR DESCRIPTION
### Description of your changes

Updated incorrect namespace usage  in README.MD 

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
n/a