### PR TITLE
fix: Resolved flaky RefresherCancelContext test

### DIFF
--- a/pkg/authtoken/token_refresher_test.go
+++ b/pkg/authtoken/token_refresher_test.go
@@ -6,6 +6,7 @@ package authtoken
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -118,7 +119,7 @@ func TestRefresherCancelContext(t *testing.T) {
 	expectedErr := context.Canceled
 	select {
 	case err := <-testChan:
-		if err == expectedErr {
+		if errors.Is(err, expectedErr) {
 			return
 		}
 		assert.Fail(t, fmt.Sprintf("got error: \"%s\", expected error: \"%s\"", err.Error(), expectedErr))


### PR DESCRIPTION
### Description of your changes
Increase the timeout duration to account for a hanging thread. Verified the return of the refresh token.

Fixes #204
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Test pass locally.
