### PR TITLE
fix: Renamed incorrect unit test file name.

### DIFF
--- a/pkg/controllers/clusterresourceplacement/resource_selector_test.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector_test.go
@@ -295,10 +295,8 @@ func TestGenerateManifest(t *testing.T) {
 }
 
 func makeIPFamilyPolicyTypePointer(policyType corev1.IPFamilyPolicyType) *corev1.IPFamilyPolicyType {
-	s := policyType
-	return &s
+	return &policyType
 }
 func makeServiceInternalTrafficPolicyPointer(policyType corev1.ServiceInternalTrafficPolicyType) *corev1.ServiceInternalTrafficPolicyType {
-	p := policyType
-	return &p
+	return &policyType
 }


### PR DESCRIPTION
### Description of your changes
Renamed unit test file name.

I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Tests pass locally.
