### PR TITLE
feat: support CA bundle and identity cert/key authentication

### DIFF
--- a/charts/member-agent/templates/deployment.yaml
+++ b/charts/member-agent/templates/deployment.yaml
@@ -25,8 +25,8 @@ spec:
               containerPort: 80
           args:
             - --leader-elect=true
-            {{- if .Values.useCaAuth }}
-            - --use-ca-auth={{ .Values.useCaAuth }}
+            {{- if .Values.useCAAuth }}
+            - --use-ca-auth={{ .Values.useCAAuth }}
             {{- else }}
             - --tls-insecure={{ .Values.tlsClientInsecure }}
             {{- end }}
@@ -41,7 +41,7 @@ spec:
             value: "{{ .Values.config.memberClusterName }}"
           - name: HUB_CERTIFICATE_AUTHORITY
             value: "{{ .Values.config.hubCA }}"
-          {{- if .Values.useCaAuth }}
+          {{- if .Values.useCAAuth }}
           - name: IDENTITY_KEY
             value:  "{{ .Values.config.identityKey }}"
           - name: IDENTITY_CERT
@@ -75,7 +75,7 @@ spec:
           volumeMounts:
           - name: provider-token 
             mountPath: /config
-        {{- if not .Values.useCaAuth }}
+        {{- if not .Values.useCAAuth }}
         - name: refresh-token
           image: "{{ .Values.refreshtoken.repository }}:{{ .Values.refreshtoken.tag }}"
           imagePullPolicy: {{ .Values.refreshtoken.pullPolicy }}

--- a/charts/member-agent/templates/deployment.yaml
+++ b/charts/member-agent/templates/deployment.yaml
@@ -72,10 +72,10 @@ spec:
             httpGet:
               path: /readyz
               port: hubhealthz
+      {{- if not .Values.useCAAuth }}
           volumeMounts:
           - name: provider-token 
             mountPath: /config
-        {{- if not .Values.useCAAuth }}
         - name: refresh-token
           image: "{{ .Values.refreshtoken.repository }}:{{ .Values.refreshtoken.tag }}"
           imagePullPolicy: {{ .Values.refreshtoken.pullPolicy }}
@@ -94,10 +94,10 @@ spec:
           volumeMounts:
           - name: provider-token
             mountPath: /config
-        {{- end }}      
       volumes:
       - name: provider-token
         emptyDir: {}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/member-agent/templates/deployment.yaml
+++ b/charts/member-agent/templates/deployment.yaml
@@ -25,7 +25,11 @@ spec:
               containerPort: 80
           args:
             - --leader-elect=true
+            {{- if .Values.useCaAuth }}
+            - --use-ca-auth={{ .Values.useCaAuth }}
+            {{- else }}
             - --tls-insecure={{ .Values.tlsClientInsecure }}
+            {{- end }}
             - --v={{ .Values.logVerbosity }}
             - -add_dir_header
           env:
@@ -37,6 +41,14 @@ spec:
             value: "{{ .Values.config.memberClusterName }}"
           - name: HUB_CERTIFICATE_AUTHORITY
             value: "{{ .Values.config.hubCA }}"
+          {{- if .Values.useCaAuth }}
+          - name: IDENTITY_KEY
+            value:  "{{ .Values.config.identityKey }}"
+          - name: IDENTITY_CERT
+            value:  "{{ .Values.config.identityCert }}"
+          - name: CA_BUNDLE
+            value:  "{{ .Values.config.CABundle }}"
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           ports:
@@ -63,15 +75,16 @@ spec:
           volumeMounts:
           - name: provider-token 
             mountPath: /config
+        {{- if not .Values.useCaAuth }}
         - name: refresh-token
           image: "{{ .Values.refreshtoken.repository }}:{{ .Values.refreshtoken.tag }}"
           imagePullPolicy: {{ .Values.refreshtoken.pullPolicy }}
           args:
-            {{ $provider := .Values.config.provider }}
+            {{- $provider := .Values.config.provider }}
             - {{ $provider }}
-            {{ range $key, $value := (index .Values $provider) }}
+            {{- range $key, $value := (index .Values $provider) }}
             - --{{ $key }}={{ $value }}
-            {{ end }}
+            {{- end }}
             - --v={{ .Values.logVerbosity }}
           ports:
             - name: http
@@ -80,7 +93,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           - name: provider-token
-            mountPath: /config    
+            mountPath: /config
+        {{- end }}      
       volumes:
       - name: provider-token
         emptyDir: {}

--- a/charts/member-agent/values.yaml
+++ b/charts/member-agent/values.yaml
@@ -44,4 +44,4 @@ azure:
   clientid: <member_cluster_clientID>
 
 tlsClientInsecure: true #TODO should be false in the production
-useCaAuth: false
+useCAAuth: false

--- a/charts/member-agent/values.yaml
+++ b/charts/member-agent/values.yaml
@@ -32,6 +32,9 @@ config:
   hubURL : https://<hub_cluster_api_server_ip>:<hub_cluster_port>
   memberClusterName: membercluster-sample
   hubCA: <certificate-authority-data>
+  identityKey: "identity-key-path"
+  identityCert: "identity-cert-path"
+  CABundle: "ca-bundle-path"
 
 secret:
   name: "hub-kubeconfig-secret"
@@ -41,3 +44,4 @@ azure:
   clientid: <member_cluster_clientID>
 
 tlsClientInsecure: true #TODO should be false in the production
+useCaAuth: false

--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -88,7 +88,7 @@ func main() {
 
 	identityKeyFile := os.Getenv("IDENTITY_KEY")
 	identityCertFile := os.Getenv("IDENTITY_CERT")
-	cABundleFile := os.Getenv("CA_BUNDLE")
+	caBundleFile := os.Getenv("CA_BUNDLE")
 
 	if *useCAAuth {
 		if identityKeyFile == "" {
@@ -101,7 +101,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if cABundleFile == "" {
+		if caBundleFile == "" {
 			klog.ErrorS(errors.New("CA bundle file path cannot be empty"), "error has occurred retrieving CA_BUNDLE")
 			os.Exit(1)
 		}
@@ -127,7 +127,7 @@ func main() {
 			TLSClientConfig: rest.TLSClientConfig{
 				CertFile: identityCertFile,
 				KeyFile:  identityKeyFile,
-				CAFile:   cABundleFile,
+				CAFile:   caBundleFile,
 			},
 		}
 	} else if *tlsClientInsecure {

--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	scheme               = runtime.NewScheme()
-	useCaAuth            = flag.Bool("use-ca-auth", false, "Use identity and CA bundle to authenticate the member agent.")
+	useCAAuth            = flag.Bool("use-ca-auth", false, "Use identity and CA bundle to authenticate the member agent.")
 	tlsClientInsecure    = flag.Bool("tls-insecure", false, "Enable TLSClientConfig.Insecure property. Enabling this will make the connection inSecure (should be 'true' for testing purpose only.)")
 	hubProbeAddr         = flag.String("hub-health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	hubMetricsAddr       = flag.String("hub-metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -73,8 +73,8 @@ func main() {
 	}
 	tokenFilePath := os.Getenv("CONFIG_PATH")
 
-	if !*useCaAuth && tokenFilePath == "" {
-		klog.ErrorS(errors.New("hub token file path cannot be empty"), "error has occurred retrieving CONFIG_PATH")
+	if !*useCAAuth && tokenFilePath == "" {
+		klog.ErrorS(errors.New("hub token file path cannot be empty if CA auth not used"), "error has occurred retrieving CONFIG_PATH")
 		os.Exit(1)
 	}
 
@@ -90,7 +90,7 @@ func main() {
 	identityCertFile := os.Getenv("IDENTITY_CERT")
 	cABundleFile := os.Getenv("CA_BUNDLE")
 
-	if *useCaAuth {
+	if *useCAAuth {
 		if identityKeyFile == "" {
 			klog.ErrorS(errors.New("identity key file path cannot be empty"), "error has occurred retrieving IDENTITY_KEY")
 			os.Exit(1)
@@ -121,7 +121,7 @@ func main() {
 	}
 
 	var hubConfig rest.Config
-	if *useCaAuth {
+	if *useCAAuth {
 		hubConfig = rest.Config{
 			Host: hubURL,
 			TLSClientConfig: rest.TLSClientConfig{

--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -39,6 +39,7 @@ import (
 
 var (
 	scheme               = runtime.NewScheme()
+	useCaAuth            = flag.Bool("use-ca-auth", false, "Use identity and CA bundle to authenticate the member agent.")
 	tlsClientInsecure    = flag.Bool("tls-insecure", false, "Enable TLSClientConfig.Insecure property. Enabling this will make the connection inSecure (should be 'true' for testing purpose only.)")
 	hubProbeAddr         = flag.String("hub-health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	hubMetricsAddr       = flag.String("hub-metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -72,7 +73,7 @@ func main() {
 	}
 	tokenFilePath := os.Getenv("CONFIG_PATH")
 
-	if tokenFilePath == "" {
+	if !*useCaAuth && tokenFilePath == "" {
 		klog.ErrorS(errors.New("hub token file path cannot be empty"), "error has occurred retrieving CONFIG_PATH")
 		os.Exit(1)
 	}
@@ -85,21 +86,51 @@ func main() {
 
 	mcNamespace := fmt.Sprintf(utils.NamespaceNameFormat, mcName)
 
-	err := retry.OnError(retry.DefaultRetry, func(e error) bool {
-		return true
-	}, func() error {
-		// Stat returns file info. It will return
-		// an error if there is no file.
-		_, err := os.Stat(tokenFilePath)
-		return err
-	})
-	if err != nil {
-		klog.ErrorS(err, " cannot retrieve token file from the path %s", tokenFilePath)
-		os.Exit(1)
+	identityKeyFile := os.Getenv("IDENTITY_KEY")
+	identityCertFile := os.Getenv("IDENTITY_CERT")
+	cABundleFile := os.Getenv("CA_BUNDLE")
+
+	if *useCaAuth {
+		if identityKeyFile == "" {
+			klog.ErrorS(errors.New("identity key file path cannot be empty"), "error has occurred retrieving IDENTITY_KEY")
+			os.Exit(1)
+		}
+
+		if identityCertFile == "" {
+			klog.ErrorS(errors.New("identity cert file path cannot be empty"), "error has occurred retrieving IDENTITY_CERT")
+			os.Exit(1)
+		}
+
+		if cABundleFile == "" {
+			klog.ErrorS(errors.New("CA bundle file path cannot be empty"), "error has occurred retrieving CA_BUNDLE")
+			os.Exit(1)
+		}
+	} else {
+		err := retry.OnError(retry.DefaultRetry, func(e error) bool {
+			return true
+		}, func() error {
+			// Stat returns file info. It will return
+			// an error if there is no file.
+			_, err := os.Stat(tokenFilePath)
+			return err
+		})
+		if err != nil {
+			klog.ErrorS(err, " cannot retrieve token file from the path %s", tokenFilePath)
+			os.Exit(1)
+		}
 	}
 
 	var hubConfig rest.Config
-	if *tlsClientInsecure {
+	if *useCaAuth {
+		hubConfig = rest.Config{
+			Host: hubURL,
+			TLSClientConfig: rest.TLSClientConfig{
+				CertFile: identityCertFile,
+				KeyFile:  identityKeyFile,
+				CAFile:   cABundleFile,
+			},
+		}
+	} else if *tlsClientInsecure {
 		hubConfig = rest.Config{
 			BearerTokenFile: tokenFilePath,
 			Host:            hubURL,


### PR DESCRIPTION
### Description of your changes
Provide an solution for community to support CA auth

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Kind Cluster e2e workflow on README is verified working, no existing workflow get affected.
- Integ test is performed in LinkedIn environment
- Helm yaml generation is verified

```
The default behavior has no changes.

For the yamls with CA info enabled
==================================================

helm template member-agent ./charts/member-agent/ \
--set useCAAuth=true \
--set config.identityKey="identity-key-path" \
--set config.identityCert="identity-cert-path" \
--set config.CABundle="ca-bundle-path" \
--set config.hubURL=hub-cluster-api-url \
--set image.repository=member-agent-image-url \
--set image.tag=0.0.1 \
--set refreshtoken.repository=refresh-token-url \
--set refreshtoken.tag=0.0.1 \
--set image.pullPolicy=IfNotPresent --set refreshtoken.pullPolicy=IfNotPresent \
--set config.memberClusterName="member-cluster-name" \
--set logVerbosity=5 \
--set namespace=fleet-system \
| awk -vout=/tmp/member-agent-with-ca -F": " '$0~/^# Source: /{file=out"/"$2; print "Creating "file; system ("mkdir -p $(dirname "file"); echo "" > "file)} $0!~/^#/ && $0!="---"{print $0 >> file}'

deployment.yaml is verified with the right arguments and there is no refresh token generated
==================================================
...
          args:
            - --leader-elect=true
            - --use-ca-auth=true
            - --v=5
            - -add_dir_header
          env:
...
          - name: IDENTITY_KEY
            value:  "identity-key-path"
          - name: IDENTITY_CERT
            value:  "identity-cert-path"
          - name: CA_BUNDLE
            value:  "ca-bundle-path"
...
```
