### PR TITLE
feat: a new "scope" argument for refresh-token

### DIFF
--- a/cmd/authtoken/main.go
+++ b/cmd/authtoken/main.go
@@ -60,7 +60,9 @@ func parseArgs() (interfaces.AuthTokenProvider, error) {
 	}
 
 	azureCmd.Flags().StringVar(&clientID, "clientid", "", "Azure AAD client ID (required)")
-	azureCmd.Flags().StringVar(&scope, "scope", "", "Azure AAD token scope (optinal)")
+	// TODO: this scope argument is specific for Azure provider. We should allow registering and parsing provider specific argument
+	// in provider level, instead of global level.
+	azureCmd.Flags().StringVar(&scope, "scope", "", "Azure AAD token scope (optional)")
 	_ = azureCmd.MarkFlagRequired("clientid")
 
 	rootCmd.AddCommand(secretCmd, azureCmd)

--- a/cmd/authtoken/main.go
+++ b/cmd/authtoken/main.go
@@ -23,10 +23,6 @@ var (
 	configPath string
 )
 
-const (
-	aksAADApplicationID = "6dae42f8-4368-4678-94ff-3960e28e3630"
-)
-
 func parseArgs() (interfaces.AuthTokenProvider, error) {
 	var tokenProvider interfaces.AuthTokenProvider
 	rootCmd := &cobra.Command{Use: "refreshtoken", Args: cobra.NoArgs}
@@ -64,7 +60,7 @@ func parseArgs() (interfaces.AuthTokenProvider, error) {
 	}
 
 	azureCmd.Flags().StringVar(&clientID, "clientid", "", "Azure AAD client ID (required)")
-	azureCmd.Flags().StringVar(&scope, "scope", aksAADApplicationID, "Azure AAD token scope (optinal)")
+	azureCmd.Flags().StringVar(&scope, "scope", "", "Azure AAD token scope (optinal)")
 	_ = azureCmd.MarkFlagRequired("clientid")
 
 	rootCmd.AddCommand(secretCmd, azureCmd)

--- a/cmd/authtoken/main.go
+++ b/cmd/authtoken/main.go
@@ -23,6 +23,10 @@ var (
 	configPath string
 )
 
+const (
+	aksAADApplicationId = "6dae42f8-4368-4678-94ff-3960e28e3630"
+)
+
 func parseArgs() (interfaces.AuthTokenProvider, error) {
 	var tokenProvider interfaces.AuthTokenProvider
 	rootCmd := &cobra.Command{Use: "refreshtoken", Args: cobra.NoArgs}
@@ -50,15 +54,17 @@ func parseArgs() (interfaces.AuthTokenProvider, error) {
 	_ = secretCmd.MarkFlagRequired("namespace")
 
 	var clientID string
+	var scope string
 	azureCmd := &cobra.Command{
 		Use:  "azure",
 		Args: cobra.NoArgs,
 		Run: func(_ *cobra.Command, args []string) {
-			tokenProvider = azure.New(clientID)
+			tokenProvider = azure.New(clientID, scope)
 		},
 	}
 
 	azureCmd.Flags().StringVar(&clientID, "clientid", "", "Azure AAD client ID (required)")
+	azureCmd.Flags().StringVar(&scope, "scope", aksAADApplicationId, "Azure AAD token scope (optinal)")
 	_ = azureCmd.MarkFlagRequired("clientid")
 
 	rootCmd.AddCommand(secretCmd, azureCmd)

--- a/cmd/authtoken/main.go
+++ b/cmd/authtoken/main.go
@@ -24,7 +24,7 @@ var (
 )
 
 const (
-	aksAADApplicationId = "6dae42f8-4368-4678-94ff-3960e28e3630"
+	aksAADApplicationID = "6dae42f8-4368-4678-94ff-3960e28e3630"
 )
 
 func parseArgs() (interfaces.AuthTokenProvider, error) {
@@ -64,7 +64,7 @@ func parseArgs() (interfaces.AuthTokenProvider, error) {
 	}
 
 	azureCmd.Flags().StringVar(&clientID, "clientid", "", "Azure AAD client ID (required)")
-	azureCmd.Flags().StringVar(&scope, "scope", aksAADApplicationId, "Azure AAD token scope (optinal)")
+	azureCmd.Flags().StringVar(&scope, "scope", aksAADApplicationID, "Azure AAD token scope (optinal)")
 	_ = azureCmd.MarkFlagRequired("clientid")
 
 	rootCmd.AddCommand(secretCmd, azureCmd)

--- a/cmd/authtoken/main_test.go
+++ b/cmd/authtoken/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseArgs(t *testing.T) {
+	t.Run("all arguments", func(t *testing.T) {
+		os.Args = []string{"refreshtoken", "azure", "--clientid=test-client-id", "--scope=test-scope"}
+		t.Cleanup(func() {
+			os.Args = nil
+		})
+		tokenProvider, err := parseArgs()
+		assert.NotNil(t, tokenProvider)
+		assert.Nil(t, err)
+
+	})
+	t.Run("no optional arguments", func(t *testing.T) {
+		os.Args = []string{"refreshtoken", "azure", "--clientid=test-client-id"}
+		t.Cleanup(func() {
+			os.Args = nil
+		})
+		tokenProvider, err := parseArgs()
+		assert.NotNil(t, tokenProvider)
+		assert.Nil(t, err)
+
+	})
+}

--- a/cmd/authtoken/main_test.go
+++ b/cmd/authtoken/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.goms.io/fleet/pkg/authtoken/providers/azure"
 )
 
@@ -18,7 +19,7 @@ func TestParseArgs(t *testing.T) {
 		assert.NotNil(t, tokenProvider)
 		assert.Nil(t, err)
 
-		azTokenProvider, ok := tokenProvider.(*azure.AzureAuthTokenProvider)
+		azTokenProvider, ok := tokenProvider.(*azure.AuthTokenProvider)
 		assert.Equal(t, true, ok)
 		assert.Equal(t, "test-scope", azTokenProvider.Scope)
 	})
@@ -31,7 +32,7 @@ func TestParseArgs(t *testing.T) {
 		assert.NotNil(t, tokenProvider)
 		assert.Nil(t, err)
 
-		azTokenProvider, ok := tokenProvider.(*azure.AzureAuthTokenProvider)
+		azTokenProvider, ok := tokenProvider.(*azure.AuthTokenProvider)
 		assert.Equal(t, true, ok)
 		assert.Equal(t, "6dae42f8-4368-4678-94ff-3960e28e3630", azTokenProvider.Scope)
 	})

--- a/cmd/authtoken/main_test.go
+++ b/cmd/authtoken/main_test.go
@@ -20,7 +20,7 @@ func TestParseArgs(t *testing.T) {
 
 		azTokenProvider, ok := tokenProvider.(*azure.AzureAuthTokenProvider)
 		assert.Equal(t, true, ok)
-		assert.Equal(t, azTokenProvider.Scope, "test-scope")
+		assert.Equal(t, "test-scope", azTokenProvider.Scope)
 	})
 	t.Run("no optional arguments", func(t *testing.T) {
 		os.Args = []string{"refreshtoken", "azure", "--clientid=test-client-id"}
@@ -33,6 +33,6 @@ func TestParseArgs(t *testing.T) {
 
 		azTokenProvider, ok := tokenProvider.(*azure.AzureAuthTokenProvider)
 		assert.Equal(t, true, ok)
-		assert.Equal(t, azTokenProvider.Scope, "6dae42f8-4368-4678-94ff-3960e28e3630")
+		assert.Equal(t, "6dae42f8-4368-4678-94ff-3960e28e3630", azTokenProvider.Scope)
 	})
 }

--- a/cmd/authtoken/main_test.go
+++ b/cmd/authtoken/main_test.go
@@ -16,7 +16,6 @@ func TestParseArgs(t *testing.T) {
 		tokenProvider, err := parseArgs()
 		assert.NotNil(t, tokenProvider)
 		assert.Nil(t, err)
-
 	})
 	t.Run("no optional arguments", func(t *testing.T) {
 		os.Args = []string{"refreshtoken", "azure", "--clientid=test-client-id"}
@@ -26,6 +25,5 @@ func TestParseArgs(t *testing.T) {
 		tokenProvider, err := parseArgs()
 		assert.NotNil(t, tokenProvider)
 		assert.Nil(t, err)
-
 	})
 }

--- a/cmd/authtoken/main_test.go
+++ b/cmd/authtoken/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.goms.io/fleet/pkg/authtoken/providers/azure"
 )
 
 func TestParseArgs(t *testing.T) {
@@ -16,6 +17,10 @@ func TestParseArgs(t *testing.T) {
 		tokenProvider, err := parseArgs()
 		assert.NotNil(t, tokenProvider)
 		assert.Nil(t, err)
+
+		azTokenProvider, ok := tokenProvider.(*azure.AzureAuthTokenProvider)
+		assert.Equal(t, true, ok)
+		assert.Equal(t, azTokenProvider.Scope, "test-scope")
 	})
 	t.Run("no optional arguments", func(t *testing.T) {
 		os.Args = []string{"refreshtoken", "azure", "--clientid=test-client-id"}
@@ -25,5 +30,9 @@ func TestParseArgs(t *testing.T) {
 		tokenProvider, err := parseArgs()
 		assert.NotNil(t, tokenProvider)
 		assert.Nil(t, err)
+
+		azTokenProvider, ok := tokenProvider.(*azure.AzureAuthTokenProvider)
+		assert.Equal(t, true, ok)
+		assert.Equal(t, azTokenProvider.Scope, "6dae42f8-4368-4678-94ff-3960e28e3630")
 	})
 }

--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -17,10 +17,9 @@ import (
 	"go.goms.io/fleet/pkg/interfaces"
 )
 
-
 type azureAuthTokenProvider struct {
 	clientID string
-	scope string
+	scope    string
 }
 
 func New(clientID, scope string) interfaces.AuthTokenProvider {

--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -17,15 +17,13 @@ import (
 	"go.goms.io/fleet/pkg/interfaces"
 )
 
-const (
-	aksScope = "6dae42f8-4368-4678-94ff-3960e28e3630"
-)
 
 type azureAuthTokenProvider struct {
 	clientID string
+	scope string
 }
 
-func New(clientID string) interfaces.AuthTokenProvider {
+func New(clientID, scope string) interfaces.AuthTokenProvider {
 	return &azureAuthTokenProvider{
 		clientID: clientID,
 	}
@@ -48,7 +46,7 @@ func (a *azureAuthTokenProvider) FetchToken(ctx context.Context) (interfaces.Aut
 		}, func() error {
 			klog.V(2).InfoS("GetToken start", "credential", credential)
 			azToken, err = credential.GetToken(ctx, policy.TokenRequestOptions{
-				Scopes: []string{aksScope},
+				Scopes: []string{a.scope},
 			})
 			if err != nil {
 				klog.ErrorS(err, "Failed to GetToken")

--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -21,7 +21,7 @@ const (
 	aksScope = "6dae42f8-4368-4678-94ff-3960e28e3630"
 )
 
-type AzureAuthTokenProvider struct {
+type AuthTokenProvider struct {
 	ClientID string
 	Scope    string
 }
@@ -30,14 +30,14 @@ func New(clientID, scope string) interfaces.AuthTokenProvider {
 	if scope == "" {
 		scope = aksScope
 	}
-	return &AzureAuthTokenProvider{
+	return &AuthTokenProvider{
 		ClientID: clientID,
 		Scope:    scope,
 	}
 }
 
 // FetchToken gets a new token to make request to the associated fleet' hub cluster.
-func (a *AzureAuthTokenProvider) FetchToken(ctx context.Context) (interfaces.AuthToken, error) {
+func (a *AuthTokenProvider) FetchToken(ctx context.Context) (interfaces.AuthToken, error) {
 	token := interfaces.AuthToken{}
 	opts := &azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID(a.ClientID)}
 


### PR DESCRIPTION
### Description of your changes

Today the Azure provider are using a static scope in token. In future the different scope need to be used for the flexible scenario. 

This changes are:
1. add a new `--scope` arguments in refresh-token. The new scope argument will be pass to Azure token provider. 
3. For the backward compatibility, the scope argument is optional. The old static scope will be used by default. 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I added unit test for changes codes

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
