### PR TITLE
feat: allow member agent use OS's root certificate authority

### DIFF
--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -39,7 +39,7 @@ import (
 
 var (
 	scheme               = runtime.NewScheme()
-	useCAAuth            = flag.Bool("use-ca-auth", false, "Use identity and CA bundle to authenticate the member agent.")
+	useCertificateAuth   = flag.Bool("use-ca-auth", false, "Use key and certificate to authenticate the member agent.")
 	tlsClientInsecure    = flag.Bool("tls-insecure", false, "Enable TLSClientConfig.Insecure property. Enabling this will make the connection inSecure (should be 'true' for testing purpose only.)")
 	hubProbeAddr         = flag.String("hub-health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	hubMetricsAddr       = flag.String("hub-metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -71,7 +71,7 @@ func main() {
 		klog.ErrorS(errors.New("hub server api cannot be empty"), "error has occurred retrieving HUB_SERVER_URL")
 		os.Exit(1)
 	}
-	hubConfig, err := buildHubConfig(hubURL, *useCAAuth, *tlsClientInsecure)
+	hubConfig, err := buildHubConfig(hubURL, *useCertificateAuth, *tlsClientInsecure)
 	if err != nil {
 		klog.ErrorS(err, "error has occurred building kubernetes client configuration for hub")
 		os.Exit(1)

--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -71,10 +71,9 @@ func main() {
 		klog.ErrorS(errors.New("hub server api cannot be empty"), "error has occurred retrieving HUB_SERVER_URL")
 		os.Exit(1)
 	}
-	tokenFilePath := os.Getenv("CONFIG_PATH")
-
-	if !*useCAAuth && tokenFilePath == "" {
-		klog.ErrorS(errors.New("hub token file path cannot be empty if CA auth not used"), "error has occurred retrieving CONFIG_PATH")
+	hubConfig, err := buildHubConfig(hubURL, *useCAAuth, *tlsClientInsecure)
+	if err != nil {
+		klog.ErrorS(err, "error has occurred building kubernetes client configuration for hub")
 		os.Exit(1)
 	}
 
@@ -85,79 +84,6 @@ func main() {
 	}
 
 	mcNamespace := fmt.Sprintf(utils.NamespaceNameFormat, mcName)
-
-	identityKeyFile := os.Getenv("IDENTITY_KEY")
-	identityCertFile := os.Getenv("IDENTITY_CERT")
-	caBundleFile := os.Getenv("CA_BUNDLE")
-
-	if *useCAAuth {
-		if identityKeyFile == "" {
-			klog.ErrorS(errors.New("identity key file path cannot be empty"), "error has occurred retrieving IDENTITY_KEY")
-			os.Exit(1)
-		}
-
-		if identityCertFile == "" {
-			klog.ErrorS(errors.New("identity cert file path cannot be empty"), "error has occurred retrieving IDENTITY_CERT")
-			os.Exit(1)
-		}
-
-		if caBundleFile == "" {
-			klog.ErrorS(errors.New("CA bundle file path cannot be empty"), "error has occurred retrieving CA_BUNDLE")
-			os.Exit(1)
-		}
-	} else {
-		err := retry.OnError(retry.DefaultRetry, func(e error) bool {
-			return true
-		}, func() error {
-			// Stat returns file info. It will return
-			// an error if there is no file.
-			_, err := os.Stat(tokenFilePath)
-			return err
-		})
-		if err != nil {
-			klog.ErrorS(err, " cannot retrieve token file from the path %s", tokenFilePath)
-			os.Exit(1)
-		}
-	}
-
-	var hubConfig rest.Config
-	if *useCAAuth {
-		hubConfig = rest.Config{
-			Host: hubURL,
-			TLSClientConfig: rest.TLSClientConfig{
-				CertFile: identityCertFile,
-				KeyFile:  identityKeyFile,
-				CAFile:   caBundleFile,
-			},
-		}
-	} else if *tlsClientInsecure {
-		hubConfig = rest.Config{
-			BearerTokenFile: tokenFilePath,
-			Host:            hubURL,
-			TLSClientConfig: rest.TLSClientConfig{
-				Insecure: *tlsClientInsecure,
-			},
-		}
-	} else {
-		hubCA := os.Getenv("HUB_CERTIFICATE_AUTHORITY")
-		if hubCA == "" {
-			klog.ErrorS(errors.New("hub certificate authority cannot be empty"), "error has occurred retrieving HUB_CERTIFICATE_AUTHORITY")
-			os.Exit(1)
-		}
-		decodedClusterCaCertificate, err := base64.StdEncoding.DecodeString(hubCA)
-		if err != nil {
-			klog.ErrorS(err, "cannot decode hub cluster certificate authority data")
-			os.Exit(1)
-		}
-		hubConfig = rest.Config{
-			BearerTokenFile: tokenFilePath,
-			Host:            hubURL,
-			TLSClientConfig: rest.TLSClientConfig{
-				Insecure: *tlsClientInsecure,
-				CAData:   decodedClusterCaCertificate,
-			},
-		}
-	}
 
 	memberConfig := ctrl.GetConfigOrDie()
 	// we place the leader election lease on the member cluster to avoid adding load to the hub
@@ -184,10 +110,72 @@ func main() {
 	}
 	//+kubebuilder:scaffold:builder
 
-	if err := Start(ctrl.SetupSignalHandler(), &hubConfig, memberConfig, hubOpts, memberOpts); err != nil {
+	if err := Start(ctrl.SetupSignalHandler(), hubConfig, memberConfig, hubOpts, memberOpts); err != nil {
 		klog.ErrorS(err, "problem running controllers")
 		os.Exit(1)
 	}
+}
+
+func buildHubConfig(hubURL string, useCAAuth bool, tlsClientInsecure bool) (*rest.Config, error) {
+	var hubConfig = &rest.Config{
+		Host: hubURL,
+	}
+	if useCAAuth {
+		identityKeyFile := os.Getenv("IDENTITY_KEY")
+		identityCertFile := os.Getenv("IDENTITY_CERT")
+		if identityKeyFile == "" {
+			err := errors.New("identity key file path cannot be empty")
+			klog.ErrorS(err, "error has occurred retrieving IDENTITY_KEY")
+			return nil, err
+		}
+
+		if identityCertFile == "" {
+			err := errors.New("identity cert file path cannot be empty")
+			klog.ErrorS(err, "error has occurred retrieving IDENTITY_CERT")
+			return nil, err
+		}
+		hubConfig.TLSClientConfig.CertFile = identityCertFile
+		hubConfig.TLSClientConfig.KeyFile = identityKeyFile
+	} else {
+		tokenFilePath := os.Getenv("CONFIG_PATH")
+		if tokenFilePath == "" {
+			err := errors.New("hub token file path cannot be empty if CA auth not used")
+			klog.ErrorS(err, "error has occurred retrieving CONFIG_PATH")
+			return nil, err
+		}
+		err := retry.OnError(retry.DefaultRetry, func(e error) bool {
+			return true
+		}, func() error {
+			// Stat returns file info. It will return
+			// an error if there is no file.
+			_, err := os.Stat(tokenFilePath)
+			return err
+		})
+		if err != nil {
+			klog.ErrorS(err, "cannot retrieve token file from the path %s", tokenFilePath)
+			return nil, err
+		}
+		hubConfig.BearerTokenFile = tokenFilePath
+	}
+
+	hubConfig.TLSClientConfig.Insecure = tlsClientInsecure
+	if !tlsClientInsecure {
+		caBundleFile := os.Getenv("CA_BUNDLE")
+		if caBundleFile != "" {
+			hubConfig.TLSClientConfig.CAFile = caBundleFile
+		}
+		hubCA := os.Getenv("HUB_CERTIFICATE_AUTHORITY")
+		if hubCA != "" {
+			caData, err := base64.StdEncoding.DecodeString(hubCA)
+			if err != nil {
+				klog.ErrorS(err, "cannot decode hub cluster certificate authority data")
+				return nil, err
+			}
+			hubConfig.TLSClientConfig.CAData = caData
+		}
+	}
+
+	return hubConfig, nil
 }
 
 // Start the member controllers with the supplied config

--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -160,10 +160,7 @@ func buildHubConfig(hubURL string, useCAAuth bool, tlsClientInsecure bool) (*res
 
 	hubConfig.TLSClientConfig.Insecure = tlsClientInsecure
 	if !tlsClientInsecure {
-		caBundleFile := os.Getenv("CA_BUNDLE")
-		if caBundleFile != "" {
-			hubConfig.TLSClientConfig.CAFile = caBundleFile
-		}
+		hubConfig.TLSClientConfig.CAFile = os.Getenv("CA_BUNDLE")
 		hubCA := os.Getenv("HUB_CERTIFICATE_AUTHORITY")
 		if hubCA != "" {
 			caData, err := base64.StdEncoding.DecodeString(hubCA)

--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -121,21 +121,21 @@ func buildHubConfig(hubURL string, useCAAuth bool, tlsClientInsecure bool) (*res
 		Host: hubURL,
 	}
 	if useCAAuth {
-		identityKeyFile := os.Getenv("IDENTITY_KEY")
-		identityCertFile := os.Getenv("IDENTITY_CERT")
-		if identityKeyFile == "" {
+		keyFilePath := os.Getenv("IDENTITY_KEY")
+		certFilePath := os.Getenv("IDENTITY_CERT")
+		if keyFilePath == "" {
 			err := errors.New("identity key file path cannot be empty")
 			klog.ErrorS(err, "error has occurred retrieving IDENTITY_KEY")
 			return nil, err
 		}
 
-		if identityCertFile == "" {
-			err := errors.New("identity cert file path cannot be empty")
+		if certFilePath == "" {
+			err := errors.New("identity certificate file path cannot be empty")
 			klog.ErrorS(err, "error has occurred retrieving IDENTITY_CERT")
 			return nil, err
 		}
-		hubConfig.TLSClientConfig.CertFile = identityCertFile
-		hubConfig.TLSClientConfig.KeyFile = identityKeyFile
+		hubConfig.TLSClientConfig.CertFile = certFilePath
+		hubConfig.TLSClientConfig.KeyFile = keyFilePath
 	} else {
 		tokenFilePath := os.Getenv("CONFIG_PATH")
 		if tokenFilePath == "" {

--- a/cmd/memberagent/main_test.go
+++ b/cmd/memberagent/main_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+)
+
+func Test_buildHubConfig(t *testing.T) {
+	t.Run("use CA auth, no key file - error", func(t *testing.T) {
+		t.Setenv("IDENTITY_KEY", "")
+		t.Setenv("IDENTITY_CERT", "/path/to/cert")
+		config, err := buildHubConfig("https://hub.domain.com", true, false)
+		assert.Nil(t, config)
+		assert.NotNil(t, err)
+	})
+	t.Run("use CA auth, no cert file - error", func(t *testing.T) {
+		t.Setenv("IDENTITY_KEY", "/path/to/key")
+		t.Setenv("IDENTITY_CERT", "")
+		config, err := buildHubConfig("https://hub.domain.com", true, false)
+		assert.Nil(t, config)
+		assert.NotNil(t, err)
+	})
+	t.Run("use CA auth  - success", func(t *testing.T) {
+		t.Setenv("IDENTITY_KEY", "/path/to/key")
+		t.Setenv("IDENTITY_CERT", "/path/to/cert")
+		config, err := buildHubConfig("https://hub.domain.com", true, false)
+		assert.NotNil(t, config)
+		assert.Nil(t, err)
+		assert.Equal(t, rest.Config{
+			Host: "https://hub.domain.com",
+			TLSClientConfig: rest.TLSClientConfig{
+				KeyFile:  "/path/to/key",
+				CertFile: "/path/to/cert",
+			},
+		}, *config)
+	})
+	t.Run("use CA bundle - success", func(t *testing.T) {
+		t.Setenv("IDENTITY_KEY", "/path/to/key")
+		t.Setenv("IDENTITY_CERT", "/path/to/cert")
+		t.Setenv("CA_BUNDLE", "/path/to/ca/bundle")
+		config, err := buildHubConfig("https://hub.domain.com", true, false)
+		assert.NotNil(t, config)
+		assert.Nil(t, err)
+		assert.Equal(t, rest.Config{
+			Host: "https://hub.domain.com",
+			TLSClientConfig: rest.TLSClientConfig{
+				KeyFile:  "/path/to/key",
+				CertFile: "/path/to/cert",
+				CAFile:   "/path/to/ca/bundle",
+			},
+		}, *config)
+	})
+	t.Run("use token auth, no toke path - error", func(t *testing.T) {
+		t.Setenv("CONFIG_PATH", "")
+		config, err := buildHubConfig("https://hub.domain.com", false, false)
+		assert.Nil(t, config)
+		assert.NotNil(t, err)
+	})
+	t.Run("use token auth, not exists toke path - error", func(t *testing.T) {
+		t.Setenv("CONFIG_PATH", "/hot/exists/token/path")
+		config, err := buildHubConfig("https://hub.domain.com", false, false)
+		assert.Nil(t, config)
+		assert.NotNil(t, err)
+	})
+	t.Run("use token auth - success", func(t *testing.T) {
+		t.Setenv("CONFIG_PATH", "./testdata/token")
+		config, err := buildHubConfig("https://hub.domain.com", false, false)
+		assert.NotNil(t, config)
+		assert.Nil(t, err)
+		assert.Equal(t, rest.Config{
+			Host:            "https://hub.domain.com",
+			BearerTokenFile: "./testdata/token",
+		}, *config)
+	})
+	t.Run("use hub ca data - success", func(t *testing.T) {
+		t.Setenv("CONFIG_PATH", "./testdata/token")
+		t.Setenv("HUB_CERTIFICATE_AUTHORITY", "dGhpcyBpcyBhIGZha2UgY2E=")
+		config, err := buildHubConfig("https://hub.domain.com", false, false)
+		assert.NotNil(t, config)
+		assert.Nil(t, err)
+		assert.Equal(t, rest.Config{
+			Host:            "https://hub.domain.com",
+			BearerTokenFile: "./testdata/token",
+			TLSClientConfig: rest.TLSClientConfig{
+				CAData: []byte("this is a fake ca"),
+			},
+		}, *config)
+	})
+	t.Run("No CA bundle, no Hub CA, not insecure - success", func(t *testing.T) {
+		t.Setenv("CONFIG_PATH", "./testdata/token")
+		config, err := buildHubConfig("https://hub.domain.com", false, false)
+		assert.NotNil(t, config)
+		assert.Nil(t, err)
+		assert.Equal(t, rest.Config{
+			Host:            "https://hub.domain.com",
+			BearerTokenFile: "./testdata/token",
+		}, *config)
+	})
+	t.Run("use insecure client - success", func(t *testing.T) {
+		t.Setenv("CONFIG_PATH", "./testdata/token")
+		config, err := buildHubConfig("https://hub.domain.com", false, true)
+		assert.NotNil(t, config)
+		assert.Nil(t, err)
+		assert.Equal(t, rest.Config{
+			Host:            "https://hub.domain.com",
+			BearerTokenFile: "./testdata/token",
+			TLSClientConfig: rest.TLSClientConfig{
+				Insecure: true,
+			},
+		}, *config)
+	})
+}

--- a/cmd/memberagent/testdata/token
+++ b/cmd/memberagent/testdata/token
@@ -1,0 +1,1 @@
+this is a fake token


### PR DESCRIPTION
### Description of your changes

When member agent use secure TLS talk to hub, it  use either a specified CA bundle or CA data in configuration. This changes to allow member agent use OS's [root certificate](https://go.dev/src/crypto/x509/root_linux.go). 

The changes are:
1. refactor the codes of building hub's kubeconfig
2. It is not mandatory to specify CA data or CA bundle in arguments

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
