### PR TITLE
feat: scheduler (1/): add schedule queue implementation

### DIFF
--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -20,14 +20,16 @@ type PolicySnapshotKeySchedulingQueueWriter interface {
 	Add(cpsKey PolicySnapshotKey)
 }
 
-// SchedulingQueue is an interface which queues PolicySnapshots for the scheduler to schedule.
+// PolicySnapshotSchedulingQueue is an interface which queues PolicySnapshots for the scheduler to schedule.
 type PolicySnapshotKeySchedulingQueue interface {
 	PolicySnapshotKeySchedulingQueueWriter
 
 	// Run starts the scheduling queue.
 	Run()
-	// Close closes the scheduling queue.
+	// Close closes the scheduling queue immediately.
 	Close()
+	// CloseWithDrain closes the scheduling queue after all items in the queue are processed.
+	CloseWithDrain()
 	// NextClusterPolicySnapshotKey returns the next-in-line PolicySnapshot key for the scheduler to schedule.
 	NextClusterPolicySnapshotKey() PolicySnapshotKey
 	// Done marks a PolicySnapshot key as done.
@@ -83,8 +85,13 @@ func WithWorkqueueName(name string) Option {
 // appropriate.
 func (sq *simplePolicySnapshotKeySchedulingQueue) Run() {}
 
-// Close shuts down the scheduling queue.
+// Close shuts down the scheduling queue immediately.
 func (sq *simplePolicySnapshotKeySchedulingQueue) Close() {
+	sq.policySanpshotWorkQueue.ShutDown()
+}
+
+// CloseWithDrain shuts down the scheduling queue and returns until all items are processed.
+func (sq *simplePolicySnapshotKeySchedulingQueue) CloseWithDrain() {
 	sq.policySanpshotWorkQueue.ShutDownWithDrain()
 }
 

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -110,7 +110,7 @@ func (sq *simplePolicySnapshotKeySchedulingQueue) Add(cpsKey PolicySnapshotKey) 
 }
 
 // NewSimplePolicySnapshotKeySchedulingQueue returns a simplePolicySnapshotKeySchedulingQueue.
-func NewSimplePolicySnapshotKeySchedulingQueue(opts ...Option) *simplePolicySnapshotKeySchedulingQueue {
+func NewSimplePolicySnapshotKeySchedulingQueue(opts ...Option) PolicySnapshotKeySchedulingQueue {
 	options := defaultSimplePolicySnapshotKeySchedulingQueueOptions
 	for _, opt := range opts {
 		opt(&options)

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -3,15 +3,15 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-// Package schedulingqueue features a scheduling queue, which keeps track of all placements for the scheduler
+// Package queue features a scheduling queue, which keeps track of all placements for the scheduler
 // to schedule.
-package schedulingqueue
+package queue
 
 import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// PolicySnapshotKey is the unique identifier for a PolicySnapshot stored in a scheduling queue.
+// PolicySnapshotKey is the unique identifier (the name of the policy) for a PolicySnapshot stored in a scheduling queue.
 type PolicySnapshotKey string
 
 // PolicySnapshotKeySchedulingQueueWriter is an interface which allows sources, such as controllers, to add

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+// Package schedulingqueue features a scheduling queue, which keeps track of all placements for the scheduler
+// to schedule.
+package schedulingqueue
+
+import (
+	"k8s.io/client-go/util/workqueue"
+)
+
+// PolicySnapshotKey is the unique identifier for a PolicySnapshot stored in a scheduling queue.
+type PolicySnapshotKey string
+
+// PolicySnapshotKeySchedulingQueueWriter is an interface which allows sources, such as controllers, to add
+// PolicySnapshots to the scheduling queue.
+type PolicySnapshotKeySchedulingQueueWriter interface {
+	Add(cpsKey PolicySnapshotKey)
+}
+
+// SchedulingQueue is an interface which queues PolicySnapshots for the scheduler to schedule.
+type PolicySnapshotKeySchedulingQueue interface {
+	PolicySnapshotKeySchedulingQueueWriter
+
+	// Run starts the scheduling queue.
+	Run()
+	// Close closes the scheduling queue.
+	Close()
+	// NextClusterPolicySnapshotKey returns the next-in-line PolicySnapshot key for the scheduler to schedule.
+	NextClusterPolicySnapshotKey() PolicySnapshotKey
+	// Done marks a PolicySnapshot key as done.
+	Done(cpsKey PolicySnapshotKey)
+}
+
+// simplePolicySnapshotKeySchedulingQueue is a simple implementation of PolicySnapshotKeySchedulingQueue.
+//
+// At this moment, one single workqueue would suffice, as sources such as the cluster watcher,
+// the binding watcher, etc., can catch all changes that need the scheduler's attention.
+// In the future, when more features, e.g., inter-placement affinity/anti-affinity, are added,
+// more queues, such as a backoff queue, might become necessary.
+type simplePolicySnapshotKeySchedulingQueue struct {
+	policySanpshotWorkQueue workqueue.RateLimitingInterface
+}
+
+// Verify that simplePolicySnapshotKeySchedulingQueue implements PolicySnapshotKeySchedulingQueue
+// at compile time.
+var _ PolicySnapshotKeySchedulingQueue = &simplePolicySnapshotKeySchedulingQueue{}
+
+// simplePolicySnapshotKeySchedulingQueueOptions are the options for the simplePolicySnapshotKeySchedulingQueue.
+type simplePolicySnapshotKeySchedulingQueueOptions struct {
+	workqueueRateLimiter workqueue.RateLimiter
+	workqueueName        string
+}
+
+// Option is the function that configures the simplePolicySnapshotKeySchedulingQueue.
+type Option func(*simplePolicySnapshotKeySchedulingQueueOptions)
+
+var defaultSimplePolicySnapshotKeySchedulingQueueOptions = simplePolicySnapshotKeySchedulingQueueOptions{
+	workqueueRateLimiter: workqueue.DefaultControllerRateLimiter(),
+	workqueueName:        "policySnapshotKeySchedulingQueue",
+}
+
+// WithWorkqueueRateLimiter sets a rate limiter for the workqueue.
+func WithWorkqueueRateLimiter(rateLimiter workqueue.RateLimiter) Option {
+	return func(o *simplePolicySnapshotKeySchedulingQueueOptions) {
+		o.workqueueRateLimiter = rateLimiter
+	}
+}
+
+// WithWorkqueueName sets a name for the workqueue.
+func WithWorkqueueName(name string) Option {
+	return func(o *simplePolicySnapshotKeySchedulingQueueOptions) {
+		o.workqueueName = name
+	}
+}
+
+// Run starts the scheduling queue.
+//
+// At this moment, Run is an no-op as there is only one queue present; in the future,
+// when more queues are added, Run would start goroutines that move items between queues as
+// appropriate.
+func (sq *simplePolicySnapshotKeySchedulingQueue) Run() {}
+
+// Close shuts down the scheduling queue.
+func (sq *simplePolicySnapshotKeySchedulingQueue) Close() {
+	sq.policySanpshotWorkQueue.ShutDownWithDrain()
+}
+
+// NextClusterPolicySnapshotKey returns the next PolicySnapshot key in the work queue for
+// the scheduler to process.
+func (sq *simplePolicySnapshotKeySchedulingQueue) NextClusterPolicySnapshotKey() PolicySnapshotKey {
+	// This will block on a condition variable if the queue is empty.
+	cpsKey, shutdown := sq.policySanpshotWorkQueue.Get()
+	if shutdown {
+		return ""
+	}
+	return cpsKey.(PolicySnapshotKey)
+}
+
+// Done marks a PolicySnapshot key as done.
+func (sq *simplePolicySnapshotKeySchedulingQueue) Done(cpsKey PolicySnapshotKey) {
+	sq.policySanpshotWorkQueue.Done(cpsKey)
+}
+
+// Add adds a PolicySnapshot key to the work queue.
+func (sq *simplePolicySnapshotKeySchedulingQueue) Add(cpsKey PolicySnapshotKey) {
+	sq.policySanpshotWorkQueue.Add(cpsKey)
+}
+
+// NewSimplePolicySnapshotKeySchedulingQueue returns a simplePolicySnapshotKeySchedulingQueue.
+func NewSimplePolicySnapshotKeySchedulingQueue(opts ...Option) *simplePolicySnapshotKeySchedulingQueue {
+	options := defaultSimplePolicySnapshotKeySchedulingQueueOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return &simplePolicySnapshotKeySchedulingQueue{
+		policySanpshotWorkQueue: workqueue.NewNamedRateLimitingQueue(options.workqueueRateLimiter, options.workqueueName),
+	}
+}

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -11,18 +11,18 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// PolicySnapshotKey is the unique identifier (the name of the policy) for a PolicySnapshot stored in a scheduling queue.
-type PolicySnapshotKey string
+// ClusterPolicySnapshotKey is the unique identifier (its name) for a ClusterPolicySnapshot stored in a scheduling queue.
+type ClusterPolicySnapshotKey string
 
-// PolicySnapshotKeySchedulingQueueWriter is an interface which allows sources, such as controllers, to add
-// PolicySnapshots to the scheduling queue.
-type PolicySnapshotKeySchedulingQueueWriter interface {
-	Add(cpsKey PolicySnapshotKey)
+// ClusterPolicySnapshotKeySchedulingQueueWriter is an interface which allows sources, such as controllers, to add
+// ClusterPolicySnapshots to the scheduling queue.
+type ClusterPolicySnapshotKeySchedulingQueueWriter interface {
+	Add(cpsKey ClusterPolicySnapshotKey)
 }
 
-// PolicySnapshotSchedulingQueue is an interface which queues PolicySnapshots for the scheduler to schedule.
-type PolicySnapshotKeySchedulingQueue interface {
-	PolicySnapshotKeySchedulingQueueWriter
+// ClusterPolicySnapshotSchedulingQueue is an interface which queues ClusterPolicySnapshots for the scheduler to schedule.
+type ClusterPolicySnapshotKeySchedulingQueue interface {
+	ClusterPolicySnapshotKeySchedulingQueueWriter
 
 	// Run starts the scheduling queue.
 	Run()
@@ -30,50 +30,52 @@ type PolicySnapshotKeySchedulingQueue interface {
 	Close()
 	// CloseWithDrain closes the scheduling queue after all items in the queue are processed.
 	CloseWithDrain()
-	// NextClusterPolicySnapshotKey returns the next-in-line PolicySnapshot key for the scheduler to schedule.
-	NextClusterPolicySnapshotKey() PolicySnapshotKey
-	// Done marks a PolicySnapshot key as done.
-	Done(cpsKey PolicySnapshotKey)
+	// NextClusterPolicySnapshotKey returns the next-in-line ClusterPolicySnapshot key for the scheduler to schedule.
+	NextClusterPolicySnapshotKey() ClusterPolicySnapshotKey
+	// Done marks a ClusterPolicySnapshot key as done.
+	Done(cpsKey ClusterPolicySnapshotKey)
 }
 
-// simplePolicySnapshotKeySchedulingQueue is a simple implementation of PolicySnapshotKeySchedulingQueue.
+// simpleClusterPolicySnapshotKeySchedulingQueue is a simple implementation of
+// ClusterPolicySnapshotKeySchedulingQueue.
 //
 // At this moment, one single workqueue would suffice, as sources such as the cluster watcher,
 // the binding watcher, etc., can catch all changes that need the scheduler's attention.
 // In the future, when more features, e.g., inter-placement affinity/anti-affinity, are added,
 // more queues, such as a backoff queue, might become necessary.
-type simplePolicySnapshotKeySchedulingQueue struct {
-	policySanpshotWorkQueue workqueue.RateLimitingInterface
+type simpleClusterPolicySnapshotKeySchedulingQueue struct {
+	clusterPolicySanpshotWorkQueue workqueue.RateLimitingInterface
 }
 
-// Verify that simplePolicySnapshotKeySchedulingQueue implements PolicySnapshotKeySchedulingQueue
-// at compile time.
-var _ PolicySnapshotKeySchedulingQueue = &simplePolicySnapshotKeySchedulingQueue{}
+// Verify that simpleClusterPolicySnapshotKeySchedulingQueue implements
+// ClusterPolicySnapshotKeySchedulingQueue at compile time.
+var _ ClusterPolicySnapshotKeySchedulingQueue = &simpleClusterPolicySnapshotKeySchedulingQueue{}
 
-// simplePolicySnapshotKeySchedulingQueueOptions are the options for the simplePolicySnapshotKeySchedulingQueue.
-type simplePolicySnapshotKeySchedulingQueueOptions struct {
+// simpleClusterPolicySnapshotKeySchedulingQueueOptions are the options for the
+// simpleClusterPolicySnapshotKeySchedulingQueue.
+type simpleClusterPolicySnapshotKeySchedulingQueueOptions struct {
 	workqueueRateLimiter workqueue.RateLimiter
 	workqueueName        string
 }
 
-// Option is the function that configures the simplePolicySnapshotKeySchedulingQueue.
-type Option func(*simplePolicySnapshotKeySchedulingQueueOptions)
+// Option is the function that configures the simpleClusterPolicySnapshotKeySchedulingQueue.
+type Option func(*simpleClusterPolicySnapshotKeySchedulingQueueOptions)
 
-var defaultSimplePolicySnapshotKeySchedulingQueueOptions = simplePolicySnapshotKeySchedulingQueueOptions{
+var defaultSimpleClusterPolicySnapshotKeySchedulingQueueOptions = simpleClusterPolicySnapshotKeySchedulingQueueOptions{
 	workqueueRateLimiter: workqueue.DefaultControllerRateLimiter(),
-	workqueueName:        "policySnapshotKeySchedulingQueue",
+	workqueueName:        "clusterPolicySnapshotKeySchedulingQueue",
 }
 
 // WithWorkqueueRateLimiter sets a rate limiter for the workqueue.
 func WithWorkqueueRateLimiter(rateLimiter workqueue.RateLimiter) Option {
-	return func(o *simplePolicySnapshotKeySchedulingQueueOptions) {
+	return func(o *simpleClusterPolicySnapshotKeySchedulingQueueOptions) {
 		o.workqueueRateLimiter = rateLimiter
 	}
 }
 
 // WithWorkqueueName sets a name for the workqueue.
 func WithWorkqueueName(name string) Option {
-	return func(o *simplePolicySnapshotKeySchedulingQueueOptions) {
+	return func(o *simpleClusterPolicySnapshotKeySchedulingQueueOptions) {
 		o.workqueueName = name
 	}
 }
@@ -83,47 +85,48 @@ func WithWorkqueueName(name string) Option {
 // At this moment, Run is an no-op as there is only one queue present; in the future,
 // when more queues are added, Run would start goroutines that move items between queues as
 // appropriate.
-func (sq *simplePolicySnapshotKeySchedulingQueue) Run() {}
+func (sq *simpleClusterPolicySnapshotKeySchedulingQueue) Run() {}
 
 // Close shuts down the scheduling queue immediately.
-func (sq *simplePolicySnapshotKeySchedulingQueue) Close() {
-	sq.policySanpshotWorkQueue.ShutDown()
+func (sq *simpleClusterPolicySnapshotKeySchedulingQueue) Close() {
+	sq.clusterPolicySanpshotWorkQueue.ShutDown()
 }
 
 // CloseWithDrain shuts down the scheduling queue and returns until all items are processed.
-func (sq *simplePolicySnapshotKeySchedulingQueue) CloseWithDrain() {
-	sq.policySanpshotWorkQueue.ShutDownWithDrain()
+func (sq *simpleClusterPolicySnapshotKeySchedulingQueue) CloseWithDrain() {
+	sq.clusterPolicySanpshotWorkQueue.ShutDownWithDrain()
 }
 
-// NextClusterPolicySnapshotKey returns the next PolicySnapshot key in the work queue for
+// NextClusterPolicySnapshotKey returns the next ClusterPolicySnapshot key in the work queue for
 // the scheduler to process.
-func (sq *simplePolicySnapshotKeySchedulingQueue) NextClusterPolicySnapshotKey() PolicySnapshotKey {
+func (sq *simpleClusterPolicySnapshotKeySchedulingQueue) NextClusterPolicySnapshotKey() ClusterPolicySnapshotKey {
 	// This will block on a condition variable if the queue is empty.
-	cpsKey, shutdown := sq.policySanpshotWorkQueue.Get()
+	cpsKey, shutdown := sq.clusterPolicySanpshotWorkQueue.Get()
 	if shutdown {
 		return ""
 	}
-	return cpsKey.(PolicySnapshotKey)
+	return cpsKey.(ClusterPolicySnapshotKey)
 }
 
-// Done marks a PolicySnapshot key as done.
-func (sq *simplePolicySnapshotKeySchedulingQueue) Done(cpsKey PolicySnapshotKey) {
-	sq.policySanpshotWorkQueue.Done(cpsKey)
+// Done marks a ClusterPolicySnapshot key as done.
+func (sq *simpleClusterPolicySnapshotKeySchedulingQueue) Done(cpsKey ClusterPolicySnapshotKey) {
+	sq.clusterPolicySanpshotWorkQueue.Done(cpsKey)
 }
 
-// Add adds a PolicySnapshot key to the work queue.
-func (sq *simplePolicySnapshotKeySchedulingQueue) Add(cpsKey PolicySnapshotKey) {
-	sq.policySanpshotWorkQueue.Add(cpsKey)
+// Add adds a ClusterPolicySnapshot key to the work queue.
+func (sq *simpleClusterPolicySnapshotKeySchedulingQueue) Add(cpsKey ClusterPolicySnapshotKey) {
+	sq.clusterPolicySanpshotWorkQueue.Add(cpsKey)
 }
 
-// NewSimplePolicySnapshotKeySchedulingQueue returns a simplePolicySnapshotKeySchedulingQueue.
-func NewSimplePolicySnapshotKeySchedulingQueue(opts ...Option) PolicySnapshotKeySchedulingQueue {
-	options := defaultSimplePolicySnapshotKeySchedulingQueueOptions
+// NewSimpleClusterPolicySnapshotKeySchedulingQueue returns a
+// simpleClusterPolicySnapshotKeySchedulingQueue.
+func NewSimpleClusterPolicySnapshotKeySchedulingQueue(opts ...Option) ClusterPolicySnapshotKeySchedulingQueue {
+	options := defaultSimpleClusterPolicySnapshotKeySchedulingQueueOptions
 	for _, opt := range opts {
 		opt(&options)
 	}
 
-	return &simplePolicySnapshotKeySchedulingQueue{
-		policySanpshotWorkQueue: workqueue.NewNamedRateLimitingQueue(options.workqueueRateLimiter, options.workqueueName),
+	return &simpleClusterPolicySnapshotKeySchedulingQueue{
+		clusterPolicySanpshotWorkQueue: workqueue.NewNamedRateLimitingQueue(options.workqueueRateLimiter, options.workqueueName),
 	}
 }

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -24,7 +24,10 @@ func TestSimpleClusterPolicySnapshotKeySchedulingQueueBasicOps(t *testing.T) {
 
 	keysRecved := []ClusterPolicySnapshotKey{}
 	for i := 0; i < len(keysToAdd); i++ {
-		key := sq.NextClusterPolicySnapshotKey()
+		key, closed := sq.NextClusterPolicySnapshotKey()
+		if closed {
+			t.Fatalf("Queue closed unexpected")
+		}
 		keysRecved = append(keysRecved, key)
 		sq.Done(key)
 	}

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -11,18 +11,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// TestSimplePolicySnapshotKeySchedulingQueueBasicOps tests the basic ops
+// TestSimpleClusterPolicySnapshotKeySchedulingQueueBasicOps tests the basic ops
 // (Add, NextClusterPolicySnapshotKey, Done) of a simplePolicySnapshotKeySchedulingQueue.
-func TestSimplePolicySnapshotKeySchedulingQueueBasicOps(t *testing.T) {
-	sq := NewSimplePolicySnapshotKeySchedulingQueue()
+func TestSimpleClusterPolicySnapshotKeySchedulingQueueBasicOps(t *testing.T) {
+	sq := NewSimpleClusterPolicySnapshotKeySchedulingQueue()
 	sq.Run()
 
-	keysToAdd := []PolicySnapshotKey{"A", "B", "C", "D", "E"}
+	keysToAdd := []ClusterPolicySnapshotKey{"A", "B", "C", "D", "E"}
 	for _, key := range keysToAdd {
 		sq.Add(key)
 	}
 
-	keysRecved := []PolicySnapshotKey{}
+	keysRecved := []ClusterPolicySnapshotKey{}
 	for i := 0; i < len(keysToAdd); i++ {
 		key := sq.NextClusterPolicySnapshotKey()
 		keysRecved = append(keysRecved, key)

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package schedulingqueue
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestSimplePolicySnapshotKeySchedulingQueueBasicOps tests the basic ops
+// (Add, NextClusterPolicySnapshotKey, Done) of a simplePolicySnapshotKeySchedulingQueue.
+func TestSimplePolicySnapshotKeySchedulingQueueBasicOps(t *testing.T) {
+	sq := NewSimplePolicySnapshotKeySchedulingQueue()
+	sq.Run()
+
+	keysToAdd := []PolicySnapshotKey{"A", "B", "C", "D", "E"}
+	for _, key := range keysToAdd {
+		sq.Add(key)
+	}
+
+	keysRecved := []PolicySnapshotKey{}
+	for i := 0; i < len(keysToAdd); i++ {
+		key := sq.NextClusterPolicySnapshotKey()
+		keysRecved = append(keysRecved, key)
+		sq.Done(key)
+	}
+
+	if !cmp.Equal(keysToAdd, keysRecved) {
+		t.Fatalf("Received keys %v, want %v", keysRecved, keysToAdd)
+	}
+
+	sq.Close()
+}

--- a/pkg/scheduler/queue/queue_test.go
+++ b/pkg/scheduler/queue/queue_test.go
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-package schedulingqueue
+package queue
 
 import (
 	"testing"


### PR DESCRIPTION
### Description of your changes

This PR is part of the PRs that implement the Fleet workload scheduling.

It features the a simple scheduling queue for the scheduler and related components to use.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer
