### PR TITLE
feat: scheduler (5/): add parallelizer

### DIFF
--- a/pkg/scheduler/framework/parallelizer/errorflag.go
+++ b/pkg/scheduler/framework/parallelizer/errorflag.go
@@ -1,0 +1,39 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package parallelizer
+
+// ErrorFlag is a flag for indicating whether an error has occurred when running tasks in
+// parallel with the parallelizer.
+type ErrorFlag struct {
+	errChan chan error
+}
+
+// Raise raises the error flag with an error; if the flag has been raised, it will return
+// immediately.
+func (f *ErrorFlag) Raise(err error) {
+	select {
+	case f.errChan <- err:
+	default:
+	}
+}
+
+// Lower lowers the error flag and returns the error that was used to raise the flag; it returns
+// nil if the flag has not been raised.
+func (f *ErrorFlag) Lower() error {
+	select {
+	case err := <-f.errChan:
+		return err
+	default:
+		return nil
+	}
+}
+
+// NewErrorFlag returns an error flag.
+func NewErrorFlag() *ErrorFlag {
+	return &ErrorFlag{
+		errChan: make(chan error, 1),
+	}
+}

--- a/pkg/scheduler/framework/parallelizer/errorflag_test.go
+++ b/pkg/scheduler/framework/parallelizer/errorflag_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package parallelizer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+// TestErrorFlag tests the basic ops of an ErrorFlag.
+func TestErrorFlag(t *testing.T) {
+	errFlag := NewErrorFlag()
+	err := fmt.Errorf("test error")
+
+	errFlag.Raise(err)
+	returnedErr := errFlag.Lower()
+	if !cmp.Equal(err, returnedErr, cmpopts.EquateErrors()) {
+		t.Fatalf("Lower() = %v, want %v", returnedErr, err)
+	}
+}

--- a/pkg/scheduler/framework/parallelizer/parallelizer.go
+++ b/pkg/scheduler/framework/parallelizer/parallelizer.go
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-// package parallelizer features some utilities to help run tasks in parallel.
+// Package parallelizer features some utilities to help run tasks in parallel.
 package parallelizer
 
 import (

--- a/pkg/scheduler/framework/parallelizer/parallelizer.go
+++ b/pkg/scheduler/framework/parallelizer/parallelizer.go
@@ -3,6 +3,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
+// package parallelizer features some utilities to help run tasks in parallel.
 package parallelizer
 
 import (

--- a/pkg/scheduler/framework/parallelizer/parallelizer.go
+++ b/pkg/scheduler/framework/parallelizer/parallelizer.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package parallelizer
+
+import (
+	"context"
+
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// The default number of workers.
+	DefaultNumOfWorkers = 4
+)
+
+// Parallelizer helps run tasks in parallel.
+type Parallerlizer struct {
+	numOfWorkers int
+}
+
+// NewParallelizer returns a Parallelizer for running tasks in parallel.
+func NewParallelizer(workers int) *Parallerlizer {
+	return &Parallerlizer{
+		numOfWorkers: workers,
+	}
+}
+
+// ParallelizeUntil wraps workqueue.ParallelizeUntil for running tasks in parallel.
+func (p *Parallerlizer) ParallelizeUntil(ctx context.Context, pieces int, doWork workqueue.DoWorkPieceFunc, operation string) {
+	doWorkWithLogs := func(piece int) {
+		klog.V(4).Infof("run piece %d for operation %s", operation, piece)
+		doWork(piece)
+		klog.V(4).Infof("completed piece %d for operation %s", operation, piece)
+	}
+
+	workqueue.ParallelizeUntil(ctx, p.numOfWorkers, pieces, doWorkWithLogs)
+}

--- a/pkg/scheduler/framework/parallelizer/parallelizer_test.go
+++ b/pkg/scheduler/framework/parallelizer/parallelizer_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package parallelizer
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+)
+
+// TestParallelizer tests the basic ops of a Parallelizer.
+func TestParallelizer(t *testing.T) {
+	p := NewParallelizer(DefaultNumOfWorkers)
+	nums := []int{1, 2, 3, 4, 5, 6, 7, 8}
+
+	var sum int32
+	doWork := func(pieces int) {
+		num := nums[pieces]
+		atomic.AddInt32(&sum, int32(num))
+	}
+
+	ctx := context.Background()
+	p.ParallelizeUntil(ctx, len(nums), doWork, "test")
+	if sum != 36 {
+		t.Errorf("sum of nums, want %d, got %d", 36, sum)
+	}
+}


### PR DESCRIPTION
### Description of your changes

This PR is part of the PRs that implement the Fleet workload scheduling.

It features a parallelizer, which the scheduler frameworks uses to run tasks in parallel.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer

