### PR TITLE
fix: remove the numberOfClusters from policySnapshot spec

### DIFF
--- a/apis/placement/v1beta1/policysnapshot_types.go
+++ b/apis/placement/v1beta1/policysnapshot_types.go
@@ -17,6 +17,7 @@ const (
 	// PolicySnapshotNameFmt is clusterPolicySnapshot name format: {CRPName}-{PolicySnapshotIndex}.
 	PolicySnapshotNameFmt = "%s-%d"
 
+	// NumberOfClustersAnnotation is the annotation that indicates how many clusters should be selected for selectN placement type.
 	NumberOfClustersAnnotation = fleetPrefix + "numberOfClusters"
 )
 

--- a/apis/placement/v1beta1/policysnapshot_types.go
+++ b/apis/placement/v1beta1/policysnapshot_types.go
@@ -16,6 +16,8 @@ const (
 
 	// PolicySnapshotNameFmt is clusterPolicySnapshot name format: {CRPName}-{PolicySnapshotIndex}.
 	PolicySnapshotNameFmt = "%s-%d"
+
+	NumberOfClustersAnnotation = fleetPrefix + "numberOfClusters"
 )
 
 // +genclient

--- a/pkg/controllers/clusterresourceplacement/placement_controller.go
+++ b/pkg/controllers/clusterresourceplacement/placement_controller.go
@@ -345,9 +345,11 @@ func (r *Reconciler) updatePlacementAppliedCondition(placement *fleetv1alpha1.Cl
 // It creates corresponding clusterPolicySnapshot and clusterResourceSnapshot if needed and updates the status based on
 // clusterPolicySnapshot status and work status.
 // If the error type is ErrUnexpectedBehavior, the controller will skip the reconciling.
-func (r *Reconciler) handleUpdate(ctx context.Context, crp *fleetv1beta1.ClusterResourcePlacement) (ctrl.Result, error) {
+func (r *Reconciler) handleUpdate(ctx context.Context, crp *fleetv1.ClusterResourcePlacement) (ctrl.Result, error) {
 	crpKObj := klog.KObj(crp)
-	policyHash, err := generatePolicyHash(crp.Spec.Policy)
+	schedulingPolicy := *crp.Spec.Policy // will exclude the numberOfClusters
+	schedulingPolicy.NumberOfClusters = nil
+	policyHash, err := generatePolicyHash(&schedulingPolicy)
 	if err != nil {
 		klog.ErrorS(err, "Failed to generate policy hash of crp", "clusterResourcePlacement", crpKObj)
 		return ctrl.Result{}, controller.NewUnexpectedBehaviorError(err)
@@ -361,57 +363,97 @@ func (r *Reconciler) handleUpdate(ctx context.Context, crp *fleetv1beta1.Cluster
 	// mark the last policy snapshot as inactive if it is different from what we have now
 	if latestPolicySnapshot != nil &&
 		string(latestPolicySnapshot.Spec.PolicyHash) != policyHash &&
-		latestPolicySnapshot.Labels[fleetv1beta1.IsLatestSnapshotLabel] == strconv.FormatBool(true) {
+		latestPolicySnapshot.Labels[fleetv1.IsLatestSnapshotLabel] == strconv.FormatBool(true) {
 		// set the latest label to false first to make sure there is only one or none active policy snapshot
-		latestPolicySnapshot.Labels[fleetv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
+		latestPolicySnapshot.Labels[fleetv1.IsLatestSnapshotLabel] = strconv.FormatBool(false)
 		if err := r.Client.Update(ctx, latestPolicySnapshot); err != nil {
 			klog.ErrorS(err, "Failed to set the isLatestSnapshot label to false", "clusterPolicySnapshot", klog.KObj(latestPolicySnapshot))
 			return ctrl.Result{}, controller.NewAPIServerError(err)
 		}
 	}
-	if latestPolicySnapshot == nil || string(latestPolicySnapshot.Spec.PolicyHash) != policyHash {
+	if latestPolicySnapshot != nil && string(latestPolicySnapshot.Spec.PolicyHash) == policyHash {
+		if err := r.ensureLatestPolicySnapshot(ctx, crp, latestPolicySnapshot); err != nil {
+			return ctrl.Result{}, err
+		}
+	} else {
 		// create a new policy snapshot
 		latestPolicySnapshotIndex++
-		latestPolicySnapshot = &fleetv1beta1.ClusterPolicySnapshot{
+		latestPolicySnapshot = &fleetv1.ClusterPolicySnapshot{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, crp.Name, latestPolicySnapshotIndex),
+				Name: fmt.Sprintf(fleetv1.PolicySnapshotNameFmt, crp.Name, latestPolicySnapshotIndex),
 				Labels: map[string]string{
-					fleetv1beta1.CRPTrackingLabel:      crp.Name,
-					fleetv1beta1.IsLatestSnapshotLabel: strconv.FormatBool(true),
-					fleetv1beta1.PolicyIndexLabel:      strconv.Itoa(latestPolicySnapshotIndex),
+					fleetv1.CRPTrackingLabel:      crp.Name,
+					fleetv1.IsLatestSnapshotLabel: strconv.FormatBool(true),
+					fleetv1.PolicyIndexLabel:      strconv.Itoa(latestPolicySnapshotIndex),
 				},
 			},
-			Spec: fleetv1beta1.PolicySnapshotSpec{
-				Policy:     crp.Spec.Policy,
+			Spec: fleetv1.PolicySnapshotSpec{
+				Policy:     &schedulingPolicy,
 				PolicyHash: []byte(policyHash),
 			},
 		}
+		policySnapshotKObj := klog.KObj(latestPolicySnapshot)
 		if err := controllerutil.SetControllerReference(crp, latestPolicySnapshot, r.Scheme); err != nil {
-			klog.ErrorS(err, "Failed to create set owner reference", "clusterPolicySnapshot", klog.KObj(latestPolicySnapshot))
+			klog.ErrorS(err, "Failed to create set owner reference", "clusterPolicySnapshot", policySnapshotKObj)
 			// should never happen
 			return ctrl.Result{}, controller.NewUnexpectedBehaviorError(err)
 		}
+		// make sure each policySnapshot should always have the annotation if CRP is selectN type
+		if crp.Spec.Policy != nil &&
+			crp.Spec.Policy.PlacementType == fleetv1.PickNPlacementType &&
+			crp.Spec.Policy.NumberOfClusters != nil {
+			latestPolicySnapshot.Annotations = map[string]string{
+				fleetv1.NumberOfClustersAnnotation: strconv.Itoa(int(*crp.Spec.Policy.NumberOfClusters)),
+			}
+		}
+
 		if err := r.Client.Create(ctx, latestPolicySnapshot); err != nil {
-			klog.ErrorS(err, "Failed to create new clusterPolicySnapshot", "clusterPolicySnapshot", klog.KObj(latestPolicySnapshot))
+			klog.ErrorS(err, "Failed to create new clusterPolicySnapshot", "clusterPolicySnapshot", policySnapshotKObj)
 			return ctrl.Result{}, controller.NewAPIServerError(err)
 		}
-	} else if latestPolicySnapshot.Labels[fleetv1beta1.IsLatestSnapshotLabel] != strconv.FormatBool(true) {
+	}
+
+	// create clusterResourceSnapshot
+	// update the status based on the latestPolicySnapshot status
+	// update the status based on the work
+	return ctrl.Result{}, nil
+}
+
+// ensureLatestPolicySnapshot ensures the latest policySnapshot has the isLatest label and the numberOfClusters are updated.
+func (r *Reconciler) ensureLatestPolicySnapshot(ctx context.Context, crp *fleetv1.ClusterResourcePlacement, latest *fleetv1.ClusterPolicySnapshot) error {
+	needUpdate := false
+	if latest.Labels[fleetv1.IsLatestSnapshotLabel] != strconv.FormatBool(true) {
 		// When latestPolicySnapshot.Spec.PolicyHash == policyHash,
 		// It could happen when the controller just sets the latest label to false for the old snapshot, and fails to
 		// create a new policy snapshot.
 		// And then the customers revert back their policy to the old one again.
 		// In this case, the "latest" snapshot without isLatest label has the same policy hash as the current policy.
 
-		latestPolicySnapshot.Labels[fleetv1beta1.IsLatestSnapshotLabel] = strconv.FormatBool(true)
-		if err := r.Client.Update(ctx, latestPolicySnapshot); err != nil {
-			klog.ErrorS(err, "Failed to set the isLatestSnapshot label to true", "clusterPolicySnapshot", klog.KObj(latestPolicySnapshot))
-			return ctrl.Result{}, controller.NewAPIServerError(err)
+		latest.Labels[fleetv1.IsLatestSnapshotLabel] = strconv.FormatBool(true)
+		needUpdate = true
+	}
+
+	if crp.Spec.Policy != nil &&
+		crp.Spec.Policy.PlacementType == fleetv1.PickNPlacementType &&
+		crp.Spec.Policy.NumberOfClusters != nil {
+		oldCount, err := parseNumberOfClustersFromAnnotation(latest)
+		if err != nil {
+			return controller.NewUnexpectedBehaviorError(err)
+		}
+		newCount := int(*crp.Spec.Policy.NumberOfClusters)
+		if oldCount != newCount {
+			latest.Annotations[fleetv1.NumberOfClustersAnnotation] = strconv.Itoa(newCount)
+			needUpdate = true
 		}
 	}
-	// create clusterResourceSnapshot
-	// update the status based on the latestPolicySnapshot status
-	// update the status based on the work
-	return ctrl.Result{}, nil
+	if !needUpdate {
+		return nil
+	}
+	if err := r.Client.Update(ctx, latest); err != nil {
+		klog.ErrorS(err, "Failed to update the clusterPolicySnapshot", "clusterPolicySnapshot", klog.KObj(latest))
+		return controller.NewAPIServerError(err)
+	}
+	return nil
 }
 
 // lookupLatestClusterPolicySnapshot finds the latest snapshots and its policy index.
@@ -480,7 +522,18 @@ func parsePolicyIndexFromLabel(s *fleetv1beta1.ClusterPolicySnapshot) (int, erro
 	return v, nil
 }
 
-func generatePolicyHash(policy *fleetv1beta1.PlacementPolicy) (string, error) {
+func parseNumberOfClustersFromAnnotation(s *fleetv1.ClusterPolicySnapshot) (int, error) {
+	n := s.Annotations[fleetv1.NumberOfClustersAnnotation]
+	v, err := strconv.Atoi(n)
+	if err != nil {
+		klog.ErrorS(err, "Failed to parse the numberOfClusterAnnotation", "clusterPolicySnapshot", klog.KObj(s), "numberOfClusterAnnotation", n)
+		// should never happen
+		return -1, err
+	}
+	return v, nil
+}
+
+func generatePolicyHash(policy *fleetv1.PlacementPolicy) (string, error) {
 	jsonBytes, err := json.Marshal(policy)
 	if err != nil {
 		return "", err

--- a/pkg/controllers/clusterresourceplacement/placement_controller_test.go
+++ b/pkg/controllers/clusterresourceplacement/placement_controller_test.go
@@ -133,10 +133,10 @@ func TestHandleUpdate(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(3),
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
-					Spec: fleetv1.PolicySnapshotSpec{
+					Spec: fleetv1beta1.PolicySnapshotSpec{
 						Policy:     wantPolicy,
 						PolicyHash: policyHash,
 					},
@@ -164,10 +164,10 @@ func TestHandleUpdate(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(3),
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
-					Spec: fleetv1.PolicySnapshotSpec{
+					Spec: fleetv1beta1.PolicySnapshotSpec{
 						Policy:     wantPolicy,
 						PolicyHash: policyHash,
 					},
@@ -192,10 +192,10 @@ func TestHandleUpdate(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(3),
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
-					Spec: fleetv1.PolicySnapshotSpec{
+					Spec: fleetv1beta1.PolicySnapshotSpec{
 						Policy:     wantPolicy,
 						PolicyHash: policyHash,
 					},
@@ -319,10 +319,10 @@ func TestHandleUpdate(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(3),
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
-					Spec: fleetv1.PolicySnapshotSpec{
+					Spec: fleetv1beta1.PolicySnapshotSpec{
 						Policy:     wantPolicy,
 						PolicyHash: policyHash,
 					},
@@ -398,10 +398,10 @@ func TestHandleUpdate(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(3),
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
-					Spec: fleetv1.PolicySnapshotSpec{
+					Spec: fleetv1beta1.PolicySnapshotSpec{
 						Policy:     wantPolicy,
 						PolicyHash: policyHash,
 					},
@@ -438,8 +438,8 @@ func TestHandleUpdate(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 1),
 						Labels: map[string]string{
-							fleetv1.PolicyIndexLabel: "1",
-							fleetv1.CRPTrackingLabel: testName,
+							fleetv1beta1.PolicyIndexLabel: "1",
+							fleetv1beta1.CRPTrackingLabel: testName,
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -451,124 +451,19 @@ func TestHandleUpdate(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(3),
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
-					Spec: fleetv1.PolicySnapshotSpec{
+					Spec: fleetv1beta1.PolicySnapshotSpec{
 						Policy:     wantPolicy,
 						PolicyHash: policyHash,
 					},
 				},
 			},
-			wantPolicySnapshots: []fleetv1.ClusterPolicySnapshot{
+			wantPolicySnapshots: []fleetv1beta1.ClusterPolicySnapshot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf(fleetv1.PolicySnapshotNameFmt, testName, 0),
-						Labels: map[string]string{
-							fleetv1.PolicyIndexLabel:      "0",
-							fleetv1.IsLatestSnapshotLabel: "false",
-							fleetv1.CRPTrackingLabel:      testName,
-						},
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								Name:               testName,
-								BlockOwnerDeletion: pointer.Bool(true),
-								Controller:         pointer.Bool(true),
-								APIVersion:         fleetAPIVersion,
-								Kind:               "ClusterResourcePlacement",
-							},
-						},
-					},
-					Spec: fleetv1.PolicySnapshotSpec{
-						// Policy is not specified.
-						PolicyHash: unspecifiedPolicyHash,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf(fleetv1.PolicySnapshotNameFmt, testName, 1),
-						Labels: map[string]string{
-							fleetv1.PolicyIndexLabel:      "1",
-							fleetv1.IsLatestSnapshotLabel: "true",
-							fleetv1.CRPTrackingLabel:      testName,
-						},
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								Name:               testName,
-								BlockOwnerDeletion: pointer.Bool(true),
-								Controller:         pointer.Bool(true),
-								APIVersion:         fleetAPIVersion,
-								Kind:               "ClusterResourcePlacement",
-							},
-						},
-						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(3),
-						},
-					},
-					Spec: fleetv1.PolicySnapshotSpec{
-						Policy:     wantPolicy,
-						PolicyHash: policyHash,
-					},
-				},
-			},
-		},
-		{
-			name: "crp policy has not been changed and only the numberOfCluster is changed",
-			policySnapshots: []fleetv1.ClusterPolicySnapshot{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf(fleetv1.PolicySnapshotNameFmt, testName, 0),
-						Labels: map[string]string{
-							fleetv1.PolicyIndexLabel:      "0",
-							fleetv1.IsLatestSnapshotLabel: "false",
-							fleetv1.CRPTrackingLabel:      testName,
-						},
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								Name:               testName,
-								BlockOwnerDeletion: pointer.Bool(true),
-								Controller:         pointer.Bool(true),
-								APIVersion:         fleetAPIVersion,
-								Kind:               "ClusterResourcePlacement",
-							},
-						},
-					},
-					Spec: fleetv1.PolicySnapshotSpec{
-						// Policy is not specified.
-						PolicyHash: unspecifiedPolicyHash,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf(fleetv1.PolicySnapshotNameFmt, testName, 1),
-						Labels: map[string]string{
-							fleetv1.PolicyIndexLabel:      "1",
-							fleetv1.CRPTrackingLabel:      testName,
-							fleetv1.IsLatestSnapshotLabel: "true",
-						},
-						OwnerReferences: []metav1.OwnerReference{
-							{
-								Name:               testName,
-								BlockOwnerDeletion: pointer.Bool(true),
-								Controller:         pointer.Bool(true),
-								APIVersion:         fleetAPIVersion,
-								Kind:               "ClusterResourcePlacement",
-							},
-						},
-						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(1),
-						},
-					},
-					Spec: fleetv1.PolicySnapshotSpec{
-						Policy:     wantPolicy,
-						PolicyHash: policyHash,
-					},
-				},
-			},
-			wantPolicySnapshots: []fleetv1.ClusterPolicySnapshot{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: fmt.Sprintf(fleetv1.PolicySnapshotNameFmt, testName, 0),
+						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 0),
 						Labels: map[string]string{
 							fleetv1beta1.PolicyIndexLabel:      "0",
 							fleetv1beta1.IsLatestSnapshotLabel: "false",
@@ -607,10 +502,115 @@ func TestHandleUpdate(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
-							fleetv1.NumberOfClustersAnnotation: strconv.Itoa(3),
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
-					Spec: fleetv1.PolicySnapshotSpec{
+					Spec: fleetv1beta1.PolicySnapshotSpec{
+						Policy:     wantPolicy,
+						PolicyHash: policyHash,
+					},
+				},
+			},
+		},
+		{
+			name: "crp policy has not been changed and only the numberOfCluster is changed",
+			policySnapshots: []fleetv1beta1.ClusterPolicySnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 0),
+						Labels: map[string]string{
+							fleetv1beta1.PolicyIndexLabel:      "0",
+							fleetv1beta1.IsLatestSnapshotLabel: "false",
+							fleetv1beta1.CRPTrackingLabel:      testName,
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:               testName,
+								BlockOwnerDeletion: pointer.Bool(true),
+								Controller:         pointer.Bool(true),
+								APIVersion:         fleetAPIVersion,
+								Kind:               "ClusterResourcePlacement",
+							},
+						},
+					},
+					Spec: fleetv1beta1.PolicySnapshotSpec{
+						// Policy is not specified.
+						PolicyHash: unspecifiedPolicyHash,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 1),
+						Labels: map[string]string{
+							fleetv1beta1.PolicyIndexLabel:      "1",
+							fleetv1beta1.CRPTrackingLabel:      testName,
+							fleetv1beta1.IsLatestSnapshotLabel: "true",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:               testName,
+								BlockOwnerDeletion: pointer.Bool(true),
+								Controller:         pointer.Bool(true),
+								APIVersion:         fleetAPIVersion,
+								Kind:               "ClusterResourcePlacement",
+							},
+						},
+						Annotations: map[string]string{
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(1),
+						},
+					},
+					Spec: fleetv1beta1.PolicySnapshotSpec{
+						Policy:     wantPolicy,
+						PolicyHash: policyHash,
+					},
+				},
+			},
+			wantPolicySnapshots: []fleetv1beta1.ClusterPolicySnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 0),
+						Labels: map[string]string{
+							fleetv1beta1.PolicyIndexLabel:      "0",
+							fleetv1beta1.IsLatestSnapshotLabel: "false",
+							fleetv1beta1.CRPTrackingLabel:      testName,
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:               testName,
+								BlockOwnerDeletion: pointer.Bool(true),
+								Controller:         pointer.Bool(true),
+								APIVersion:         fleetAPIVersion,
+								Kind:               "ClusterResourcePlacement",
+							},
+						},
+					},
+					Spec: fleetv1beta1.PolicySnapshotSpec{
+						// Policy is not specified.
+						PolicyHash: unspecifiedPolicyHash,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 1),
+						Labels: map[string]string{
+							fleetv1beta1.PolicyIndexLabel:      "1",
+							fleetv1beta1.IsLatestSnapshotLabel: "true",
+							fleetv1beta1.CRPTrackingLabel:      testName,
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:               testName,
+								BlockOwnerDeletion: pointer.Bool(true),
+								Controller:         pointer.Bool(true),
+								APIVersion:         fleetAPIVersion,
+								Kind:               "ClusterResourcePlacement",
+							},
+						},
+						Annotations: map[string]string{
+							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
+						},
+					},
+					Spec: fleetv1beta1.PolicySnapshotSpec{
 						Policy:     wantPolicy,
 						PolicyHash: policyHash,
 					},
@@ -655,6 +655,13 @@ func TestHandleUpdate(t *testing.T) {
 }
 
 func TestHandleUpdate_failure(t *testing.T) {
+	wantPolicy := placementPolicyForTest()
+	wantPolicy.NumberOfClusters = nil
+	jsonBytes, err := json.Marshal(wantPolicy)
+	if err != nil {
+		t.Fatalf("failed to create the policy hash: %v", err)
+	}
+	policyHash := []byte(fmt.Sprintf("%x", sha256.Sum256(jsonBytes)))
 	tests := []struct {
 		name            string
 		policySnapshots []fleetv1beta1.ClusterPolicySnapshot
@@ -762,6 +769,91 @@ func TestHandleUpdate_failure(t *testing.T) {
 								Controller:         pointer.Bool(true),
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			// Should never hit this case unless there is a bug in the controller or customers manually modify the clusterPolicySnapshot.
+			name: "no active policy snapshot exists and policySnapshot with invalid policyIndex label (negative value)",
+			policySnapshots: []fleetv1beta1.ClusterPolicySnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 0),
+						Labels: map[string]string{
+							fleetv1beta1.PolicyIndexLabel: "-1",
+							fleetv1beta1.CRPTrackingLabel: testName,
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:               testName,
+								BlockOwnerDeletion: pointer.Bool(true),
+								Controller:         pointer.Bool(true),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// Should never hit this case unless there is a bug in the controller or customers manually modify the clusterPolicySnapshot.
+			name: "active policy snapshot exists and policySnapshot with invalid numberOfClusters annotation",
+			policySnapshots: []fleetv1beta1.ClusterPolicySnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 1),
+						Labels: map[string]string{
+							fleetv1beta1.PolicyIndexLabel:      "1",
+							fleetv1beta1.IsLatestSnapshotLabel: "true",
+							fleetv1beta1.CRPTrackingLabel:      testName,
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:               testName,
+								BlockOwnerDeletion: pointer.Bool(true),
+								Controller:         pointer.Bool(true),
+								APIVersion:         fleetAPIVersion,
+								Kind:               "ClusterResourcePlacement",
+							},
+						},
+						Annotations: map[string]string{
+							fleetv1beta1.NumberOfClustersAnnotation: "invalid",
+						},
+					},
+					Spec: fleetv1beta1.PolicySnapshotSpec{
+						Policy:     wantPolicy,
+						PolicyHash: policyHash,
+					},
+				},
+			},
+		},
+		{
+			// Should never hit this case unless there is a bug in the controller or customers manually modify the clusterPolicySnapshot.
+			name: "no active policy snapshot exists and policySnapshot with invalid numberOfClusters annotation (negative)",
+			policySnapshots: []fleetv1beta1.ClusterPolicySnapshot{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf(fleetv1beta1.PolicySnapshotNameFmt, testName, 1),
+						Labels: map[string]string{
+							fleetv1beta1.PolicyIndexLabel: "1",
+							fleetv1beta1.CRPTrackingLabel: testName,
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name:               testName,
+								BlockOwnerDeletion: pointer.Bool(true),
+								Controller:         pointer.Bool(true),
+								APIVersion:         fleetAPIVersion,
+								Kind:               "ClusterResourcePlacement",
+							},
+						},
+						Annotations: map[string]string{
+							fleetv1beta1.NumberOfClustersAnnotation: "-123",
+						},
+					},
+					Spec: fleetv1beta1.PolicySnapshotSpec{
+						Policy:     wantPolicy,
+						PolicyHash: policyHash,
 					},
 				},
 			},


### PR DESCRIPTION
### Description of your changes
CRPcontroller should not create a new scheduling policySnapshot for the scaling out/down cases.

- Remove the numberOfClusters when calculating the hash
- Remove the numberOfClusters from the scheduling policySnapshot spec
- Add the numberOfClusters annotation on scheduling policySnapshot


I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
added scaling out/down UT
