### PR TITLE
feat: scheduler (10/): add more scheduler logic

### DIFF
--- a/pkg/scheduler/framework/dummyplugin_test.go
+++ b/pkg/scheduler/framework/dummyplugin_test.go
@@ -11,6 +11,10 @@ import (
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 )
 
+const (
+	dummyAllPurposePluginNameFormat = "dummyAllPurposePlugin-%d"
+)
+
 // A no-op, dummy plugin which connects to all extension points.
 type DummyAllPurposePlugin struct {
 	name            string

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -544,13 +544,11 @@ func TestRunFilterPlugins(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                     string
-		filterPlugins            []FilterPlugin
-		wantClusters             []*fleetv1beta1.MemberCluster
-		wantFiltered             []*filteredClusterWithStatus
-		wantPassedClusterNames   []string
-		wantFilteredClusterNames []string
-		expectedToFail           bool
+		name           string
+		filterPlugins  []FilterPlugin
+		wantClusters   []*fleetv1beta1.MemberCluster
+		wantFiltered   []*filteredClusterWithStatus
+		expectedToFail bool
 	}{
 		{
 			name: "three clusters, two filter plugins, all passed",

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -7,6 +7,7 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/scheduler/framework/parallelizer"
 )
 
 const (
@@ -35,6 +37,7 @@ const (
 var (
 	ignoreObjectMetaResourceVersionField = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")
 	ignoreTypeMetaAPIVersionKindFields   = cmpopts.IgnoreFields(metav1.TypeMeta{}, "APIVersion", "Kind")
+	ignoredStatusFields                  = cmpopts.IgnoreFields(Status{}, "reasons", "err")
 )
 
 // TO-DO (chenyu1): expand the test cases as development stablizes.
@@ -302,5 +305,375 @@ func TestMarkAsUnscheduled(t *testing.T) {
 	}
 	if diff := cmp.Diff(binding, want, ignoreTypeMetaAPIVersionKindFields, ignoreObjectMetaResourceVersionField); diff != "" {
 		t.Errorf("binding diff (-got, +want): %s", diff)
+	}
+}
+
+// TestRunPreFilterPlugins tests the runPreFilterPlugins method.
+func TestRunPreFilterPlugins(t *testing.T) {
+	dummyPreFilterPluginNameA := fmt.Sprintf(dummyAllPurposePluginNameFormat, 0)
+	dummyPreFilterPluginNameB := fmt.Sprintf(dummyAllPurposePluginNameFormat, 1)
+
+	testCases := []struct {
+		name                   string
+		preFilterPlugins       []PreFilterPlugin
+		wantSkippedPluginNames []string
+		wantStatus             *Status
+	}{
+		{
+			name: "single plugin, success",
+			preFilterPlugins: []PreFilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyPreFilterPluginNameA,
+					preFilterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) *Status {
+						return nil
+					},
+				},
+			},
+		},
+		{
+			name: "multiple plugins, one success, one skip",
+			preFilterPlugins: []PreFilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyPreFilterPluginNameA,
+					preFilterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) (status *Status) {
+						return nil
+					},
+				},
+				&DummyAllPurposePlugin{
+					name: dummyPreFilterPluginNameB,
+					preFilterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) (status *Status) {
+						return NewNonErrorStatus(Skip, dummyPreFilterPluginNameB)
+					},
+				},
+			},
+			wantSkippedPluginNames: []string{dummyPreFilterPluginNameB},
+		},
+		{
+			name: "single plugin, internal error",
+			preFilterPlugins: []PreFilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyPreFilterPluginNameA,
+					preFilterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) *Status {
+						return FromError(fmt.Errorf("internal error"), dummyPreFilterPluginNameA)
+					},
+				},
+			},
+			wantStatus: FromError(fmt.Errorf("internal error"), dummyPreFilterPluginNameA),
+		},
+		{
+			name: "single plugin, unschedulable",
+			preFilterPlugins: []PreFilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyPreFilterPluginNameA,
+					preFilterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) *Status {
+						return NewNonErrorStatus(ClusterUnschedulable, dummyPreFilterPluginNameA)
+					},
+				},
+			},
+			wantStatus: FromError(fmt.Errorf("cluster is unschedulable"), dummyPreFilterPluginNameA),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := NewProfile(dummyProfileName)
+			for _, p := range tc.preFilterPlugins {
+				profile.WithPreFilterPlugin(p)
+			}
+			// Construct framework manually instead of using NewFramework() to avoid mocking the controller manager.
+			f := &framework{
+				profile: profile,
+			}
+
+			ctx := context.Background()
+			state := NewCycleState()
+			policy := &fleetv1beta1.ClusterSchedulingPolicySnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: policyName,
+				},
+			}
+
+			status := f.runPreFilterPlugins(ctx, state, policy)
+			if diff := cmp.Diff(status, tc.wantStatus, cmp.AllowUnexported(Status{}), ignoredStatusFields); diff != "" {
+				t.Errorf("runPreFilterPlugins() returned status diff (-got, +want): %s", diff)
+			}
+		})
+	}
+}
+
+// TestRunFilterPluginsFor tests the runFilterPluginsFor method.
+func TestRunFilterPluginsFor(t *testing.T) {
+	dummyFilterPluginNameA := fmt.Sprintf(dummyAllPurposePluginNameFormat, 0)
+	dummyFilterPluginNameB := fmt.Sprintf(dummyAllPurposePluginNameFormat, 1)
+
+	testCases := []struct {
+		name               string
+		filterPlugins      []FilterPlugin
+		skippedPluginNames []string
+		wantStatus         *Status
+	}{
+		{
+			name: "single plugin, success",
+			filterPlugins: []FilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameA,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return nil
+					},
+				},
+			},
+		},
+		{
+			name: "multiple plugins, one success, one skipped",
+			filterPlugins: []FilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameA,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return nil
+					},
+				},
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameB,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return NewNonErrorStatus(ClusterUnschedulable, dummyFilterPluginNameB)
+					},
+				},
+			},
+			skippedPluginNames: []string{dummyFilterPluginNameB},
+		},
+		{
+			name: "single plugin, internal error",
+			filterPlugins: []FilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameA,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return FromError(fmt.Errorf("internal error"), dummyFilterPluginNameA)
+					},
+				},
+			},
+			wantStatus: FromError(fmt.Errorf("internal error"), dummyFilterPluginNameA),
+		},
+		{
+			name: "multiple plugins, one unschedulable, one success",
+			filterPlugins: []FilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameA,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return NewNonErrorStatus(ClusterUnschedulable, dummyFilterPluginNameA)
+					},
+				},
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameB,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return nil
+					},
+				},
+			},
+			wantStatus: NewNonErrorStatus(ClusterUnschedulable, dummyFilterPluginNameA),
+		},
+		{
+			name: "single plugin, skip",
+			filterPlugins: []FilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameA,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return NewNonErrorStatus(Skip, dummyFilterPluginNameA)
+					},
+				},
+			},
+			wantStatus: FromError(fmt.Errorf("internal error"), dummyFilterPluginNameA),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := NewProfile(dummyProfileName)
+			for _, p := range tc.filterPlugins {
+				profile.WithFilterPlugin(p)
+			}
+			// Construct framework manually instead of using NewFramework() to avoid mocking the controller manager.
+			f := &framework{
+				profile: profile,
+			}
+
+			ctx := context.Background()
+			state := NewCycleState()
+			for _, name := range tc.skippedPluginNames {
+				state.skippedFilterPlugins.Insert(name)
+			}
+			policy := &fleetv1beta1.ClusterSchedulingPolicySnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: policyName,
+				},
+			}
+			cluster := &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+			}
+
+			status := f.runFilterPluginsFor(ctx, state, policy, cluster)
+			if diff := cmp.Diff(status, tc.wantStatus, cmpopts.IgnoreUnexported(Status{}), ignoredStatusFields); diff != "" {
+				t.Errorf("runFilterPluginsFor() returned status diff (-got, +want) = %s", diff)
+			}
+		})
+	}
+}
+
+// TestRunFilterPlugins tests the runFilterPlugins method.
+func TestRunFilterPlugins(t *testing.T) {
+	dummyFilterPluginNameA := fmt.Sprintf(dummyAllPurposePluginNameFormat, 0)
+	dummyFilterPluginNameB := fmt.Sprintf(dummyAllPurposePluginNameFormat, 1)
+
+	clusters := []fleetv1beta1.MemberCluster{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: altClusterName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: anotherClusterName,
+			},
+		},
+	}
+
+	testCases := []struct {
+		name                     string
+		filterPlugins            []FilterPlugin
+		wantPassedClusterNames   []string
+		wantFilteredClusterNames []string
+		expectedToFail           bool
+	}{
+		{
+			name: "three clusters, two filter plugins, all passed",
+			filterPlugins: []FilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameA,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return nil
+					},
+				},
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameB,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return nil
+					},
+				},
+			},
+			wantPassedClusterNames: []string{clusterName, altClusterName, anotherClusterName},
+		},
+		{
+			name: "three clusters, two filter plugins, two filtered",
+			filterPlugins: []FilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameA,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						if cluster.Name == clusterName {
+							return NewNonErrorStatus(ClusterUnschedulable, dummyFilterPluginNameA)
+						}
+						return nil
+					},
+				},
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameB,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						if cluster.Name == anotherClusterName {
+							return NewNonErrorStatus(ClusterUnschedulable, dummyFilterPluginNameB)
+						}
+						return nil
+					},
+				},
+			},
+			wantPassedClusterNames:   []string{altClusterName},
+			wantFilteredClusterNames: []string{clusterName, anotherClusterName},
+		},
+		{
+			name: "three clusters, two filter plugins, one success, one internal error on specific cluster",
+			filterPlugins: []FilterPlugin{
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameA,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						return nil
+					},
+				},
+				&DummyAllPurposePlugin{
+					name: dummyFilterPluginNameB,
+					filterRunner: func(ctx context.Context, state CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, cluster *fleetv1beta1.MemberCluster) (status *Status) {
+						if cluster.Name == anotherClusterName {
+							return FromError(fmt.Errorf("internal error"), dummyFilterPluginNameB)
+						}
+						return nil
+					},
+				},
+			},
+			expectedToFail: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			profile := NewProfile(dummyProfileName)
+			for _, p := range tc.filterPlugins {
+				profile.WithFilterPlugin(p)
+			}
+			f := &framework{
+				profile:      profile,
+				parallelizer: parallelizer.NewParallelizer(parallelizer.DefaultNumOfWorkers),
+			}
+
+			ctx := context.Background()
+			state := NewCycleState()
+			policy := &fleetv1beta1.ClusterSchedulingPolicySnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: policyName,
+				},
+			}
+
+			passed, filtered, err := f.runFilterPlugins(ctx, state, policy, clusters)
+			if tc.expectedToFail {
+				if err == nil {
+					t.Fatalf("runFilterPlugins(%v, %v, %v) = %v %v %v, want error", state, policy, clusters, passed, filtered, err)
+				}
+				return
+			}
+
+			// The method runs in parallel; as a result the order cannot be guaranteed.
+			// Organize the results into maps for easier comparison.
+			passedMap := make(map[string]bool)
+			for _, cluster := range passed {
+				passedMap[cluster.Name] = true
+			}
+			wantPassedMap := make(map[string]bool)
+			for _, name := range tc.wantPassedClusterNames {
+				wantPassedMap[name] = true
+			}
+
+			if diff := cmp.Diff(passedMap, wantPassedMap); diff != "" {
+				t.Errorf("passed clusters diff (-got, +want): %s", diff)
+			}
+
+			filteredMap := make(map[string]bool)
+			for _, item := range filtered {
+				filteredMap[item.cluster.Name] = true
+				// As a sanity check, verify if all status are of the ClusterUnschedulable status code.
+				if !item.status.IsClusterUnschedulable() {
+					t.Errorf("filtered cluster %s status, got %v, want status code ClusterUnschedulable", item.cluster.Name, item.status)
+				}
+			}
+			wantFilteredMap := make(map[string]bool)
+			for _, name := range tc.wantFilteredClusterNames {
+				wantFilteredMap[name] = true
+			}
+
+			if diff := cmp.Diff(filteredMap, wantFilteredMap); diff != "" {
+				t.Errorf("filtered clusters diff (-got, +want): %s", diff)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/framework/status.go
+++ b/pkg/scheduler/framework/status.go
@@ -5,7 +5,10 @@ Licensed under the MIT license.
 
 package framework
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // StatusCode is the status code of a Status, returned by a plugin.
 type StatusCode int
@@ -70,7 +73,7 @@ func (s *Status) IsInteralError() bool {
 }
 
 // IsPreSkip returns if a Status is of the status code Skip.
-func (s *Status) IsPreSkip() bool {
+func (s *Status) IsSkip() bool {
 	return s.code() == Skip
 }
 
@@ -114,6 +117,15 @@ func (s *Status) String() string {
 	}
 	desc = append(desc, s.reasons...)
 	return strings.Join(desc, ", ")
+}
+
+// AsError returns a status as an error; it returns nil if the status is of the internalError code.
+func (s *Status) AsError() error {
+	if !s.IsInteralError() {
+		return nil
+	}
+
+	return fmt.Errorf("plugin %s returned an error %s", s.sourcePlugin, s.String())
 }
 
 // NewNonErrorStatus returns a Status with a non-error status code.

--- a/pkg/scheduler/framework/status_test.go
+++ b/pkg/scheduler/framework/status_test.go
@@ -73,7 +73,7 @@ func TestNonNilStatusMethods(t *testing.T) {
 				status.IsSuccess,
 				status.IsInteralError,
 				status.IsClusterUnschedulable,
-				status.IsPreSkip,
+				status.IsSkip,
 			}
 			for idx, checkFunc := range checkFuncs {
 				if wantCheckOutputs[idx] != checkFunc() {
@@ -114,7 +114,7 @@ func TestNilStatusMethods(t *testing.T) {
 		status.IsSuccess,
 		status.IsInteralError,
 		status.IsClusterUnschedulable,
-		status.IsPreSkip,
+		status.IsSkip,
 	}
 	for idx, checkFunc := range checkFuncs {
 		if wantCheckOutputs[idx] != checkFunc() {


### PR DESCRIPTION
### Description of your changes

This PR is part of the PRs that implement the Fleet workload scheduling.

It features more scheduling logic for PickAll type CRPs.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer

To control the size of the PR, certain unit tests are not checked in; they will be sent in a separate PR.
