### PR TITLE
chore: deprecate set-output commands in github actions

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -35,7 +35,7 @@ jobs:
             RELEASE_TAG=`git describe --tags $(git rev-list --tags --max-count=1)`
             echo "The user input release tag is empty, will use the latest tag $RELEASE_TAG."
           fi
-          echo "::set-output name=release_tag::$RELEASE_TAG"
+          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
 
           # NOTE: As exporting a variable from a secret is not possible, the shared variable registry obtained
           # from AZURE_REGISTRY secret is not exported from here.

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -30,7 +30,7 @@ jobs:
       - id: export
         run: |
           # registry must be in lowercase
-          echo "::set-output name=registry::$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr [:upper:] [:lower:])"
+          echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr [:upper:] [:lower:])" >> $GITHUB_OUTPUT
   publish-images:
     needs: export-registry
     env:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -30,7 +30,7 @@ jobs:
           # registry must be in lowercase
           # store the images under dev
           # TODO: need to cleanup dev images periodically 
-          echo "::set-output name=registry::$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr [:upper:] [:lower:])"
+          echo "registry=$(echo "${{ env.REGISTRY }}/${{ github.repository }}" | tr [:upper:] [:lower:])"  >> $GITHUB_OUTPUT
   scan-images:
     needs: export-registry
     env:


### PR DESCRIPTION
### Description of your changes

The `set-output` command is deprecated and will be disabled soon. 

For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Github action workflow