### PR TITLE
interface: update crp status api and add validation markers

### DIFF
--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -218,6 +218,7 @@ type TopologySpreadConstraint struct {
 	// to topologies that satisfy it.
 	// It's an optional field. Default value is 1 and 0 is not allowed.
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=1
 	// +optional
 	MaxSkew *int32 `json:"maxSkew,omitempty"`
 
@@ -365,6 +366,7 @@ type ResourceIdentifier struct {
 // ResourcePlacementStatus represents the placement status of selected resources for one target cluster.
 type ResourcePlacementStatus struct {
 	// ClusterName is the name of the cluster this resource is assigned to.
+	// +required
 	ClusterName string `json:"clusterName"`
 
 	// +kubebuilder:validation:MaxItems=100

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -79,7 +79,7 @@ type ClusterResourcePlacementSpec struct {
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// Defaults to 10.
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=20
+	// +kubebuilder:validation:Maximum=1000
 	// +kubebuilder:default=10
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -366,8 +366,9 @@ type ResourceIdentifier struct {
 // ResourcePlacementStatus represents the placement status of selected resources for one target cluster.
 type ResourcePlacementStatus struct {
 	// ClusterName is the name of the cluster this resource is assigned to.
-	// +required
-	ClusterName string `json:"clusterName"`
+	// If it is not empty, its value should be unique cross all placement decisions for the Placement.
+	// +optional
+	ClusterName string `json:"clusterName,omitempty"`
 
 	// +kubebuilder:validation:MaxItems=100
 

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -78,6 +78,9 @@ type ClusterResourcePlacementSpec struct {
 	// The number of old ClusterSchedulingPolicySnapshot or ClusterResourceSnapshot resources to retain to allow rollback.
 	// This is a pointer to distinguish between explicit zero and not specified.
 	// Defaults to 10.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=20
+	// +kubebuilder:default=10
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }
@@ -127,10 +130,13 @@ type PlacementPolicy struct {
 	ClusterNames []string `json:"clusterNames,omitempty"`
 
 	// Type of placement. Can be "PickAll" or "PickN". Default is PickAll.
+	// +kubebuilder:validation:Enum=PickAll;PickN
+	// +kubebuilder:default=PickAll
 	// +optional
 	PlacementType PlacementType `json:"placementType,omitempty"`
 
 	// NumberOfClusters of placement. Only valid if the placement type is "PickN".
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	NumberOfClusters *int32 `json:"numberOfClusters,omitempty"`
 
@@ -186,6 +192,8 @@ type ClusterSelector struct {
 type PreferredClusterSelector struct {
 	// Weight associated with matching the corresponding clusterSelectorTerm, in the range [-100, 100].
 	// +required
+	// +kubebuilder:validation:Minimum=-100
+	// +kubebuilder:validation:Maximum=100
 	Weight int32 `json:"weight"`
 
 	// A cluster selector term, associated with the corresponding weight.
@@ -209,6 +217,7 @@ type TopologySpreadConstraint struct {
 	// When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
 	// to topologies that satisfy it.
 	// It's an optional field. Default value is 1 and 0 is not allowed.
+	// +kubebuilder:default=1
 	// +optional
 	MaxSkew *int32 `json:"maxSkew,omitempty"`
 
@@ -248,6 +257,8 @@ const (
 type RolloutStrategy struct {
 	// Type of rollout. The only supported type is "RollingUpdate". Default is "RollingUpdate".
 	// +optional
+	// +kubebuilder:validation:Enum=RollingUpdate
+	// +kubebuilder:default=RollingUpdate
 	Type RolloutStrategyType `json:"type,omitempty"`
 
 	// Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
@@ -276,6 +287,9 @@ type RollingUpdateConfig struct {
 	// upgrade the resources content on the same cluster.
 	// This can not be 0 if MaxSurge is 0.
 	// Defaults to 25%.
+	// +kubebuilder:default="25%"
+	// +kubebuilder:validation:XIntOrString
+	// +kubebuilder:validation:Pattern="^((100|[0-9]{1,2})%|[0-9]+)$"
 	// +optional
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 
@@ -287,6 +301,9 @@ type RollingUpdateConfig struct {
 	// This does not apply to the case that we do in-place upgrade of resources on the same cluster.
 	// This can not be 0 if MaxUnavailable is 0.
 	// Defaults to 25%.
+	// +kubebuilder:default="25%"
+	// +kubebuilder:validation:XIntOrString
+	// +kubebuilder:validation:Pattern="^((100|[0-9]{1,2})%|[0-9]+)$"
 	// +optional
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty"`
 
@@ -294,6 +311,7 @@ type RollingUpdateConfig struct {
 	// A resource placement is considered available after `UnavailablePeriodSeconds` seconds
 	// has passed after the resources are applied to the target cluster successfully.
 	// Default is 60.
+	// +kubebuilder:default=60
 	// +optional
 	UnavailablePeriodSeconds *int `json:"unavailablePeriodSeconds,omitempty"`
 }
@@ -347,8 +365,6 @@ type ResourceIdentifier struct {
 // ResourcePlacementStatus represents the placement status of selected resources for one target cluster.
 type ResourcePlacementStatus struct {
 	// ClusterName is the name of the cluster this resource is assigned to.
-	// If it is not empty, its value should be unique cross all placement decisions for the Placement.
-	// +optional
 	ClusterName string `json:"clusterName"`
 
 	// +kubebuilder:validation:MaxItems=100
@@ -369,10 +385,6 @@ type FailedResourcePlacement struct {
 	// The resource failed to be placed.
 	// +required
 	ResourceIdentifier `json:",inline"`
-
-	// Name of the member cluster that the resource is placed to.
-	// +required
-	ClusterName string `json:"clusterName"`
 
 	// The failed condition status.
 	// +required

--- a/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
@@ -160,6 +160,8 @@ spec:
                                     corresponding clusterSelectorTerm, in the range
                                     [-100, 100].
                                   format: int32
+                                  maximum: 100
+                                  minimum: -100
                                   type: integer
                               required:
                               - preference
@@ -259,10 +261,15 @@ spec:
                     description: NumberOfClusters of placement. Only valid if the
                       placement type is "PickN".
                     format: int32
+                    minimum: 0
                     type: integer
                   placementType:
+                    default: PickAll
                     description: Type of placement. Can be "PickAll" or "PickN". Default
                       is PickAll.
+                    enum:
+                    - PickAll
+                    - PickN
                     type: string
                   topologySpreadConstraints:
                     description: TopologySpreadConstraints describes how a group of
@@ -274,6 +281,7 @@ spec:
                         resources among the given cluster topology.
                       properties:
                         maxSkew:
+                          default: 1
                           description: MaxSkew describes the degree to which resources
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
@@ -390,11 +398,14 @@ spec:
                 minItems: 1
                 type: array
               revisionHistoryLimit:
+                default: 10
                 description: The number of old ClusterSchedulingPolicySnapshot or
                   ClusterResourceSnapshot resources to retain to allow rollback. This
                   is a pointer to distinguish between explicit zero and not specified.
                   Defaults to 10.
                 format: int32
+                maximum: 20
+                minimum: 1
                 type: integer
               strategy:
                 description: The rollout strategy to use to replace existing placement
@@ -408,6 +419,7 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
+                        default: 25%
                         description: 'The maximum number of clusters that can be scheduled
                           above the desired number of clusters. The desired number
                           equals to the `NumberOfClusters` field when the placement
@@ -419,11 +431,13 @@ spec:
                           case that we do in-place upgrade of resources on the same
                           cluster. This can not be 0 if MaxUnavailable is 0. Defaults
                           to 25%.'
+                        pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
                         x-kubernetes-int-or-string: true
                       maxUnavailable:
                         anyOf:
                         - type: integer
                         - type: string
+                        default: 25%
                         description: 'The maximum number of clusters that can be unavailable
                           during the rolling update comparing to the desired number
                           of clusters. The desired number equals to the `NumberOfClusters`
@@ -436,8 +450,10 @@ spec:
                           we either remove it from a cluster or in-place upgrade the
                           resources content on the same cluster. This can not be 0
                           if MaxSurge is 0. Defaults to 25%.'
+                        pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
                         x-kubernetes-int-or-string: true
                       unavailablePeriodSeconds:
+                        default: 60
                         description: UnavailablePeriodSeconds is used to config the
                           time to wait between rolling out phases. A resource placement
                           is considered available after `UnavailablePeriodSeconds`
@@ -446,8 +462,11 @@ spec:
                         type: integer
                     type: object
                   type:
+                    default: RollingUpdate
                     description: Type of rollout. The only supported type is "RollingUpdate".
                       Default is "RollingUpdate".
+                    enum:
+                    - RollingUpdate
                     type: string
                 type: object
             required:
@@ -543,8 +562,7 @@ spec:
                   properties:
                     clusterName:
                       description: ClusterName is the name of the cluster this resource
-                        is assigned to. If it is not empty, its value should be unique
-                        cross all placement decisions for the Placement.
+                        is assigned to.
                       type: string
                     conditions:
                       description: Conditions is an array of current observed conditions
@@ -631,10 +649,6 @@ spec:
                         description: FailedResourcePlacement contains the failure
                           details of a failed resource placement.
                         properties:
-                          clusterName:
-                            description: Name of the member cluster that the resource
-                              is placed to.
-                            type: string
                           condition:
                             description: The failed condition status.
                             properties:
@@ -717,7 +731,6 @@ spec:
                             description: Version is the version of the selected resource.
                             type: string
                         required:
-                        - clusterName
                         - condition
                         - kind
                         - name
@@ -725,6 +738,8 @@ spec:
                         type: object
                       maxItems: 100
                       type: array
+                  required:
+                  - clusterName
                   type: object
                 type: array
               selectedResources:

--- a/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
@@ -563,7 +563,8 @@ spec:
                   properties:
                     clusterName:
                       description: ClusterName is the name of the cluster this resource
-                        is assigned to.
+                        is assigned to. If it is not empty, its value should be unique
+                        cross all placement decisions for the Placement.
                       type: string
                     conditions:
                       description: Conditions is an array of current observed conditions
@@ -739,8 +740,6 @@ spec:
                         type: object
                       maxItems: 100
                       type: array
-                  required:
-                  - clusterName
                   type: object
                 type: array
               selectedResources:

--- a/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
@@ -405,7 +405,7 @@ spec:
                   is a pointer to distinguish between explicit zero and not specified.
                   Defaults to 10.
                 format: int32
-                maximum: 20
+                maximum: 1000
                 minimum: 1
                 type: integer
               strategy:

--- a/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
@@ -292,6 +292,7 @@ spec:
                             satisfy it. It's an optional field. Default value is 1
                             and 0 is not allowed.
                           format: int32
+                          minimum: 1
                           type: integer
                         topologyKey:
                           description: TopologyKey is the key of cluster labels. Clusters

--- a/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
@@ -276,6 +276,7 @@ spec:
                             satisfy it. It's an optional field. Default value is 1
                             and 0 is not allowed.
                           format: int32
+                          minimum: 1
                           type: integer
                         topologyKey:
                           description: TopologyKey is the key of cluster labels. Clusters

--- a/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
@@ -144,6 +144,8 @@ spec:
                                     corresponding clusterSelectorTerm, in the range
                                     [-100, 100].
                                   format: int32
+                                  maximum: 100
+                                  minimum: -100
                                   type: integer
                               required:
                               - preference
@@ -243,10 +245,15 @@ spec:
                     description: NumberOfClusters of placement. Only valid if the
                       placement type is "PickN".
                     format: int32
+                    minimum: 0
                     type: integer
                   placementType:
+                    default: PickAll
                     description: Type of placement. Can be "PickAll" or "PickN". Default
                       is PickAll.
+                    enum:
+                    - PickAll
+                    - PickN
                     type: string
                   topologySpreadConstraints:
                     description: TopologySpreadConstraints describes how a group of
@@ -258,6 +265,7 @@ spec:
                         resources among the given cluster topology.
                       properties:
                         maxSkew:
+                          default: 1
                           description: MaxSkew describes the degree to which resources
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number


### PR DESCRIPTION
### Description of your changes

-  Remove the duplicate clusterName from FailedResourcePlacement as it's already in its parent, ResourcePlacementStatus.
- Add validation markers

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

### Special notes for your reviewer

