### PR TITLE
feat: scheduler (12/): add more scheduler logic 

### DIFF
--- a/apis/placement/v1beta1/policysnapshot_types.go
+++ b/apis/placement/v1beta1/policysnapshot_types.go
@@ -74,7 +74,7 @@ type SchedulingPolicySnapshotStatus struct {
 	// +optional
 	Conditions []metav1.Condition `json:"conditions"`
 
-	// +kubebuilder:validation:MaxItems=100
+	// +kubebuilder:validation:MaxItems=1000
 	// ClusterDecisions contains a list of names of member clusters considered by the scheduler.
 	// Note that all the selected clusters must present in the list while not all the
 	// member clusters are guaranteed to be listed due to the size limit. We will try to

--- a/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
@@ -432,7 +432,7 @@ spec:
                   - reason
                   - selected
                   type: object
-                maxItems: 100
+                maxItems: 1000
                 type: array
             type: object
         required:

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -364,9 +364,15 @@ func (f *framework) runSchedulingCycleForPickAllPlacementType(
 		return ctrl.Result{}, err
 	}
 
+	// Extract the patched bindings.
+	patched := make([]*fleetv1beta1.ClusterResourceBinding, 0, len(toPatch))
+	for _, p := range toPatch {
+		patched = append(patched, p.updated)
+	}
+
 	// Update policy snapshot status with the latest scheduling decisions and condition.
 	klog.V(2).InfoS("Updating policy snapshot status", "clusterSchedulingPolicySnapshot", policyRef)
-	if err := f.updatePolicySnapshotStatusFrom(ctx, policy, filtered, toCreate, toUpdate, scheduled, bound); err != nil {
+	if err := f.updatePolicySnapshotStatusFrom(ctx, policy, filtered, toCreate, patched, scheduled, bound); err != nil {
 		klog.ErrorS(err, "Failed to update latest scheduling decisions and condition", "clusterSchedulingPolicySnapshot", policyRef)
 		return ctrl.Result{}, err
 	}

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -22,6 +23,7 @@ import (
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/scheduler/framework/parallelizer"
+	"go.goms.io/fleet/pkg/utils/condition"
 	"go.goms.io/fleet/pkg/utils/controller"
 )
 
@@ -31,6 +33,10 @@ const (
 
 	// pickedByPolicyReason is the reason to use for scheduling decision when a cluster is picked.
 	pickedByPolicyReason = "picked by scheduling policy"
+
+	// The reasons and messages for scheduled conditions.
+	fullyScheduledReason  = "SchedulingCompleted"
+	fullyScheduledMessage = "all required number of bindings have been created"
 )
 
 // Handle is an interface which allows plugins to access some shared structs (e.g., client, manager)
@@ -303,10 +309,10 @@ func (f *framework) markAsUnscheduledFor(ctx context.Context, bindings []*fleetv
 func (f *framework) runSchedulingCycleForPickAllPlacementType(
 	ctx context.Context,
 	state *CycleState,
-	crpName string, //nolint: revive
+	crpName string,
 	policy *fleetv1beta1.ClusterSchedulingPolicySnapshot,
 	clusters []fleetv1beta1.MemberCluster,
-	bound, scheduled, obsolete []*fleetv1beta1.ClusterResourceBinding, //nolint: revive
+	bound, scheduled, obsolete []*fleetv1beta1.ClusterResourceBinding,
 ) (result ctrl.Result, err error) {
 	policyRef := klog.KObj(policy)
 
@@ -315,9 +321,7 @@ func (f *framework) runSchedulingCycleForPickAllPlacementType(
 	klog.V(2).InfoS("Scheduling is always needed for CRPs of the PickAll placement type; entering scheduling stages", "clusterSchedulingPolicySnapshot", policyRef)
 
 	// Run all plugins needed.
-	//
-	// TO-DO (chenyu1): assign variables when needed.
-	scored, _, err := f.runAllPluginsForPickAllPlacementType(ctx, state, policy, clusters)
+	scored, filtered, err := f.runAllPluginsForPickAllPlacementType(ctx, state, policy, clusters)
 	if err != nil {
 		klog.ErrorS(err, "Failed to run all plugins (pickAll placement type)", "clusterSchedulingPolicySnapshot", policyRef)
 		return ctrl.Result{}, err
@@ -354,7 +358,16 @@ func (f *framework) runSchedulingCycleForPickAllPlacementType(
 		return ctrl.Result{}, err
 	}
 
-	// Not yet implemented.
+	// Update policy snapshot status with the latest scheduling decisions and condition.
+	klog.V(2).InfoS("Updating policy snapshot status", "clusterSchedulingPolicySnapshot", policyRef)
+	if err := f.updatePolicySnapshotStatusFrom(ctx, policy, filtered, toCreate, toUpdate, scheduled, bound); err != nil {
+		klog.ErrorS(err, "Failed to update latest scheduling decisions and condition", "clusterSchedulingPolicySnapshot", policyRef)
+		return ctrl.Result{}, err
+	}
+
+	// The scheduling cycle has completed.
+	//
+	// Note that for CRPs of the PickAll type, no requeue check is needed.
 	return ctrl.Result{}, nil
 }
 
@@ -574,6 +587,37 @@ func (f *framework) patchBindings(ctx context.Context, toPatch []*bindingWithPat
 		if err := f.client.Patch(ctx, bp.updated, bp.patch); err != nil {
 			return controller.NewAPIServerError(false, fmt.Errorf("failed to patch binding %s: %w", bp.updated.Name, err))
 		}
+	}
+	return nil
+}
+
+// updatePolicySnapshotStatusFrom updates the policy snapshot status, in accordance with the list of
+// clusters filtered out by the scheduler, and the list of bindings provisioned by the scheduler.
+func (f *framework) updatePolicySnapshotStatusFrom(
+	ctx context.Context,
+	policy *fleetv1beta1.ClusterSchedulingPolicySnapshot,
+	filtered []*filteredClusterWithStatus,
+	existing ...[]*fleetv1beta1.ClusterResourceBinding,
+) error {
+	policyRef := klog.KObj(policy)
+
+	// Prepare new scheduling decisions.
+	newDecisions := newSchedulingDecisionsFrom(f.maxClusterDecisionCount, filtered, existing...)
+	// Prepare new scheduling condition.
+	newCondition := fullyScheduledCondition(policy)
+
+	currentDecisions := policy.Status.ClusterDecisions
+	currentCondition := meta.FindStatusCondition(policy.Status.Conditions, string(fleetv1beta1.PolicySnapshotScheduled))
+	if equalDecisions(currentDecisions, newDecisions) && condition.EqualCondition(currentCondition, &newCondition) {
+		// Skip if there is no change in decisions and conditions.
+		return nil
+	}
+
+	policy.Status.ClusterDecisions = newDecisions
+	meta.SetStatusCondition(&policy.Status.Conditions, newCondition)
+	if err := f.client.Status().Update(ctx, policy, &client.UpdateOptions{}); err != nil {
+		klog.ErrorS(err, "failed to update policy snapshot status", "clusterSchedulingPolicySnapshot", policyRef)
+		return controller.NewAPIServerError(false, err)
 	}
 	return nil
 }

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -43,7 +44,11 @@ var (
 	ignoreObjectMetaNameField            = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name")
 	ignoreTypeMetaAPIVersionKindFields   = cmpopts.IgnoreFields(metav1.TypeMeta{}, "APIVersion", "Kind")
 	ignoredStatusFields                  = cmpopts.IgnoreFields(Status{}, "reasons", "err")
+<<<<<<< HEAD
 	ignoredBindingWithPatchFields        = cmpopts.IgnoreFields(bindingWithPatch{}, "patch")
+=======
+	ignoredCondFields                    = cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
+>>>>>>> 5ba64b2 (Added more scheduler logic)
 
 	lessFuncCluster = func(cluster1, cluster2 *fleetv1beta1.MemberCluster) bool {
 		return cluster1.Name < cluster2.Name

--- a/pkg/scheduler/framework/frameworkutils.go
+++ b/pkg/scheduler/framework/frameworkutils.go
@@ -234,7 +234,6 @@ func fullyScheduledCondition(policy *fleetv1beta1.ClusterSchedulingPolicySnapsho
 		Type:               string(fleetv1beta1.PolicySnapshotScheduled),
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: policy.Generation,
-		LastTransitionTime: metav1.Now(),
 		Reason:             fullyScheduledReason,
 		Message:            fullyScheduledMessage,
 	}

--- a/pkg/scheduler/framework/frameworkutils.go
+++ b/pkg/scheduler/framework/frameworkutils.go
@@ -213,9 +213,9 @@ func newSchedulingDecisionsFrom(maxUnselectedClusterDecisionCount int, filtered 
 		setLength := len(bindingSet)
 		for i := 0; i < setLength && i < slotsLeft; i++ {
 			newDecisions = append(newDecisions, bindingSet[i].Spec.ClusterDecision)
-			slotsLeft--
 		}
 
+		slotsLeft -= setLength
 		if slotsLeft <= 0 {
 			klog.V(2).InfoS("Reached API limit of cluster decision count; decisions off the limit will be discarded")
 			break


### PR DESCRIPTION
### Description of your changes

This PR is part of the PRs that implement the Fleet workload scheduling.

It features more scheduling logic for PickAll type CRPs.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer

To control the size of the PR, certain unit tests are not checked in; they will be sent in a separate PR.
