### PR TITLE
feat: use patches in scheduler to avoid races + add some more unit tests

### DIFF
--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -1594,6 +1594,15 @@ func TestManipulateBindings(t *testing.T) {
 		},
 	}
 
+	unscheduledBinding := &fleetv1beta1.ClusterResourceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: anotherBindingName,
+		},
+		Spec: fleetv1beta1.ResourceBindingSpec{
+			State: fleetv1beta1.BindingStateUnscheduled,
+		},
+	}
+
 	policy := &fleetv1beta1.ClusterSchedulingPolicySnapshot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: policyName,
@@ -1646,7 +1655,7 @@ func TestManipulateBindings(t *testing.T) {
 	if err := fakeClient.Get(ctx, types.NamespacedName{Name: anotherBindingName}, deletedBinding); err != nil {
 		t.Errorf("Get() binding %s = %v, want no error", anotherBindingName, err)
 	}
-	if deletedBinding.Spec.State != fleetv1beta1.BindingStateUnscheduled {
-		t.Errorf("binding %s state = %s, want unscheduled", anotherBindingName, deletedBinding.Spec.State)
+	if diff := cmp.Diff(deletedBinding, unscheduledBinding, ignoreTypeMetaAPIVersionKindFields, ignoreObjectMetaResourceVersionField); diff != "" {
+		t.Errorf("unscheduled binding %s diff (-got, +want): %s", anotherBindingName, diff)
 	}
 }

--- a/pkg/scheduler/framework/frameworkutils.go
+++ b/pkg/scheduler/framework/frameworkutils.go
@@ -132,9 +132,6 @@ func crossReferencePickedCustersAndObsoleteBindings(
 		// The binding's target cluster is picked again in the current run; yet the binding
 		// is originally created/updated in accordance with an out-of-date scheduling policy.
 
-		// Prepare the patch.
-		patch := client.MergeFrom(binding)
-
 		// Update the binding so that it is associated with the latest score.
 		updated := binding.DeepCopy()
 		affinityScore := int32(scored.Score.AffinityScore)
@@ -155,7 +152,8 @@ func crossReferencePickedCustersAndObsoleteBindings(
 		// Add the binding to the toUpdate list.
 		toPatch = append(toPatch, &bindingWithPatch{
 			updated: updated,
-			patch:   patch,
+			// Prepare the patch.
+			patch: client.MergeFrom(binding),
 		})
 	}
 


### PR DESCRIPTION
### Description of your changes

This PR updates the scheduler logic to use patches (instead of updates) to avoid races.

It also adds a number of unit tests that wasn't included in previous scheduler PRs.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer
