### PR TITLE
test: fix the crp watcher integration test flakiness

### DIFF
--- a/pkg/controllers/clusterresourceplacementwatcher/watcher_integration_test.go
+++ b/pkg/controllers/clusterresourceplacementwatcher/watcher_integration_test.go
@@ -82,6 +82,13 @@ var _ = Describe("Test ClusterResourcePlacement Watcher", func() {
 
 	Context("When updating clusterResourcePlacement", func() {
 		BeforeEach(func() {
+			By("By checking the placement queue before resetting")
+			// The event could arrive after the resetting, which causes the flakiness.
+			// It makes sure the queue is clear before proceed.
+			Eventually(func() bool {
+				return fakePlacementController.Key() == testCRPName
+			}, eventuallyTimeout, interval).Should(BeTrue(), "placementController should receive the CRP name")
+
 			By("By resetting the placement queue")
 			fakePlacementController.ResetQueue()
 		})
@@ -132,6 +139,13 @@ var _ = Describe("Test ClusterResourcePlacement Watcher", func() {
 
 	Context("When deleting clusterResourcePlacement", func() {
 		BeforeEach(func() {
+			By("By checking the placement queue before resetting")
+			// The event could arrive after the resetting, which causes the flakiness.
+			// It makes sure the queue is clear before proceed.
+			Eventually(func() bool {
+				return fakePlacementController.Key() == testCRPName
+			}, eventuallyTimeout, interval).Should(BeTrue(), "placementController should receive the CRP name")
+
 			By("By resetting the placement queue")
 			fakePlacementController.ResetQueue()
 		})


### PR DESCRIPTION
### Description of your changes

make sure the event has arrived before resetting the queue to fix the test flakiness

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

run the unit test ci

### Special notes for your reviewer

