### PR TITLE
feat: add the subindex annotation

### DIFF
--- a/apis/placement/v1beta1/resourcesnapshot_types.go
+++ b/apis/placement/v1beta1/resourcesnapshot_types.go
@@ -22,7 +22,7 @@ const (
 	// NumberOfResourceSnapshotsAnnotation is the annotation that contains the total number of resource snapshots.
 	NumberOfResourceSnapshotsAnnotation = fleetPrefix + "numberOfResourceSnapshots"
 
-	// SubindexOfResourceSnapshotAnnotation is the annotation to store the index of resource snapshot in the group.
+	// SubindexOfResourceSnapshotAnnotation is the annotation to store the subindex of resource snapshot in the group.
 	SubindexOfResourceSnapshotAnnotation = fleetPrefix + "subindexOfResourceSnapshot"
 
 	// ResourceSnapshotNameFmt is resourcePolicySnapshot name format: {CRPName}-{resourceIndex}.

--- a/apis/placement/v1beta1/resourcesnapshot_types.go
+++ b/apis/placement/v1beta1/resourcesnapshot_types.go
@@ -27,6 +27,9 @@ const (
 
 	// ResourceSnapshotNameFmt is resourcePolicySnapshot name format: {CRPName}-{resourceIndex}-snapshot.
 	ResourceSnapshotNameFmt = "%s-%d-snapshot"
+
+	// ResourceSnapshotNameWithSubindexFmt is resourcePolicySnapshot name with subindex format: {CRPName}-{resourceIndex}-{subindex}.
+	ResourceSnapshotNameWithSubindexFmt = " %s-%d-%d"
 )
 
 // +genclient
@@ -42,7 +45,7 @@ const (
 // Its spec is immutable.
 // We may need to produce more than one resourceSnapshot for all the resources a ResourcePlacement selected to get around the 1MB size limit of k8s objects.
 // We assign an ever-increasing index for each such group of resourceSnapshots.
-// The name convention of a clusterResourceSnapshot is {CRPName}-{resourceIndex}-{snapshot|-{subindex}}
+// The naming convention of a clusterResourceSnapshot is {CRPName}-{resourceIndex}-{subindex}
 // where the name of the first snapshot of a group has no subindex part so its name is {CRPName}-{resourceIndex}-snapshot.
 // resourceIndex will begin with 0.
 // Each snapshot MUST have the following labels:

--- a/apis/placement/v1beta1/resourcesnapshot_types.go
+++ b/apis/placement/v1beta1/resourcesnapshot_types.go
@@ -25,7 +25,7 @@ const (
 	// SubindexOfResourceSnapshotAnnotation is the annotation to store the subindex of resource snapshot in the group.
 	SubindexOfResourceSnapshotAnnotation = fleetPrefix + "subindexOfResourceSnapshot"
 
-	// ResourceSnapshotNameFmt is resourcePolicySnapshot name format: {CRPName}-{resourceIndex}.
+	// ResourceSnapshotNameFmt is resourcePolicySnapshot name format: {CRPName}-{resourceIndex}-snapshot.
 	ResourceSnapshotNameFmt = "%s-%d-snapshot"
 )
 

--- a/apis/placement/v1beta1/resourcesnapshot_types.go
+++ b/apis/placement/v1beta1/resourcesnapshot_types.go
@@ -26,7 +26,7 @@ const (
 	SubindexOfResourceSnapshotAnnotation = fleetPrefix + "subindexOfResourceSnapshot"
 
 	// ResourceSnapshotNameFmt is resourcePolicySnapshot name format: {CRPName}-{resourceIndex}.
-	ResourceSnapshotNameFmt = "%s-%d"
+	ResourceSnapshotNameFmt = "%s-%d-snapshot"
 )
 
 // +genclient
@@ -42,8 +42,9 @@ const (
 // Its spec is immutable.
 // We may need to produce more than one resourceSnapshot for all the resources a ResourcePlacement selected to get around the 1MB size limit of k8s objects.
 // We assign an ever-increasing index for each such group of resourceSnapshots.
-// The name convention of a clusterResourceSnapshot is {CRPName}-{resourceIndex}-{subindex} where resourceIndex and
-// subindex will begin with 0.
+// The name convention of a clusterResourceSnapshot is {CRPName}-{resourceIndex}-{snapshot|-{subindex}}
+// where the name of the first snapshot of a group has no subindex part so its name is {CRPName}-{resourceIndex}-snapshot.
+// resourceIndex will begin with 0.
 // Each snapshot MUST have the following labels:
 //   - `CRPTrackingLabel` which points to its owner CRP.
 //   - `ResourceIndexLabel` which is the index  of the snapshot group.
@@ -55,8 +56,8 @@ const (
 //   - "NumberOfResourceSnapshots" to store the total number of resource snapshots in the index group.
 //   - `ResourceGroupHashAnnotation` whose value is the sha-256 hash of all the snapshots belong to the same snapshot index.
 //
-// Each snapshot MUST have the following annotations:
-//   - "SubindexOfResourceSnapshotAnnotation" to store the index of resource snapshot in the group.
+// Each snapshot (excluding the first snapshot) MUST have the following annotations:
+//   - "SubindexOfResourceSnapshotAnnotation" to store the subindex of resource snapshot in the group.
 type ClusterResourceSnapshot struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/placement/v1beta1/resourcesnapshot_types.go
+++ b/apis/placement/v1beta1/resourcesnapshot_types.go
@@ -22,6 +22,9 @@ const (
 	// NumberOfResourceSnapshotsAnnotation is the annotation that contains the total number of resource snapshots.
 	NumberOfResourceSnapshotsAnnotation = fleetPrefix + "numberOfResourceSnapshots"
 
+	// SubindexOfResourceSnapshotAnnotation is the annotation to store the index of resource snapshot in the group.
+	SubindexOfResourceSnapshotAnnotation = fleetPrefix + "subindexOfResourceSnapshot"
+
 	// ResourceSnapshotNameFmt is resourcePolicySnapshot name format: {CRPName}-{resourceIndex}.
 	ResourceSnapshotNameFmt = "%s-%d"
 )
@@ -39,9 +42,8 @@ const (
 // Its spec is immutable.
 // We may need to produce more than one resourceSnapshot for all the resources a ResourcePlacement selected to get around the 1MB size limit of k8s objects.
 // We assign an ever-increasing index for each such group of resourceSnapshots.
-// The name convention of a clusterResourceSnapshot is {CRPName}-{resourceIndex}(-{subindex})*
-// where the name of the first snapshot of a group has no subindex part so its name is {CRPName}-{resourceIndex}.
-// resourceIndex will begin with 0.
+// The name convention of a clusterResourceSnapshot is {CRPName}-{resourceIndex}-{subindex} where resourceIndex and
+// subindex will begin with 0.
 // Each snapshot MUST have the following labels:
 //   - `CRPTrackingLabel` which points to its owner CRP.
 //   - `ResourceIndexLabel` which is the index  of the snapshot group.
@@ -52,6 +54,9 @@ const (
 // The first snapshot of the index group MUST have the following annotations:
 //   - "NumberOfResourceSnapshots" to store the total number of resource snapshots in the index group.
 //   - `ResourceGroupHashAnnotation` whose value is the sha-256 hash of all the snapshots belong to the same snapshot index.
+//
+// Each snapshot MUST have the following annotations:
+//   - "SubindexOfResourceSnapshotAnnotation" to store the index of resource snapshot in the group.
 type ClusterResourceSnapshot struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/placement.azure.com_clusterresourcesnapshots.yaml
+++ b/config/crd/bases/placement.azure.com_clusterresourcesnapshots.yaml
@@ -32,17 +32,17 @@ spec:
           resources by a resource placement policy. Its spec is immutable. We may
           need to produce more than one resourceSnapshot for all the resources a ResourcePlacement
           selected to get around the 1MB size limit of k8s objects. We assign an ever-increasing
-          index for each such group of resourceSnapshots. The name convention of a
-          clusterResourceSnapshot is {CRPName}-{resourceIndex}-{snapshot|-{subindex}}
-          where the name of the first snapshot of a group has no subindex part so
-          its name is {CRPName}-{resourceIndex}-snapshot. resourceIndex will begin
-          with 0. Each snapshot MUST have the following labels: - `CRPTrackingLabel`
-          which points to its owner CRP. - `ResourceIndexLabel` which is the index
-          \ of the snapshot group. - `IsLatestSnapshotLabel` which indicates whether
-          the snapshot is the latest one. \n All the snapshots within the same index
-          group must have the same ResourceIndexLabel. \n The first snapshot of the
-          index group MUST have the following annotations: - \"NumberOfResourceSnapshots\"
-          to store the total number of resource snapshots in the index group. - `ResourceGroupHashAnnotation`
+          index for each such group of resourceSnapshots. The naming convention of
+          a clusterResourceSnapshot is {CRPName}-{resourceIndex}-{subindex} where
+          the name of the first snapshot of a group has no subindex part so its name
+          is {CRPName}-{resourceIndex}-snapshot. resourceIndex will begin with 0.
+          Each snapshot MUST have the following labels: - `CRPTrackingLabel` which
+          points to its owner CRP. - `ResourceIndexLabel` which is the index  of the
+          snapshot group. - `IsLatestSnapshotLabel` which indicates whether the snapshot
+          is the latest one. \n All the snapshots within the same index group must
+          have the same ResourceIndexLabel. \n The first snapshot of the index group
+          MUST have the following annotations: - \"NumberOfResourceSnapshots\" to
+          store the total number of resource snapshots in the index group. - `ResourceGroupHashAnnotation`
           whose value is the sha-256 hash of all the snapshots belong to the same
           snapshot index. \n Each snapshot (excluding the first snapshot) MUST have
           the following annotations: - \"SubindexOfResourceSnapshotAnnotation\" to

--- a/config/crd/bases/placement.azure.com_clusterresourcesnapshots.yaml
+++ b/config/crd/bases/placement.azure.com_clusterresourcesnapshots.yaml
@@ -33,18 +33,20 @@ spec:
           need to produce more than one resourceSnapshot for all the resources a ResourcePlacement
           selected to get around the 1MB size limit of k8s objects. We assign an ever-increasing
           index for each such group of resourceSnapshots. The name convention of a
-          clusterResourceSnapshot is {CRPName}-{resourceIndex}-{subindex} where resourceIndex
-          and subindex will begin with 0. Each snapshot MUST have the following labels:
-          - `CRPTrackingLabel` which points to its owner CRP. - `ResourceIndexLabel`
-          which is the index  of the snapshot group. - `IsLatestSnapshotLabel` which
-          indicates whether the snapshot is the latest one. \n All the snapshots within
-          the same index group must have the same ResourceIndexLabel. \n The first
-          snapshot of the index group MUST have the following annotations: - \"NumberOfResourceSnapshots\"
+          clusterResourceSnapshot is {CRPName}-{resourceIndex}-{snapshot|-{subindex}}
+          where the name of the first snapshot of a group has no subindex part so
+          its name is {CRPName}-{resourceIndex}-snapshot. resourceIndex will begin
+          with 0. Each snapshot MUST have the following labels: - `CRPTrackingLabel`
+          which points to its owner CRP. - `ResourceIndexLabel` which is the index
+          \ of the snapshot group. - `IsLatestSnapshotLabel` which indicates whether
+          the snapshot is the latest one. \n All the snapshots within the same index
+          group must have the same ResourceIndexLabel. \n The first snapshot of the
+          index group MUST have the following annotations: - \"NumberOfResourceSnapshots\"
           to store the total number of resource snapshots in the index group. - `ResourceGroupHashAnnotation`
           whose value is the sha-256 hash of all the snapshots belong to the same
-          snapshot index. \n Each snapshot MUST have the following annotations: -
-          \"SubindexOfResourceSnapshotAnnotation\" to store the index of resource
-          snapshot in the group."
+          snapshot index. \n Each snapshot (excluding the first snapshot) MUST have
+          the following annotations: - \"SubindexOfResourceSnapshotAnnotation\" to
+          store the subindex of resource snapshot in the group."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/bases/placement.azure.com_clusterresourcesnapshots.yaml
+++ b/config/crd/bases/placement.azure.com_clusterresourcesnapshots.yaml
@@ -33,18 +33,18 @@ spec:
           need to produce more than one resourceSnapshot for all the resources a ResourcePlacement
           selected to get around the 1MB size limit of k8s objects. We assign an ever-increasing
           index for each such group of resourceSnapshots. The name convention of a
-          clusterResourceSnapshot is {CRPName}-{resourceIndex}(-{subindex})* where
-          the name of the first snapshot of a group has no subindex part so its name
-          is {CRPName}-{resourceIndex}. resourceIndex will begin with 0. Each snapshot
-          MUST have the following labels: - `CRPTrackingLabel` which points to its
-          owner CRP. - `ResourceIndexLabel` which is the index  of the snapshot group.
-          - `IsLatestSnapshotLabel` which indicates whether the snapshot is the latest
-          one. \n All the snapshots within the same index group must have the same
-          ResourceIndexLabel. \n The first snapshot of the index group MUST have the
-          following annotations: - \"NumberOfResourceSnapshots\" to store the total
-          number of resource snapshots in the index group. - `ResourceGroupHashAnnotation`
+          clusterResourceSnapshot is {CRPName}-{resourceIndex}-{subindex} where resourceIndex
+          and subindex will begin with 0. Each snapshot MUST have the following labels:
+          - `CRPTrackingLabel` which points to its owner CRP. - `ResourceIndexLabel`
+          which is the index  of the snapshot group. - `IsLatestSnapshotLabel` which
+          indicates whether the snapshot is the latest one. \n All the snapshots within
+          the same index group must have the same ResourceIndexLabel. \n The first
+          snapshot of the index group MUST have the following annotations: - \"NumberOfResourceSnapshots\"
+          to store the total number of resource snapshots in the index group. - `ResourceGroupHashAnnotation`
           whose value is the sha-256 hash of all the snapshots belong to the same
-          snapshot index."
+          snapshot index. \n Each snapshot MUST have the following annotations: -
+          \"SubindexOfResourceSnapshotAnnotation\" to store the index of resource
+          snapshot in the group."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/pkg/controllers/clusterresourceplacement/controller_test.go
+++ b/pkg/controllers/clusterresourceplacement/controller_test.go
@@ -675,15 +675,15 @@ func TestGetOrCreateClusterSchedulingPolicySnapshot(t *testing.T) {
 				WithObjects(objects...).
 				Build()
 			r := Reconciler{Client: fakeClient, Scheme: scheme}
-			got, err := r.getOrCreateClusterPolicySnapshot(ctx, crp)
+			got, err := r.getOrCreateClusterSchedulingPolicySnapshot(ctx, crp)
 			if err != nil {
-				t.Fatalf("failed to getOrCreateClusterPolicySnapshot: %v", err)
+				t.Fatalf("failed to getOrCreateClusterSchedulingPolicySnapshot: %v", err)
 			}
 			options := []cmp.Option{
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 			}
 			if diff := cmp.Diff(tc.wantPolicySnapshots[tc.wantLatestSnapshotIndex], *got, options...); diff != "" {
-				t.Errorf("getOrCreateClusterPolicySnapshot() mismatch (-want, +got):\n%s", diff)
+				t.Errorf("getOrCreateClusterSchedulingPolicySnapshot() mismatch (-want, +got):\n%s", diff)
 			}
 			clusterPolicySnapshotList := &fleetv1beta1.ClusterSchedulingPolicySnapshotList{}
 			if err := fakeClient.List(ctx, clusterPolicySnapshotList); err != nil {
@@ -932,7 +932,7 @@ func TestGetOrCreateClusterSchedulingPolicySnapshot_failure(t *testing.T) {
 				WithObjects(objects...).
 				Build()
 			r := Reconciler{Client: fakeClient, Scheme: scheme}
-			_, err := r.getOrCreateClusterPolicySnapshot(ctx, crp)
+			_, err := r.getOrCreateClusterSchedulingPolicySnapshot(ctx, crp)
 			if err == nil { // if error is nil
 				t.Fatal("getOrCreateClusterResourceSnapshot() = nil, want err")
 			}


### PR DESCRIPTION
### Description of your changes

- Add this annotation to help CRP to sort the snapshots in the group and work generator to create the work name.
- Fix the log to use the final policy snapshot name.

Now the first snapshot name will always be {CRPName}-{resourceIndex}-snapshot.
It helps to solve the duplication of resourceSnapshotName and now the name format is fixed and there is no ambiguity. 

This approach is simpler compared with other options' complexity otherwise the CRP name cannot contain "-" and not supporting it will hurt customer's experience.

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer


