### PR TITLE
feat: add generation related fields to policy snapshot status

### DIFF
--- a/apis/placement/v1beta1/commons.go
+++ b/apis/placement/v1beta1/commons.go
@@ -26,6 +26,10 @@ const (
 
 	// FleetResourceLabelKey is that label that indicates the resource is a fleet resource.
 	FleetResourceLabelKey = fleetPrefix + "isFleetResource"
+
+	// CRPGenerationAnnotation is the annotation that indicates the generation of the CRP from
+	// which an object is derived or last updated.
+	CRPGenerationAnnotation = fleetPrefix + "CRPGeneration"
 )
 
 const (

--- a/apis/placement/v1beta1/policysnapshot_types.go
+++ b/apis/placement/v1beta1/policysnapshot_types.go
@@ -19,10 +19,6 @@ const (
 
 	// NumberOfClustersAnnotation is the annotation that indicates how many clusters should be selected for selectN placement type.
 	NumberOfClustersAnnotation = fleetPrefix + "numberOfClusters"
-
-	// CRPGenerationAnnotation is the annotation that indicates the generation from which the
-	// policy snapshot is created or last updated.
-	CRPGenerationAnnotation = fleetPrefix + "CRPGeneration"
 )
 
 // +genclient

--- a/apis/placement/v1beta1/policysnapshot_types.go
+++ b/apis/placement/v1beta1/policysnapshot_types.go
@@ -19,6 +19,10 @@ const (
 
 	// NumberOfClustersAnnotation is the annotation that indicates how many clusters should be selected for selectN placement type.
 	NumberOfClustersAnnotation = fleetPrefix + "numberOfClusters"
+
+	// CRPGenerationAnnotation is the annotation that indicates the generation from which the
+	// policy snapshot is created or last updated.
+	CRPGenerationAnnotation = fleetPrefix + "CRPGeneration"
 )
 
 // +genclient
@@ -67,6 +71,12 @@ type SchedulingPolicySnapshotSpec struct {
 type SchedulingPolicySnapshotStatus struct {
 	// +patchMergeKey=type
 	// +patchStrategy=merge
+
+	// ObservedCRPGeneration is the generation of the CRP which the scheduler uses to perform
+	// the scheduling cycle and prepare the scheduling status.
+	// +required
+	ObservedCRPGeneration int64 `json:"observedCRPGeneration"`
+
 	// +listType=map
 	// +listMapKey=type
 

--- a/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
@@ -383,6 +383,12 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              observedCRPGeneration:
+                description: ObservedCRPGeneration is the generation of the CRP which
+                  the scheduler uses to perform the scheduling cycle and prepare the
+                  scheduling status.
+                format: int64
+                type: integer
               targetClusters:
                 description: ClusterDecisions contains a list of names of member clusters
                   considered by the scheduler. Note that all the selected clusters
@@ -434,6 +440,8 @@ spec:
                   type: object
                 maxItems: 1000
                 type: array
+            required:
+            - observedCRPGeneration
             type: object
         required:
         - spec


### PR DESCRIPTION
### Description of your changes

This PR adds generation related fields to the policy snapshot status API. This helps resolve some inconsistencies regarding status updates.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A