### PR TITLE
feat: scheduler plugins (2/): add topology spread constraints plugin logic

### DIFF
--- a/pkg/scheduler/framework/cyclestate_test.go
+++ b/pkg/scheduler/framework/cyclestate_test.go
@@ -5,11 +5,46 @@ Licensed under the MIT license.
 
 package framework
 
-import "testing"
+import (
+	"testing"
 
-// TestCycleStateBasicOps tests the basic ops (Read, Write, and Delete) of a CycleState.
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+// TestCycleStateBasicOps tests the basic ops of a CycleState.
 func TestCycleStateBasicOps(t *testing.T) {
-	cs := NewCycleState()
+	clusters := []fleetv1beta1.MemberCluster{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterName,
+			},
+		},
+	}
+	scheduledOrBoundBindings := []*fleetv1beta1.ClusterResourceBinding{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bindingName,
+			},
+			Spec: fleetv1beta1.ResourceBindingSpec{
+				TargetCluster: clusterName,
+				State:         fleetv1beta1.BindingStateBound,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: altBindingName,
+			},
+			Spec: fleetv1beta1.ResourceBindingSpec{
+				TargetCluster: altClusterName,
+				State:         fleetv1beta1.BindingStateScheduled,
+			},
+		},
+	}
+
+	cs := NewCycleState(clusters, scheduledOrBoundBindings)
 
 	k, v := "key", "value"
 	cs.Write(StateKey(k), StateValue(v))
@@ -19,5 +54,50 @@ func TestCycleStateBasicOps(t *testing.T) {
 	cs.Delete(StateKey(k))
 	if out, err := cs.Read("key"); out != nil || err == nil {
 		t.Fatalf("Read(%v) = %v, %v, want nil, not found error", k, out, err)
+	}
+
+	clustersInState := cs.ListClusters()
+	if diff := cmp.Diff(clustersInState, clusters); diff != "" {
+		t.Fatalf("ListClusters() diff (-got, +want): %s", diff)
+	}
+
+	for _, binding := range scheduledOrBoundBindings {
+		if !cs.IsClusterScheduledOrBound(binding.Spec.TargetCluster) {
+			t.Fatalf("IsClusterScheduledOrBound(%v) = false, want true", binding.Spec.TargetCluster)
+		}
+	}
+}
+
+// TestPrepareScheduledOrBoundMap tests the prepareScheduledOrBoundMap function.
+func TestPrepareScheduledOrBoundMap(t *testing.T) {
+	scheduled := []*fleetv1beta1.ClusterResourceBinding{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bindingName,
+			},
+			Spec: fleetv1beta1.ResourceBindingSpec{
+				TargetCluster: clusterName,
+			},
+		},
+	}
+	bound := []*fleetv1beta1.ClusterResourceBinding{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: altBindingName,
+			},
+			Spec: fleetv1beta1.ResourceBindingSpec{
+				TargetCluster: altClusterName,
+			},
+		},
+	}
+
+	want := map[string]bool{
+		clusterName:    true,
+		altClusterName: true,
+	}
+
+	scheduleOrBoundMap := prepareScheduledOrBoundMap(scheduled, bound)
+	if diff := cmp.Diff(scheduleOrBoundMap, want); diff != "" {
+		t.Errorf("scheduledOrBoundMap diff (-got, +want): %s", diff)
 	}
 }

--- a/pkg/scheduler/framework/cyclestateutils.go
+++ b/pkg/scheduler/framework/cyclestateutils.go
@@ -1,0 +1,25 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package framework
+
+import (
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+// prepareScheduledOrBoundMap returns a map that allows quick lookup of whether a cluster
+// already has a binding of the scheduled or bound state relevant to the current scheduling
+// cycle.
+func prepareScheduledOrBoundMap(scheduledOrBoundBindings ...[]*fleetv1beta1.ClusterResourceBinding) map[string]bool {
+	scheduledOrBound := make(map[string]bool)
+
+	for _, bindingSet := range scheduledOrBoundBindings {
+		for _, binding := range bindingSet {
+			scheduledOrBound[binding.Spec.TargetCluster] = true
+		}
+	}
+
+	return scheduledOrBound
+}

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -259,7 +259,7 @@ func (f *framework) RunSchedulingCycleFor(ctx context.Context, crpName string, p
 	// Note that this state is shared between all plugins and the scheduler framework itself (though some fields are reserved by
 	// the framework). These resevered fields are never accessed concurrently, as each scheduling run has its own cycle and a run
 	// is always executed in one single goroutine; plugin access to the state is guarded by sync.Map.
-	state := NewCycleState()
+	state := NewCycleState(clusters, bound, scheduled)
 
 	switch policy.Spec.Policy.PlacementType {
 	case fleetv1beta1.PickAllPlacementType:

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -404,7 +404,7 @@ func TestRunPreFilterPlugins(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			state := NewCycleState()
+			state := NewCycleState([]fleetv1beta1.MemberCluster{}, []*fleetv1beta1.ClusterResourceBinding{})
 			policy := &fleetv1beta1.ClusterSchedulingPolicySnapshot{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: policyName,
@@ -515,7 +515,7 @@ func TestRunFilterPluginsFor(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			state := NewCycleState()
+			state := NewCycleState([]fleetv1beta1.MemberCluster{}, []*fleetv1beta1.ClusterResourceBinding{})
 			for _, name := range tc.skippedPluginNames {
 				state.skippedFilterPlugins.Insert(name)
 			}
@@ -686,7 +686,7 @@ func TestRunFilterPlugins(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			state := NewCycleState()
+			state := NewCycleState([]fleetv1beta1.MemberCluster{}, []*fleetv1beta1.ClusterResourceBinding{})
 			policy := &fleetv1beta1.ClusterSchedulingPolicySnapshot{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: policyName,
@@ -989,7 +989,7 @@ func TestRunAllPluginsForPickAllPlacementType(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			state := NewCycleState()
+			state := NewCycleState([]fleetv1beta1.MemberCluster{}, []*fleetv1beta1.ClusterResourceBinding{})
 			scored, filtered, err := f.runAllPluginsForPickAllPlacementType(ctx, state, policy, clusters)
 			if tc.expectedToFail {
 				if err == nil {

--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/plugin.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/plugin.go
@@ -16,6 +16,25 @@ import (
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 )
 
+const (
+	// skewChangeScoreFactor is the factor applied to topology spread score for every unit
+	// of skew change.
+	//
+	// Note that it should be a negative value, so that any provisional placement that reduces
+	// skewing will be assigned a positive topology spread score.
+	skewChangeScoreFactor = -1
+	// maxSkewViolationPenality is the penalty applied to topology spread score when a
+	// provisional placement violates a topology spread constraint.
+	//
+	// Note that it should be a positive value, as the plugin will subtract this value from
+	// the total score.
+	maxSkewViolationPenality = 1000
+)
+
+var (
+	doNotScheduleConstraintViolationReasonTemplate = "violated topology spread constraint %q (max skew %d)"
+)
+
 // Plugin is the scheduler plugin that enforces the
 // topology spread constraints (if any) defined on a CRP.
 type Plugin struct {

--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/state.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/state.go
@@ -9,6 +9,96 @@ import (
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 )
 
+// domainName is the name of a topology domain.
+type domainName string
+
+// count is the number of bindings in a topology domain.
+type count int
+
+// bindingCounter is an interface which allows counting the number of bindings in each
+// topology domain.
+type bindingCounter interface {
+	// Count returns the number of bindings in a topology domain.
+	//
+	// It returns false if the domain does not exist, or the counter has not been initialized
+	// (i.e. no domain has been registered).
+	Count(domainName) (count, bool)
+
+	// Smallest returns the smallest count in the counter.
+	//
+	// It returns false if the counter has not been initialized (i.e. no domain has been registered).
+	Smallest() (count, bool)
+	// SecondSmallest returns the second smallest count in the counter.
+	//
+	// It returns false if the counter has not been initialized (i.e. no domain has been registered).
+	SecondSmallest() (count, bool)
+	// Largest returns the largest count in the counter.
+	//
+	// It returns false if the counter has not been initialized (i.e. no domain has been registered).
+	Largest() (count, bool)
+}
+
+// bindingCounterByDomain implements the bindingCounter interface, counting the number of
+// bindings in each topology domain.
+type bindingCounterByDomain struct {
+	// counter tracks the number of bindings in each domain.
+	counter map[domainName]count
+
+	// smallest is the smallest count in the counter.
+	smallest count
+	// secondSmallest is the second smallest count in the counter.
+	//
+	// Note that the second smallest count might be the same as the smallest count.
+	secondSmallest count
+	// largest is the largest count in the counter.
+	//
+	// Note that the largest count might be the same as the second smallest (and consequently
+	// the smallest) count.
+	largest count
+}
+
+var (
+	// Verify that bindingCounterByDomain implements the bindingCounter interface at compile time.
+	_ bindingCounter = &bindingCounterByDomain{}
+)
+
+// Count returns the number of bindings in a topology domain.
+func (c *bindingCounterByDomain) Count(name domainName) (count, bool) {
+	if len(c.counter) == 0 {
+		return 0, false
+	}
+
+	val, ok := c.counter[name]
+	return val, ok
+}
+
+// Smallest returns the smallest count in the counter.
+func (c *bindingCounterByDomain) Smallest() (count, bool) {
+	if len(c.counter) == 0 {
+		return 0, false
+	}
+
+	return c.smallest, true
+}
+
+// SecondSmallest returns the second smallest count in the counter.
+func (c *bindingCounterByDomain) SecondSmallest() (count, bool) {
+	if len(c.counter) == 0 {
+		return 0, false
+	}
+
+	return c.secondSmallest, true
+}
+
+// Largest returns the largest count in the counter.
+func (c *bindingCounterByDomain) Largest() (count, bool) {
+	if len(c.counter) == 0 {
+		return 0, false
+	}
+
+	return c.largest, true
+}
+
 // clusterName is the name of a cluster.
 type clusterName string
 

--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/state_test.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/state_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package topologyspreadconstraints
+
+import "testing"
+
+const (
+	domainName1   = "test-domain"
+	bindingCount1 = 1
+	domainName2   = "alt-test-domain"
+	bindingCount2 = 2
+)
+
+// TestBindingCounterByDomain tests if the bindingCounterByDomain struct correctly implements the
+// bindingCounter interface.
+func TestBindingCounterByDomain(t *testing.T) {
+	testCases := []struct {
+		name               string
+		counter            bindingCounterByDomain
+		initialized        bool
+		wantCounts         map[domainName]count
+		wantSmallest       count
+		wantSecondSmallest count
+		wantLargest        count
+	}{
+		{
+			name:    "uninitialized",
+			counter: bindingCounterByDomain{},
+		},
+		{
+			name: "normal counter",
+			counter: bindingCounterByDomain{
+				counter: map[domainName]count{
+					domainName1: bindingCount1,
+					domainName2: bindingCount2,
+				},
+				smallest:       bindingCount1,
+				secondSmallest: bindingCount2,
+				largest:        bindingCount2,
+			},
+			initialized: true,
+			wantCounts: map[domainName]count{
+				domainName1: bindingCount1,
+				domainName2: bindingCount2,
+			},
+			wantSmallest:       bindingCount1,
+			wantSecondSmallest: bindingCount2,
+			wantLargest:        bindingCount2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.initialized == false {
+				val, ok := tc.counter.Count(domainName1)
+				if ok {
+					t.Errorf("Count() = %v, true, want false", val)
+				}
+
+				val, ok = tc.counter.Smallest()
+				if ok {
+					t.Errorf("Smallest() = %v, true, want false", val)
+				}
+
+				val, ok = tc.counter.SecondSmallest()
+				if ok {
+					t.Errorf("SecondSmallest() = %v, true, want false", val)
+				}
+
+				val, ok = tc.counter.Largest()
+				if ok {
+					t.Errorf("Largest() = %v, true, want false", val)
+				}
+
+				return
+			}
+
+			for name, wantCount := range tc.wantCounts {
+				count, ok := tc.counter.Count(name)
+				if !ok || count != wantCount {
+					t.Errorf("Count() = %v, %t, want %v, true", count, ok, wantCount)
+				}
+			}
+
+			smallest, ok := tc.counter.Smallest()
+			if !ok || smallest != tc.wantSmallest {
+				t.Errorf("Smallest() = %v, %t, want %v, true", smallest, ok, tc.wantSmallest)
+			}
+
+			secondSmallest, ok := tc.counter.SecondSmallest()
+			if !ok || secondSmallest != tc.wantSecondSmallest {
+				t.Errorf("SecondSmallest() = %v, %t, want %v, true", secondSmallest, ok, tc.wantSecondSmallest)
+			}
+
+			largest, ok := tc.counter.Largest()
+			if !ok || largest != tc.wantLargest {
+				t.Errorf("Largest() = %v, %t, want %v, true", largest, ok, tc.wantLargest)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils.go
@@ -6,15 +6,170 @@ Licensed under the MIT license.
 package topologyspreadconstraints
 
 import (
+	"fmt"
+
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/scheduler/framework"
 )
 
+// countByDomain counts the number of scheduled or bound bindings in each domain per a given
+// topology key.
+func countByDomain(_ []fleetv1beta1.MemberCluster, _ framework.CycleStatePluginReadWriter, _ string) bindingCounter {
+	// Not yet implemented.
+	return &bindingCounterByDomain{}
+}
+
+// willViolatereturns whether producing one more binding in a domain would lead
+// to violations; it will also return the skew change caused by the provisional placement.
+func willViolate(_ bindingCounter, _ domainName, _ int) (violated bool, skewChange int, err error) {
+	// Not yet implemented.
+	return false, 0, nil
+}
+
+// classifyConstraints classifies topology spread constraints in a policy based on their
+// whenUnsatisfiable requirements.
+func classifyConstraints(policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) (doNotSchedule, scheduleAnyway []*fleetv1beta1.TopologySpreadConstraint) {
+	// Pre-allocate arrays.
+	doNotSchedule = make([]*fleetv1beta1.TopologySpreadConstraint, 0, len(policy.Spec.Policy.TopologySpreadConstraints))
+	scheduleAnyway = make([]*fleetv1beta1.TopologySpreadConstraint, 0, len(policy.Spec.Policy.TopologySpreadConstraints))
+
+	for idx := range policy.Spec.Policy.TopologySpreadConstraints {
+		constraint := policy.Spec.Policy.TopologySpreadConstraints[idx]
+		if constraint.WhenUnsatisfiable == fleetv1beta1.ScheduleAnyway {
+			scheduleAnyway = append(scheduleAnyway, &constraint)
+			continue
+		}
+
+		// DoNotSchedule is the default value for the whenUnsatisfiable field; currently the only
+		// two supported requirements are DoNotSchedule and ScheduleAnyway.
+		doNotSchedule = append(doNotSchedule, &constraint)
+	}
+
+	return doNotSchedule, scheduleAnyway
+}
+
+// evaluateAllConstraints evaluates all topology spread constraints in a policy againsts all
+// clusters being inspected in the current scheduling cycle.
+//
+// Note that every cluster that does not lead to violations will be assigned a score, even if
+// the cluster does not concern any of the topology spread constraints.
+func evaluateAllConstraints(
+	state framework.CycleStatePluginReadWriter,
+	doNotSchedule, scheduleAnyway []*fleetv1beta1.TopologySpreadConstraint,
+) (violations doNotScheduleViolations, scores topologySpreadScores, err error) {
+	violations = make(doNotScheduleViolations)
+	// Note that this function guarantees that all clusters that do not lead to violations of
+	// DoNotSchedule topology spread constraints will be assigned a score, even if none of the
+	// topology spread constraints concerns these clusters.
+	scores = make(topologySpreadScores)
+
+	clusters := state.ListClusters()
+
+	for _, constraint := range doNotSchedule {
+		domainCounter := countByDomain(clusters, state, constraint.TopologyKey)
+
+		for _, cluster := range clusters {
+			if _, ok := violations[clusterName(cluster.Name)]; ok {
+				// The cluster has violated a DoNotSchedule topology spread constraint; no need
+				// evaluate other constraints for this cluster.
+				continue
+			}
+
+			val, ok := cluster.Labels[constraint.TopologyKey]
+			if !ok {
+				// The cluster under inspection does not have the topology key and thus is not part
+				// of the spread.
+				//
+				// Placing resources on such clusters will not lead to topology spread constraint
+				// violations.
+				//
+				// Assign a score even if the constraint does not concern the cluster.
+				scores[clusterName(cluster.Name)] += 0
+				continue
+			}
+
+			// The cluster under inspection is part of the spread.
+
+			// Verify if the placement will violate the constraint.
+			violated, skewChange, err := willViolate(domainCounter, domainName(val), int(*constraint.MaxSkew))
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to evaluate DoNotSchedule topology spread constraints: %w", err)
+			}
+			if violated {
+				// A violation happens.
+				reasons := violationReasons{
+					fmt.Sprintf(doNotScheduleConstraintViolationReasonTemplate, constraint.TopologyKey, *constraint.MaxSkew),
+				}
+				violations[clusterName(cluster.Name)] = reasons
+				continue
+			}
+			scores[clusterName(cluster.Name)] += skewChange * skewChangeScoreFactor
+		}
+	}
+
+	for _, constraint := range scheduleAnyway {
+		domainCounter := countByDomain(clusters, state, constraint.TopologyKey)
+
+		for _, cluster := range clusters {
+			if _, ok := violations[clusterName(cluster.Name)]; ok {
+				// The cluster has violated a DoNotSchedule topology spread constraint; no need
+				// evaluate other constraints for this cluster.
+				continue
+			}
+
+			val, ok := cluster.Labels[constraint.TopologyKey]
+			if !ok {
+				// The cluster under inspection does not have the topology key and thus is not part
+				// of the spread.
+				//
+				// Placing resources on such clusters will not lead to topology spread constraint
+				// violations.
+				//
+				// Assign a score even if the constraint does not concern the cluster.
+				scores[clusterName(cluster.Name)] += 0
+				continue
+			}
+
+			// The cluster under inspection is part of the spread.
+
+			// Verify if the placement will violate the constraint.
+			violated, skewChange, err := willViolate(domainCounter, domainName(val), int(*constraint.MaxSkew))
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to evaluate ScheduleAnyway topology spread constraints: %w", err)
+			}
+			if violated {
+				// A violation happens; since this is a ScheduleAnyway topology spread constraint,
+				// a violation score penality is applied to the score.
+				scores[clusterName(cluster.Name)] -= maxSkewViolationPenality
+				continue
+			}
+			scores[clusterName(cluster.Name)] += skewChange * skewChangeScoreFactor
+		}
+	}
+
+	return violations, scores, nil
+}
+
 // prepareTopologySpreadConstraintsPluginState initializes the state for the plugin to use
 // in the scheduling cycle.
-//
-// TO-DO (chenyu1): assign variables when needed.
-func prepareTopologySpreadConstraintsPluginState(_ framework.CycleStatePluginReadWriter, _ *fleetv1beta1.ClusterSchedulingPolicySnapshot) (*pluginState, error) {
-	// Not yet implemented.
-	return &pluginState{}, nil
+func prepareTopologySpreadConstraintsPluginState(state framework.CycleStatePluginReadWriter, policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) (*pluginState, error) {
+	// Classify the topology spread constraints.
+	doNotSchedule, scheduleAnyway := classifyConstraints(policy)
+
+	// Based on current spread, inspect the clusters.
+	//
+	// Specifically, check if a cluster violates any DoNotSchedule topology spread constraint,
+	// and how much of a skew change it will incur for each constraint.
+	violations, scores, err := evaluateAllConstraints(state, doNotSchedule, scheduleAnyway)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare topology spread constraints plugin state: %w", err)
+	}
+
+	pluginState := &pluginState{
+		doNotScheduleConstraints:  doNotSchedule,
+		scheduleAnywayConstraints: scheduleAnyway,
+		violations:                violations,
+		scores:                    scores,
+	}
+	return pluginState, nil
 }

--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils_test.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package topologyspreadconstraints
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+const (
+	topologyKey1   = "topology-key-1"
+	topologyKey2   = "topology-key-2"
+	topologyKey3   = "topology-key-3"
+	topologyValue1 = "topology-value-1"
+	topologyValue2 = "topology-value-2"
+	topologyValue3 = "topology-value-3"
+
+	policyName = "policy-1"
+)
+
+// TestClassifyConstraints tests the classifyConstraints function.
+func TestClassifyConstriants(t *testing.T) {
+	maxSkew := int32(2)
+
+	testCases := []struct {
+		name               string
+		policy             *fleetv1beta1.ClusterSchedulingPolicySnapshot
+		wantDoNotSchedule  []*fleetv1beta1.TopologySpreadConstraint
+		wantScheduleAnyway []*fleetv1beta1.TopologySpreadConstraint
+	}{
+		{
+			name: "all doNotSchedule topology spread constraints",
+			policy: &fleetv1beta1.ClusterSchedulingPolicySnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: policyName,
+				},
+				Spec: fleetv1beta1.SchedulingPolicySnapshotSpec{
+					Policy: &fleetv1beta1.PlacementPolicy{
+						TopologySpreadConstraints: []fleetv1beta1.TopologySpreadConstraint{
+							{
+								MaxSkew:           &maxSkew,
+								TopologyKey:       topologyKey1,
+								WhenUnsatisfiable: fleetv1beta1.DoNotSchedule,
+							},
+							// Use the default value.
+							{
+								MaxSkew:     &maxSkew,
+								TopologyKey: topologyKey2,
+							},
+						},
+					},
+				},
+			},
+			wantDoNotSchedule: []*fleetv1beta1.TopologySpreadConstraint{
+				{
+					MaxSkew:           &maxSkew,
+					TopologyKey:       topologyKey1,
+					WhenUnsatisfiable: fleetv1beta1.DoNotSchedule,
+				},
+				{
+					MaxSkew:     &maxSkew,
+					TopologyKey: topologyKey2,
+				},
+			},
+			wantScheduleAnyway: []*fleetv1beta1.TopologySpreadConstraint{},
+		},
+		{
+			name: "all scheduleAnyway topology spread constraints",
+			policy: &fleetv1beta1.ClusterSchedulingPolicySnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: policyName,
+				},
+				Spec: fleetv1beta1.SchedulingPolicySnapshotSpec{
+					Policy: &fleetv1beta1.PlacementPolicy{
+						TopologySpreadConstraints: []fleetv1beta1.TopologySpreadConstraint{
+							{
+								MaxSkew:           &maxSkew,
+								TopologyKey:       topologyKey1,
+								WhenUnsatisfiable: fleetv1beta1.ScheduleAnyway,
+							},
+							{
+								MaxSkew:           &maxSkew,
+								TopologyKey:       topologyKey2,
+								WhenUnsatisfiable: fleetv1beta1.ScheduleAnyway,
+							},
+						},
+					},
+				},
+			},
+			wantDoNotSchedule: []*fleetv1beta1.TopologySpreadConstraint{},
+			wantScheduleAnyway: []*fleetv1beta1.TopologySpreadConstraint{
+				{
+					MaxSkew:           &maxSkew,
+					TopologyKey:       topologyKey1,
+					WhenUnsatisfiable: fleetv1beta1.ScheduleAnyway,
+				},
+				{
+					MaxSkew:           &maxSkew,
+					TopologyKey:       topologyKey2,
+					WhenUnsatisfiable: fleetv1beta1.ScheduleAnyway,
+				},
+			},
+		},
+		{
+			name: "mixed",
+			policy: &fleetv1beta1.ClusterSchedulingPolicySnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: policyName,
+				},
+				Spec: fleetv1beta1.SchedulingPolicySnapshotSpec{
+					Policy: &fleetv1beta1.PlacementPolicy{
+						TopologySpreadConstraints: []fleetv1beta1.TopologySpreadConstraint{
+							{
+								MaxSkew:           &maxSkew,
+								TopologyKey:       topologyKey1,
+								WhenUnsatisfiable: fleetv1beta1.ScheduleAnyway,
+							},
+							{
+								MaxSkew:           &maxSkew,
+								TopologyKey:       topologyKey2,
+								WhenUnsatisfiable: fleetv1beta1.ScheduleAnyway,
+							},
+							// Use the default value.
+							{
+								MaxSkew:     &maxSkew,
+								TopologyKey: topologyKey3,
+							},
+						},
+					},
+				},
+			},
+			wantDoNotSchedule: []*fleetv1beta1.TopologySpreadConstraint{
+				{
+					MaxSkew:     &maxSkew,
+					TopologyKey: topologyKey3,
+				},
+			},
+			wantScheduleAnyway: []*fleetv1beta1.TopologySpreadConstraint{
+				{
+					MaxSkew:           &maxSkew,
+					TopologyKey:       topologyKey1,
+					WhenUnsatisfiable: fleetv1beta1.ScheduleAnyway,
+				},
+				{
+					MaxSkew:           &maxSkew,
+					TopologyKey:       topologyKey2,
+					WhenUnsatisfiable: fleetv1beta1.ScheduleAnyway,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doNotSchedule, scheduleAnyway := classifyConstraints(tc.policy)
+			if diff := cmp.Diff(doNotSchedule, tc.wantDoNotSchedule); diff != "" {
+				t.Errorf("classifyConstraints() doNotSchedule topology spread constraints diff (-got, +want): %s", diff)
+			}
+			if diff := cmp.Diff(scheduleAnyway, tc.wantScheduleAnyway); diff != "" {
+				t.Errorf("classifyConstraints() scheduleAnyway topology spread constraints diff (-got, +want): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

This PR is part of the PRs that implement the in-tree scheduler framework plugins.

It features some scheduling logic for the topology spread constraints plugin.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer

To control the size of the PR, certain unit tests are not checked in; they will be sent in a separate PR.
