### PR TITLE
feat: scheduler plugins (3/): add topology spread constraints plugin logic

### DIFF
--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils_test.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils_test.go
@@ -12,9 +12,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/scheduler/framework"
 )
 
 const (
+	clusterName1 = "bravelion"
+	clusterName2 = "smartfish"
+	clusterName3 = "jumpingcat"
+	clusterName4 = "singingbutterfly"
+	clusterName5 = "sleepingwolf"
+
 	topologyKey1   = "topology-key-1"
 	topologyKey2   = "topology-key-2"
 	topologyKey3   = "topology-key-3"
@@ -22,8 +29,494 @@ const (
 	topologyValue2 = "topology-value-2"
 	topologyValue3 = "topology-value-3"
 
+	bindingName1 = "binding-1"
+	bindingName2 = "binding-2"
+	bindingName3 = "binding-3"
+
 	policyName = "policy-1"
 )
+
+// TestCountByDomain tests the countByDomain function.
+func TestCountByDomain(t *testing.T) {
+	clusterName6 := "dancingelephant"
+
+	bindingName4 := "binding-4"
+	bindingName5 := "binding-5"
+	bindingName6 := "binding-6"
+
+	testCases := []struct {
+		name                       string
+		clusters                   []fleetv1beta1.MemberCluster
+		bindings                   []*fleetv1beta1.ClusterResourceBinding
+		wantBindingCounterByDomain *bindingCounterByDomain
+	}{
+		{
+			name:     "uninitialized (no clusters)",
+			clusters: []fleetv1beta1.MemberCluster{},
+			bindings: []*fleetv1beta1.ClusterResourceBinding{},
+			wantBindingCounterByDomain: &bindingCounterByDomain{
+				counter:        make(map[domainName]count),
+				smallest:       -1,
+				secondSmallest: -1,
+				largest:        -1,
+			},
+		},
+		{
+			name: "uninitialized (no topology key present in clusters)",
+			clusters: []fleetv1beta1.MemberCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName1,
+					},
+				},
+			},
+			bindings: []*fleetv1beta1.ClusterResourceBinding{},
+			wantBindingCounterByDomain: &bindingCounterByDomain{
+				counter:        make(map[domainName]count),
+				smallest:       -1,
+				secondSmallest: -1,
+				largest:        -1,
+			},
+		},
+		{
+			name: "single domain",
+			clusters: []fleetv1beta1.MemberCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName1,
+						Labels: map[string]string{
+							topologyKey1: topologyValue1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName2,
+						Labels: map[string]string{
+							topologyKey1: topologyValue1,
+						},
+					},
+				},
+			},
+			bindings: []*fleetv1beta1.ClusterResourceBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName1,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName1,
+					},
+				},
+			},
+			wantBindingCounterByDomain: &bindingCounterByDomain{
+				counter: map[domainName]count{
+					topologyValue1: 1,
+				},
+				smallest:       1,
+				secondSmallest: 1,
+				largest:        1,
+			},
+		},
+		{
+			name: "multiple domains, same count",
+			clusters: []fleetv1beta1.MemberCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName1,
+						Labels: map[string]string{
+							topologyKey1: topologyValue1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName2,
+						Labels: map[string]string{
+							topologyKey1: topologyValue2,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName3,
+						Labels: map[string]string{
+							topologyKey1: topologyValue3,
+						},
+					},
+				},
+			},
+			bindings: []*fleetv1beta1.ClusterResourceBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName1,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName2,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName2,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName3,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName3,
+					},
+				},
+			},
+			wantBindingCounterByDomain: &bindingCounterByDomain{
+				counter: map[domainName]count{
+					topologyValue1: 1,
+					topologyValue2: 1,
+					topologyValue3: 1,
+				},
+				smallest:       1,
+				secondSmallest: 1,
+				largest:        1,
+			},
+		},
+		{
+			name: "multiple domains, different counts, separate special counts",
+			clusters: []fleetv1beta1.MemberCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName1,
+						Labels: map[string]string{
+							topologyKey1: topologyValue1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName2,
+						Labels: map[string]string{
+							topologyKey1: topologyValue1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName3,
+						Labels: map[string]string{
+							topologyKey1: topologyValue2,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName4,
+						Labels: map[string]string{
+							topologyKey1: topologyValue2,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName5,
+						Labels: map[string]string{
+							topologyKey1: topologyValue2,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName6,
+						Labels: map[string]string{
+							topologyKey1: topologyValue3,
+						},
+					},
+				},
+			},
+			bindings: []*fleetv1beta1.ClusterResourceBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName1,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName2,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName2,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName3,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName3,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName4,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName4,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName5,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName5,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName6,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName6,
+					},
+				},
+			},
+			wantBindingCounterByDomain: &bindingCounterByDomain{
+				counter: map[domainName]count{
+					topologyValue1: 2,
+					topologyValue2: 3,
+					topologyValue3: 1,
+				},
+				smallest:       1,
+				secondSmallest: 2,
+				largest:        3,
+			},
+		},
+		{
+			name: "multiple domains, different counts, multiple smallests",
+			clusters: []fleetv1beta1.MemberCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName1,
+						Labels: map[string]string{
+							topologyKey1: topologyValue1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName2,
+						Labels: map[string]string{
+							topologyKey1: topologyValue2,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName3,
+						Labels: map[string]string{
+							topologyKey1: topologyValue3,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName4,
+						Labels: map[string]string{
+							topologyKey1: topologyValue3,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName5,
+						Labels: map[string]string{
+							topologyKey1: topologyValue3,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName6,
+						Labels: map[string]string{
+							topologyKey1: topologyValue3,
+						},
+					},
+				},
+			},
+			bindings: []*fleetv1beta1.ClusterResourceBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName1,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName2,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName2,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName3,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName3,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName4,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName4,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName5,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName5,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName6,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName6,
+					},
+				},
+			},
+			wantBindingCounterByDomain: &bindingCounterByDomain{
+				counter: map[domainName]count{
+					topologyValue1: 1,
+					topologyValue2: 1,
+					topologyValue3: 4,
+				},
+				smallest:       1,
+				secondSmallest: 1,
+				largest:        4,
+			},
+		},
+		{
+			name: "multiple domains, different counts, multiple largests",
+			clusters: []fleetv1beta1.MemberCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName1,
+						Labels: map[string]string{
+							topologyKey1: topologyValue1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName2,
+						Labels: map[string]string{
+							topologyKey1: topologyValue2,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName3,
+						Labels: map[string]string{
+							topologyKey1: topologyValue2,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName4,
+						Labels: map[string]string{
+							topologyKey1: topologyValue3,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterName5,
+						Labels: map[string]string{
+							topologyKey1: topologyValue3,
+						},
+					},
+				},
+			},
+			bindings: []*fleetv1beta1.ClusterResourceBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName1,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName2,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName2,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName3,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName3,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName4,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName4,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: bindingName5,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						TargetCluster: clusterName5,
+					},
+				},
+			},
+			wantBindingCounterByDomain: &bindingCounterByDomain{
+				counter: map[domainName]count{
+					topologyValue1: 1,
+					topologyValue2: 2,
+					topologyValue3: 2,
+				},
+				smallest:       1,
+				secondSmallest: 2,
+				largest:        2,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := framework.NewCycleState(tc.clusters, tc.bindings)
+			counter := countByDomain(tc.clusters, state, topologyKey1)
+			if diff := cmp.Diff(counter, tc.wantBindingCounterByDomain, cmp.AllowUnexported(bindingCounterByDomain{})); diff != "" {
+				t.Errorf("countByDomain() diff (-got, +want): %s", diff)
+			}
+		})
+	}
+}
 
 // TestClassifyConstraints tests the classifyConstraints function.
 func TestClassifyConstriants(t *testing.T) {


### PR DESCRIPTION
### Description of your changes

This PR is part of the PRs that implement the in-tree scheduler framework plugins.

It features some scheduling logic for the topology spread constraints plugin.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer

To control the size of the PR, certain unit tests are not checked in; they will be sent in a separate PR.
