### PR TITLE
feat: scheduler plugins (4/): add topology spread constraints plugin logic

### DIFF
--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils_test.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils_test.go
@@ -935,6 +935,11 @@ func TestWillViolate(t *testing.T) {
 
 				return
 			}
+
+			if err != nil {
+				t.Fatalf("willViolate() = %v, want no error", err)
+			}
+
 			if violated != tc.wantViolated {
 				t.Errorf("willViolate() violated = %t, want %t", violated, tc.wantViolated)
 			}


### PR DESCRIPTION
### Description of your changes

This PR is part of the PRs that implement the in-tree scheduler framework plugins.

It features some scheduling logic for the topology spread constraints plugin.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer

To control the size of the PR, certain unit tests are not checked in; they will be sent in a separate PR.