### PR TITLE
feat: v1beta1 IMC controller

### DIFF
--- a/apis/types.go
+++ b/apis/types.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
 )
 
@@ -19,11 +20,18 @@ type Conditioned interface {
 	GetCondition(string) *metav1.Condition
 }
 
-// A ConditionedWithType may have conditions set or retrieved based on agent type. Conditions typically
+// A V1alpha1ConditionedWithType may have conditions set or retrieved based on agent type. Conditions typically
 // indicate the status of both a resource and its reconciliation process.
-type ConditionedWithType interface {
+type V1alpha1ConditionedWithType interface {
 	SetConditionsWithType(fleetv1alpha1.AgentType, ...metav1.Condition)
 	GetConditionWithType(fleetv1alpha1.AgentType, string) *metav1.Condition
+}
+
+// A V1beta1ConditionedWithType may have conditions set or retrieved based on agent type. Conditions typically
+// indicate the status of both a resource and its reconciliation process.
+type V1beta1ConditionedWithType interface {
+	SetConditionsWithType(fleetv1beta1.AgentType, ...metav1.Condition)
+	GetConditionWithType(fleetv1beta1.AgentType, string) *metav1.Condition
 }
 
 // A ConditionedObj is for kubernetes resource with conditions.
@@ -32,8 +40,14 @@ type ConditionedObj interface {
 	Conditioned
 }
 
-// A ConditionedAgentObj is for kubernetes resources where multiple agents can set and update conditions within AgentStatus.
-type ConditionedAgentObj interface {
+// A V1alpha1ConditionedAgentObj is for kubernetes resources where multiple agents can set and update conditions within AgentStatus.
+type V1alpha1ConditionedAgentObj interface {
 	client.Object
-	ConditionedWithType
+	V1alpha1ConditionedWithType
+}
+
+// A V1beta11ConditionedAgentObj is for kubernetes resources where multiple agents can set and update conditions within AgentStatus.
+type V1beta11ConditionedAgentObj interface {
+	client.Object
+	V1beta1ConditionedWithType
 }

--- a/cmd/hubagent/main.go
+++ b/cmd/hubagent/main.go
@@ -99,7 +99,7 @@ func main() {
 		Client:                  mgr.GetClient(),
 		NetworkingAgentsEnabled: opts.NetworkingAgentsEnabled,
 	}).SetupWithManager(mgr); err != nil {
-		klog.ErrorS(err, "unable to create controller", "controller", "MemberCluster")
+		klog.ErrorS(err, "unable to create v1alpha1 controller", "controller", "MemberCluster")
 		exitWithErrorFunc()
 	}
 
@@ -107,7 +107,7 @@ func main() {
 		Client:                  mgr.GetClient(),
 		NetworkingAgentsEnabled: opts.NetworkingAgentsEnabled,
 	}).SetupWithManager(mgr); err != nil {
-		klog.ErrorS(err, "unable to create controller", "controller", "MemberCluster")
+		klog.ErrorS(err, "unable to create v1beta1 controller", "controller", "MemberCluster")
 		exitWithErrorFunc()
 	}
 

--- a/cmd/memberagent/main.go
+++ b/cmd/memberagent/main.go
@@ -29,8 +29,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
-	"go.goms.io/fleet/pkg/controllers/internalmembercluster"
+	imcv1alpha1 "go.goms.io/fleet/pkg/controllers/internalmembercluster/v1alpha1"
+	imcv1beta1 "go.goms.io/fleet/pkg/controllers/internalmembercluster/v1beta1"
 	workapi "go.goms.io/fleet/pkg/controllers/work"
 	fleetmetrics "go.goms.io/fleet/pkg/metrics"
 	"go.goms.io/fleet/pkg/utils"
@@ -55,6 +57,7 @@ func init() {
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(fleetv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(fleetv1beta1.AddToScheme(scheme))
 	utilruntime.Must(workv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 
@@ -246,8 +249,12 @@ func Start(ctx context.Context, hubCfg, memberConfig *rest.Config, hubOpts, memb
 		return err
 	}
 
-	if err = internalmembercluster.NewReconciler(hubMgr.GetClient(), memberMgr.GetClient(), workController).SetupWithManager(hubMgr); err != nil {
-		return fmt.Errorf("unable to create controller hub_member: %w", err)
+	if err = imcv1alpha1.NewReconciler(hubMgr.GetClient(), memberMgr.GetClient(), workController).SetupWithManager(hubMgr); err != nil {
+		return fmt.Errorf("unable to create controller v1alpha1 hub_member: %w", err)
+	}
+
+	if err = imcv1beta1.NewReconciler(hubMgr.GetClient(), memberMgr.GetClient(), workController).SetupWithManager(hubMgr); err != nil {
+		return fmt.Errorf("unable to create controller v1beta1 hub_member: %w", err)
 	}
 
 	klog.V(3).InfoS("starting hub manager")

--- a/examples/fleet_v1beta1_membercluster.yaml
+++ b/examples/fleet_v1beta1_membercluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: placement.azure.com/v1beta1
 kind: MemberCluster
 metadata:
-  name: kind-member-testing1
+  name: kind-member-testing
 spec:
   state: Join
   identity:

--- a/pkg/controllers/internalmembercluster/v1alpha1/member_controller.go
+++ b/pkg/controllers/internalmembercluster/v1alpha1/member_controller.go
@@ -1,0 +1,338 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"go.goms.io/fleet/apis"
+	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
+	workapi "go.goms.io/fleet/pkg/controllers/work"
+	"go.goms.io/fleet/pkg/metrics"
+)
+
+// Reconciler reconciles a InternalMemberCluster object in the member cluster.
+type Reconciler struct {
+	hubClient    client.Client
+	memberClient client.Client
+
+	// the join/leave agent maintains the list of controllers in the member cluster
+	// so that it can make sure that all the agents on the member cluster have joined/left
+	// before updating the internal member cluster CR status
+	workController *workapi.ApplyWorkReconciler
+
+	recorder record.EventRecorder
+}
+
+const (
+	eventReasonInternalMemberClusterHealthy       = "InternalMemberClusterHealthy"
+	eventReasonInternalMemberClusterUnhealthy     = "InternalMemberClusterUnhealthy"
+	eventReasonInternalMemberClusterJoined        = "InternalMemberClusterJoined"
+	eventReasonInternalMemberClusterFailedToJoin  = "InternalMemberClusterFailedToJoin"
+	eventReasonInternalMemberClusterFailedToLeave = "InternalMemberClusterFailedToLeave"
+	eventReasonInternalMemberClusterLeft          = "InternalMemberClusterLeft"
+
+	// we add +-5% jitter
+	jitterPercent = 10
+)
+
+// NewReconciler creates a new reconciler for the internalMemberCluster CR
+func NewReconciler(hubClient client.Client, memberClient client.Client, workController *workapi.ApplyWorkReconciler) *Reconciler {
+	return &Reconciler{
+		hubClient:      hubClient,
+		memberClient:   memberClient,
+		workController: workController,
+	}
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(2).InfoS("Reconcile", "InternalMemberCluster", req.NamespacedName)
+
+	var imc fleetv1alpha1.InternalMemberCluster
+	if err := r.hubClient.Get(ctx, req.NamespacedName, &imc); err != nil {
+		klog.ErrorS(err, "failed to get internal member cluster: %s", req.NamespacedName)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	switch imc.Spec.State {
+	case fleetv1alpha1.ClusterStateJoin:
+		if err := r.startAgents(ctx, &imc); err != nil {
+			return ctrl.Result{}, err
+		}
+		updateMemberAgentHeartBeat(&imc)
+		updateHealthErr := r.updateHealth(ctx, &imc)
+		r.markInternalMemberClusterJoined(&imc)
+		if err := r.updateInternalMemberClusterWithRetry(ctx, &imc); err != nil {
+			if apierrors.IsConflict(err) {
+				klog.V(2).InfoS("failed to update status due to conflicts", "imc", klog.KObj(&imc))
+			} else {
+				klog.ErrorS(err, "failed to update status", "imc", klog.KObj(&imc))
+			}
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		if updateHealthErr != nil {
+			klog.ErrorS(updateHealthErr, "failed to update health", "imc", klog.KObj(&imc))
+			return ctrl.Result{}, updateHealthErr
+		}
+		// add jitter to the heart beat to mitigate the herding of multiple agents
+		hbinterval := 1000 * imc.Spec.HeartbeatPeriodSeconds
+		jitterRange := int64(hbinterval*jitterPercent) / 100
+		return ctrl.Result{RequeueAfter: time.Millisecond *
+			(time.Duration(hbinterval) + time.Duration(utilrand.Int63nRange(0, jitterRange)-jitterRange/2))}, nil
+
+	case fleetv1alpha1.ClusterStateLeave:
+		if err := r.stopAgents(ctx, &imc); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.markInternalMemberClusterLeft(&imc)
+		if err := r.updateInternalMemberClusterWithRetry(ctx, &imc); err != nil {
+			if apierrors.IsConflict(err) {
+				klog.V(2).InfoS("failed to update status due to conflicts", "imc", klog.KObj(&imc))
+			} else {
+				klog.ErrorS(err, "failed to update status", "imc", klog.KObj(&imc))
+			}
+			return ctrl.Result{}, client.IgnoreNotFound(err)
+		}
+		return ctrl.Result{}, nil
+
+	default:
+		klog.Errorf("encountered a fatal error. unknown state %v in InternalMemberCluster: %s", imc.Spec.State, req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+}
+
+// startAgents start all the member agents running on the member cluster
+func (r *Reconciler) startAgents(ctx context.Context, imc *fleetv1alpha1.InternalMemberCluster) error {
+	// TODO: handle all the controllers uniformly if we have more
+	if err := r.workController.Join(ctx); err != nil {
+		r.markInternalMemberClusterJoinFailed(imc, err)
+		// ignore the update error since we will return an error anyway
+		_ = r.updateInternalMemberClusterWithRetry(ctx, imc)
+		return err
+	}
+	return nil
+}
+
+// stopAgents stops all the member agents running on the member cluster
+func (r *Reconciler) stopAgents(ctx context.Context, imc *fleetv1alpha1.InternalMemberCluster) error {
+	// TODO: handle all the controllers uniformly if we have more
+	if err := r.workController.Leave(ctx); err != nil {
+		r.markInternalMemberClusterLeaveFailed(imc, err)
+		// ignore the update error since we will return an error anyway
+		_ = r.updateInternalMemberClusterWithRetry(ctx, imc)
+		return err
+	}
+	return nil
+}
+
+// updateHealth collects and updates member cluster resource stats and set ConditionTypeInternalMemberClusterHealth.
+func (r *Reconciler) updateHealth(ctx context.Context, imc *fleetv1alpha1.InternalMemberCluster) error {
+	klog.V(2).InfoS("updateHealth", "InternalMemberCluster", klog.KObj(imc))
+
+	if err := r.updateResourceStats(ctx, imc); err != nil {
+		r.markInternalMemberClusterUnhealthy(imc, fmt.Errorf("failed to update resource stats %s: %w", klog.KObj(imc), err))
+		return err
+	}
+
+	r.markInternalMemberClusterHealthy(imc)
+	return nil
+}
+
+// updateResourceStats collects and updates resource usage stats of the member cluster.
+func (r *Reconciler) updateResourceStats(ctx context.Context, imc *fleetv1alpha1.InternalMemberCluster) error {
+	klog.V(2).InfoS("updateResourceStats", "InternalMemberCluster", klog.KObj(imc))
+	var nodes corev1.NodeList
+	if err := r.memberClient.List(ctx, &nodes); err != nil {
+		return fmt.Errorf("failed to list nodes for member cluster %s: %w", klog.KObj(imc), err)
+	}
+
+	var capacityCPU, capacityMemory, allocatableCPU, allocatableMemory resource.Quantity
+
+	for _, node := range nodes.Items {
+		capacityCPU.Add(*(node.Status.Capacity.Cpu()))
+		capacityMemory.Add(*(node.Status.Capacity.Memory()))
+		allocatableCPU.Add(*(node.Status.Allocatable.Cpu()))
+		allocatableMemory.Add(*(node.Status.Allocatable.Memory()))
+	}
+
+	imc.Status.ResourceUsage.Capacity = corev1.ResourceList{
+		corev1.ResourceCPU:    capacityCPU,
+		corev1.ResourceMemory: capacityMemory,
+	}
+	imc.Status.ResourceUsage.Allocatable = corev1.ResourceList{
+		corev1.ResourceCPU:    allocatableCPU,
+		corev1.ResourceMemory: allocatableMemory,
+	}
+	imc.Status.ResourceUsage.ObservationTime = metav1.Now()
+
+	return nil
+}
+
+// updateInternalMemberClusterWithRetry updates InternalMemberCluster status.
+func (r *Reconciler) updateInternalMemberClusterWithRetry(ctx context.Context, imc *fleetv1alpha1.InternalMemberCluster) error {
+	klog.V(2).InfoS("updateInternalMemberClusterWithRetry", "InternalMemberCluster", klog.KObj(imc))
+	backOffPeriod := retry.DefaultBackoff
+	backOffPeriod.Cap = time.Second * time.Duration(imc.Spec.HeartbeatPeriodSeconds)
+
+	return retry.OnError(backOffPeriod,
+		func(err error) bool {
+			return apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err)
+		},
+		func() error {
+			return r.hubClient.Status().Update(ctx, imc)
+		})
+}
+
+// updateMemberAgentHeartBeat is used to update member agent heart beat for Internal member cluster.
+func updateMemberAgentHeartBeat(imc *fleetv1alpha1.InternalMemberCluster) {
+	klog.V(2).InfoS("update Internal member cluster heartbeat", "InternalMemberCluster", klog.KObj(imc))
+	desiredAgentStatus := imc.GetAgentStatus(fleetv1alpha1.MemberAgent)
+	if desiredAgentStatus != nil {
+		desiredAgentStatus.LastReceivedHeartbeat = metav1.Now()
+	}
+}
+
+func (r *Reconciler) markInternalMemberClusterHealthy(imc apis.V1alpha1ConditionedAgentObj) {
+	klog.V(2).InfoS("markInternalMemberClusterHealthy", "InternalMemberCluster", klog.KObj(imc))
+	newCondition := metav1.Condition{
+		Type:               string(fleetv1alpha1.AgentHealthy),
+		Status:             metav1.ConditionTrue,
+		Reason:             eventReasonInternalMemberClusterHealthy,
+		ObservedGeneration: imc.GetGeneration(),
+	}
+
+	// Healthy status changed.
+	existingCondition := imc.GetConditionWithType(fleetv1alpha1.MemberAgent, newCondition.Type)
+	if existingCondition == nil || existingCondition.Status != newCondition.Status {
+		klog.V(2).InfoS("healthy", "InternalMemberCluster", klog.KObj(imc))
+		r.recorder.Event(imc, corev1.EventTypeNormal, eventReasonInternalMemberClusterHealthy, "internal member cluster healthy")
+	}
+
+	imc.SetConditionsWithType(fleetv1alpha1.MemberAgent, newCondition)
+}
+
+func (r *Reconciler) markInternalMemberClusterUnhealthy(imc apis.V1alpha1ConditionedAgentObj, err error) {
+	klog.V(2).InfoS("markInternalMemberClusterUnhealthy", "InternalMemberCluster", klog.KObj(imc))
+	newCondition := metav1.Condition{
+		Type:               string(fleetv1alpha1.AgentHealthy),
+		Status:             metav1.ConditionFalse,
+		Reason:             eventReasonInternalMemberClusterUnhealthy,
+		Message:            err.Error(),
+		ObservedGeneration: imc.GetGeneration(),
+	}
+
+	// Healthy status changed.
+	existingCondition := imc.GetConditionWithType(fleetv1alpha1.MemberAgent, newCondition.Type)
+	if existingCondition == nil || existingCondition.Status != newCondition.Status {
+		klog.V(2).InfoS("unhealthy", "InternalMemberCluster", klog.KObj(imc))
+		r.recorder.Event(imc, corev1.EventTypeWarning, eventReasonInternalMemberClusterUnhealthy, "internal member cluster unhealthy")
+	}
+
+	imc.SetConditionsWithType(fleetv1alpha1.MemberAgent, newCondition)
+}
+
+func (r *Reconciler) markInternalMemberClusterJoined(imc apis.V1alpha1ConditionedAgentObj) {
+	klog.V(2).InfoS("markInternalMemberClusterJoined", "InternalMemberCluster", klog.KObj(imc))
+	newCondition := metav1.Condition{
+		Type:               string(fleetv1alpha1.AgentJoined),
+		Status:             metav1.ConditionTrue,
+		Reason:             eventReasonInternalMemberClusterJoined,
+		ObservedGeneration: imc.GetGeneration(),
+	}
+
+	// Joined status changed.
+	existingCondition := imc.GetConditionWithType(fleetv1alpha1.MemberAgent, newCondition.Type)
+	if existingCondition == nil || existingCondition.ObservedGeneration != imc.GetGeneration() || existingCondition.Status != newCondition.Status {
+		r.recorder.Event(imc, corev1.EventTypeNormal, eventReasonInternalMemberClusterJoined, "internal member cluster joined")
+		klog.V(2).InfoS("joined", "InternalMemberCluster", klog.KObj(imc))
+		metrics.ReportJoinResultMetric()
+	}
+
+	imc.SetConditionsWithType(fleetv1alpha1.MemberAgent, newCondition)
+}
+
+func (r *Reconciler) markInternalMemberClusterJoinFailed(imc apis.V1alpha1ConditionedAgentObj, err error) {
+	klog.V(2).InfoS("markInternalMemberCluster join failed", "error", err, "InternalMemberCluster", klog.KObj(imc))
+	newCondition := metav1.Condition{
+		Type:               string(fleetv1alpha1.AgentJoined),
+		Status:             metav1.ConditionUnknown,
+		Reason:             eventReasonInternalMemberClusterFailedToJoin,
+		Message:            err.Error(),
+		ObservedGeneration: imc.GetGeneration(),
+	}
+
+	// Joined status changed.
+	existingCondition := imc.GetConditionWithType(fleetv1alpha1.MemberAgent, newCondition.Type)
+	if existingCondition == nil || existingCondition.ObservedGeneration != imc.GetGeneration() || existingCondition.Status != newCondition.Status {
+		r.recorder.Event(imc, corev1.EventTypeNormal, eventReasonInternalMemberClusterFailedToJoin, "internal member cluster failed to join")
+		klog.ErrorS(err, "agent join failed", "InternalMemberCluster", klog.KObj(imc))
+	}
+
+	imc.SetConditionsWithType(fleetv1alpha1.MemberAgent, newCondition)
+}
+
+func (r *Reconciler) markInternalMemberClusterLeft(imc apis.V1alpha1ConditionedAgentObj) {
+	klog.V(2).InfoS("markInternalMemberClusterLeft", "InternalMemberCluster", klog.KObj(imc))
+	newCondition := metav1.Condition{
+		Type:               string(fleetv1alpha1.AgentJoined),
+		Status:             metav1.ConditionFalse,
+		Reason:             eventReasonInternalMemberClusterLeft,
+		ObservedGeneration: imc.GetGeneration(),
+	}
+
+	// Joined status changed.
+	existingCondition := imc.GetConditionWithType(fleetv1alpha1.MemberAgent, newCondition.Type)
+	if existingCondition == nil || existingCondition.ObservedGeneration != imc.GetGeneration() || existingCondition.Status != newCondition.Status {
+		r.recorder.Event(imc, corev1.EventTypeNormal, eventReasonInternalMemberClusterLeft, "internal member cluster left")
+		klog.V(2).InfoS("left", "InternalMemberCluster", klog.KObj(imc))
+		metrics.ReportLeaveResultMetric()
+	}
+
+	imc.SetConditionsWithType(fleetv1alpha1.MemberAgent, newCondition)
+}
+
+func (r *Reconciler) markInternalMemberClusterLeaveFailed(imc apis.V1alpha1ConditionedAgentObj, err error) {
+	klog.V(2).InfoS("markInternalMemberCluster leave failed", "error", err, "InternalMemberCluster", klog.KObj(imc))
+	newCondition := metav1.Condition{
+		Type:               string(fleetv1alpha1.AgentJoined),
+		Status:             metav1.ConditionUnknown,
+		Reason:             eventReasonInternalMemberClusterFailedToLeave,
+		Message:            err.Error(),
+		ObservedGeneration: imc.GetGeneration(),
+	}
+
+	// Joined status changed.
+	existingCondition := imc.GetConditionWithType(fleetv1alpha1.MemberAgent, newCondition.Type)
+	if existingCondition == nil || existingCondition.ObservedGeneration != imc.GetGeneration() || existingCondition.Status != newCondition.Status {
+		r.recorder.Event(imc, corev1.EventTypeNormal, eventReasonInternalMemberClusterFailedToLeave, "internal member cluster failed to leave")
+		klog.ErrorS(err, "agent leave failed", "InternalMemberCluster", klog.KObj(imc))
+	}
+
+	imc.SetConditionsWithType(fleetv1alpha1.MemberAgent, newCondition)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.recorder = mgr.GetEventRecorderFor("v1alpha1InternalMemberClusterController")
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&fleetv1alpha1.InternalMemberCluster{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Complete(r)
+}

--- a/pkg/controllers/internalmembercluster/v1alpha1/member_controller_integration_test.go
+++ b/pkg/controllers/internalmembercluster/v1alpha1/member_controller_integration_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+package v1alpha1
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
+	workapi "go.goms.io/fleet/pkg/controllers/work"
+	"go.goms.io/fleet/pkg/utils"
+)
+
+var _ = Describe("Test Internal Member Cluster Controller", func() {
+	var (
+		ctx                         context.Context
+		HBPeriod                    int
+		memberClusterName           string
+		memberClusterNamespace      string
+		memberClusterNamespacedName types.NamespacedName
+		nodes                       corev1.NodeList
+		r                           *Reconciler
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		HBPeriod = int(utils.RandSecureInt(600))
+		memberClusterName = "rand-" + strings.ToLower(utils.RandStr()) + "-mc"
+		memberClusterNamespace = "fleet-" + memberClusterName
+		memberClusterNamespacedName = types.NamespacedName{
+			Name:      memberClusterName,
+			Namespace: memberClusterNamespace,
+		}
+
+		By("create the member cluster namespace")
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: memberClusterNamespace,
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ns)).Should(Succeed())
+
+		By("creating member cluster nodes")
+		nodes = corev1.NodeList{Items: utils.NewTestNodes(memberClusterNamespace)}
+		for _, node := range nodes.Items {
+			node := node // prevent Implicit memory aliasing in for loop
+			Expect(k8sClient.Create(ctx, &node)).Should(Succeed())
+		}
+
+		By("create the internalMemberCluster reconciler")
+		workController := workapi.NewApplyWorkReconciler(
+			k8sClient, nil, k8sClient, nil, nil, 5, memberClusterNamespace)
+		r = NewReconciler(k8sClient, k8sClient, workController)
+		err := r.SetupWithManager(mgr)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By("delete member cluster namespace")
+		ns := corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: memberClusterNamespace,
+			},
+		}
+		Expect(k8sClient.Delete(ctx, &ns)).Should(Succeed())
+
+		By("delete member cluster nodes")
+		for _, node := range nodes.Items {
+			node := node
+			Expect(k8sClient.Delete(ctx, &node)).Should(Succeed())
+		}
+
+		By("delete member cluster")
+		internalMemberCluster := fleetv1alpha1.InternalMemberCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      memberClusterName,
+				Namespace: memberClusterNamespace,
+			},
+		}
+		Expect(k8sClient.Delete(ctx, &internalMemberCluster)).Should(SatisfyAny(Succeed(), &utils.NotFoundMatcher{}))
+	})
+
+	Context("join", func() {
+		BeforeEach(func() {
+			internalMemberCluster := fleetv1alpha1.InternalMemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      memberClusterName,
+					Namespace: memberClusterNamespace,
+				},
+				Spec: fleetv1alpha1.InternalMemberClusterSpec{
+					State:                  fleetv1alpha1.ClusterStateJoin,
+					HeartbeatPeriodSeconds: int32(HBPeriod),
+				},
+			}
+			Expect(k8sClient.Create(ctx, &internalMemberCluster)).Should(Succeed())
+		})
+
+		It("should update internalMemberCluster to joined", func() {
+			result, err := r.Reconcile(ctx, ctrl.Request{
+				NamespacedName: memberClusterNamespacedName,
+			})
+			// take into account the +- jitter
+			Expect(result.RequeueAfter.Milliseconds() < (1000+1000*jitterPercent/2/100)*time.Millisecond.Milliseconds()*int64(HBPeriod)).Should(BeTrue())
+			Expect(result.RequeueAfter.Milliseconds() > (1000-1000*jitterPercent/2/100)*time.Millisecond.Milliseconds()*int64(HBPeriod)).Should(BeTrue())
+			Expect(err).Should(Not(HaveOccurred()))
+
+			var imc fleetv1alpha1.InternalMemberCluster
+			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &imc)).Should(Succeed())
+
+			By("checking updated join condition")
+			updatedJoinedCond := imc.GetConditionWithType(fleetv1alpha1.MemberAgent, string(fleetv1alpha1.AgentJoined))
+			Expect(updatedJoinedCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(updatedJoinedCond.Reason).To(Equal(eventReasonInternalMemberClusterJoined))
+
+			By("checking updated heartbeat condition")
+			agentStatus := imc.Status.AgentStatus[0]
+			Expect(agentStatus.LastReceivedHeartbeat).ToNot(Equal(metav1.Now()))
+
+			By("checking updated health condition")
+			updatedHealthCond := imc.GetConditionWithType(fleetv1alpha1.MemberAgent, string(fleetv1alpha1.AgentHealthy))
+			Expect(updatedHealthCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(updatedHealthCond.Reason).To(Equal(eventReasonInternalMemberClusterHealthy))
+
+			By("checking updated member cluster usage")
+			Expect(imc.Status.ResourceUsage.Allocatable).ShouldNot(BeNil())
+			Expect(imc.Status.ResourceUsage.Capacity).ShouldNot(BeNil())
+			Expect(imc.Status.ResourceUsage.ObservationTime).ToNot(Equal(metav1.Now()))
+		})
+
+		It("last received heart beat gets updated after heartbeat", func() {
+			result, err := r.Reconcile(ctx, ctrl.Request{
+				NamespacedName: memberClusterNamespacedName,
+			})
+			// take into account the +- jitter
+			Expect(result.RequeueAfter.Milliseconds() < (1000+1000*jitterPercent/2/100)*time.Millisecond.Milliseconds()*int64(HBPeriod)).Should(BeTrue())
+			Expect(result.RequeueAfter.Milliseconds() > (1000-1000*jitterPercent/2/100)*time.Millisecond.Milliseconds()*int64(HBPeriod)).Should(BeTrue())
+			Expect(err).Should(Not(HaveOccurred()))
+
+			var imc fleetv1alpha1.InternalMemberCluster
+			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &imc)).Should(Succeed())
+
+			memberAgentStatus := imc.GetAgentStatus(fleetv1alpha1.MemberAgent)
+			lastReceivedHeartbeat := memberAgentStatus.LastReceivedHeartbeat
+
+			time.Sleep(time.Second)
+
+			By("trigger reconcile which should update last received heart beat time")
+			result, err = r.Reconcile(ctx, ctrl.Request{
+				NamespacedName: memberClusterNamespacedName,
+			})
+			// take into account the +- jitter
+			Expect(result.RequeueAfter.Milliseconds() < (1000+1000*jitterPercent/2/100)*time.Millisecond.Milliseconds()*int64(HBPeriod)).Should(BeTrue())
+			Expect(result.RequeueAfter.Milliseconds() > (1000-1000*jitterPercent/2/100)*time.Millisecond.Milliseconds()*int64(HBPeriod)).Should(BeTrue())
+			Expect(err).Should(Not(HaveOccurred()))
+			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &imc)).Should(Succeed())
+			Expect(lastReceivedHeartbeat).ShouldNot(Equal(imc.Status.AgentStatus[0].LastReceivedHeartbeat))
+		})
+	})
+
+	Context("leave", func() {
+		BeforeEach(func() {
+			By("create internalMemberCluster CR")
+			internalMemberCluster := fleetv1alpha1.InternalMemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      memberClusterName,
+					Namespace: memberClusterNamespace,
+				},
+				Spec: fleetv1alpha1.InternalMemberClusterSpec{
+					State:                  fleetv1alpha1.ClusterStateLeave,
+					HeartbeatPeriodSeconds: int32(HBPeriod),
+				},
+			}
+			Expect(k8sClient.Create(ctx, &internalMemberCluster)).Should(Succeed())
+
+			By("update internalMemberCluster CR with random usage status")
+			internalMemberCluster.Status = fleetv1alpha1.InternalMemberClusterStatus{
+				ResourceUsage: fleetv1alpha1.ResourceUsage{
+					Capacity:        utils.NewResourceList(),
+					Allocatable:     utils.NewResourceList(),
+					ObservationTime: metav1.Now(),
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, &internalMemberCluster)).Should(Succeed())
+		})
+
+		It("should update internalMemberCluster to Left", func() {
+			result, err := r.Reconcile(ctx, ctrl.Request{
+				NamespacedName: memberClusterNamespacedName,
+			})
+			Expect(result).Should(Equal(ctrl.Result{}))
+			Expect(err).Should(Not(HaveOccurred()))
+
+			var internalMemberCluster fleetv1alpha1.InternalMemberCluster
+			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &internalMemberCluster)).Should(Succeed())
+
+			By("checking updated join condition")
+			updatedJoinedCond := internalMemberCluster.GetConditionWithType(fleetv1alpha1.MemberAgent, string(fleetv1alpha1.AgentJoined))
+			Expect(updatedJoinedCond.Status).Should(Equal(metav1.ConditionFalse))
+			Expect(updatedJoinedCond.Reason).Should(Equal(eventReasonInternalMemberClusterLeft))
+		})
+	})
+})

--- a/pkg/controllers/internalmembercluster/v1alpha1/member_controller_test.go
+++ b/pkg/controllers/internalmembercluster/v1alpha1/member_controller_test.go
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
 
-package internalmembercluster
+package v1alpha1
 
 import (
 	"context"
@@ -23,13 +23,13 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"go.goms.io/fleet/apis/v1alpha1"
+	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
 	"go.goms.io/fleet/pkg/utils"
 )
 
 func TestMarkInternalMemberClusterJoined(t *testing.T) {
 	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
-	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+	internalMemberCluster := &fleetv1alpha1.InternalMemberCluster{}
 
 	r.markInternalMemberClusterJoined(internalMemberCluster)
 
@@ -39,14 +39,14 @@ func TestMarkInternalMemberClusterJoined(t *testing.T) {
 	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterJoined")
 
 	// Check expected condition.
-	expectedCondition := metav1.Condition{Type: string(v1alpha1.AgentJoined), Status: metav1.ConditionTrue, Reason: eventReasonInternalMemberClusterJoined}
-	actualCondition := internalMemberCluster.GetConditionWithType(v1alpha1.MemberAgent, expectedCondition.Type)
+	expectedCondition := metav1.Condition{Type: string(fleetv1alpha1.AgentJoined), Status: metav1.ConditionTrue, Reason: eventReasonInternalMemberClusterJoined}
+	actualCondition := internalMemberCluster.GetConditionWithType(fleetv1alpha1.MemberAgent, expectedCondition.Type)
 	assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterJoined")
 }
 
 func TestMarkInternalMemberClusterLeft(t *testing.T) {
 	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
-	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+	internalMemberCluster := &fleetv1alpha1.InternalMemberCluster{}
 
 	r.markInternalMemberClusterLeft(internalMemberCluster)
 
@@ -56,13 +56,13 @@ func TestMarkInternalMemberClusterLeft(t *testing.T) {
 	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterLeft")
 
 	// Check expected conditions.
-	expectedCondition := metav1.Condition{Type: string(v1alpha1.AgentJoined), Status: metav1.ConditionFalse, Reason: eventReasonInternalMemberClusterLeft}
-	actualCondition := internalMemberCluster.GetConditionWithType(v1alpha1.MemberAgent, expectedCondition.Type)
+	expectedCondition := metav1.Condition{Type: string(fleetv1alpha1.AgentJoined), Status: metav1.ConditionFalse, Reason: eventReasonInternalMemberClusterLeft}
+	actualCondition := internalMemberCluster.GetConditionWithType(fleetv1alpha1.MemberAgent, expectedCondition.Type)
 	assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterLeft")
 }
 
 func TestUpdateMemberAgentHeartBeat(t *testing.T) {
-	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+	internalMemberCluster := &fleetv1alpha1.InternalMemberCluster{}
 
 	updateMemberAgentHeartBeat(internalMemberCluster)
 	lastReceivedHeartBeat := internalMemberCluster.Status.AgentStatus[0].LastReceivedHeartbeat
@@ -75,7 +75,7 @@ func TestUpdateMemberAgentHeartBeat(t *testing.T) {
 
 func TestMarkInternalMemberClusterHealthy(t *testing.T) {
 	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
-	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+	internalMemberCluster := &fleetv1alpha1.InternalMemberCluster{}
 
 	r.markInternalMemberClusterHealthy(internalMemberCluster)
 
@@ -85,13 +85,13 @@ func TestMarkInternalMemberClusterHealthy(t *testing.T) {
 	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterHealthy")
 
 	// Check expected conditions.
-	expectedCondition := metav1.Condition{Type: string(v1alpha1.AgentHealthy), Status: metav1.ConditionTrue, Reason: eventReasonInternalMemberClusterHealthy}
-	actualCondition := internalMemberCluster.GetConditionWithType(v1alpha1.MemberAgent, expectedCondition.Type)
+	expectedCondition := metav1.Condition{Type: string(fleetv1alpha1.AgentHealthy), Status: metav1.ConditionTrue, Reason: eventReasonInternalMemberClusterHealthy}
+	actualCondition := internalMemberCluster.GetConditionWithType(fleetv1alpha1.MemberAgent, expectedCondition.Type)
 	assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterHealthy")
 }
 
 func TestMarkInternalMemberClusterHeartbeatUnhealthy(t *testing.T) {
-	internalMemberCluster := &v1alpha1.InternalMemberCluster{}
+	internalMemberCluster := &fleetv1alpha1.InternalMemberCluster{}
 	err := errors.New("rand-err-msg")
 	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
 
@@ -103,8 +103,8 @@ func TestMarkInternalMemberClusterHeartbeatUnhealthy(t *testing.T) {
 	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterHeartbeatUnhealthy")
 
 	// Check expected conditions.
-	expectedCondition := metav1.Condition{Type: string(v1alpha1.AgentHealthy), Status: metav1.ConditionFalse, Reason: eventReasonInternalMemberClusterUnhealthy, Message: "rand-err-msg"}
-	actualCondition := internalMemberCluster.GetConditionWithType(v1alpha1.MemberAgent, expectedCondition.Type)
+	expectedCondition := metav1.Condition{Type: string(fleetv1alpha1.AgentHealthy), Status: metav1.ConditionFalse, Reason: eventReasonInternalMemberClusterUnhealthy, Message: "rand-err-msg"}
+	actualCondition := internalMemberCluster.GetConditionWithType(fleetv1alpha1.MemberAgent, expectedCondition.Type)
 	assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterHeartbeatUnhealthy")
 }
 
@@ -115,7 +115,7 @@ func TestUpdateInternalMemberClusterWithRetry(t *testing.T) {
 
 	testCases := map[string]struct {
 		r                     *Reconciler
-		internalMemberCluster *v1alpha1.InternalMemberCluster
+		internalMemberCluster *fleetv1alpha1.InternalMemberCluster
 		retries               int
 		wantRetries           int
 		wantErr               error
@@ -126,7 +126,7 @@ func TestUpdateInternalMemberClusterWithRetry(t *testing.T) {
 				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
 					return nil
 				}}},
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{},
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{},
 			wantErr:               nil,
 		},
 		"succeed with retries for retriable errors: TooManyRequests": {
@@ -138,8 +138,8 @@ func TestUpdateInternalMemberClusterWithRetry(t *testing.T) {
 					}
 					return apierrors.NewTooManyRequests("", 0)
 				}}},
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{
-				Spec: v1alpha1.InternalMemberClusterSpec{HeartbeatPeriodSeconds: int32(3)},
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{
+				Spec: fleetv1alpha1.InternalMemberClusterSpec{HeartbeatPeriodSeconds: int32(3)},
 			},
 			wantErr: nil,
 		},
@@ -152,7 +152,7 @@ func TestUpdateInternalMemberClusterWithRetry(t *testing.T) {
 					}
 					return apierrors.NewInvalid(schema.GroupKind{}, "", field.ErrorList{})
 				}}},
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{},
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{},
 			wantErr:               apierrors.NewInvalid(schema.GroupKind{}, "", field.ErrorList{}),
 		},
 		"fail if too many retries for retirable errors: TooManyRequests": {
@@ -164,7 +164,7 @@ func TestUpdateInternalMemberClusterWithRetry(t *testing.T) {
 					}
 					return apierrors.NewTooManyRequests("", 0)
 				}}},
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{},
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{},
 			wantErr:               apierrors.NewTooManyRequests("", 0),
 		},
 	}
@@ -179,22 +179,22 @@ func TestUpdateInternalMemberClusterWithRetry(t *testing.T) {
 
 func TestSetConditionWithType(t *testing.T) {
 	testCases := map[string]struct {
-		internalMemberCluster *v1alpha1.InternalMemberCluster
+		internalMemberCluster *fleetv1alpha1.InternalMemberCluster
 		condition             metav1.Condition
-		wantedAgentStatus     *v1alpha1.AgentStatus
+		wantedAgentStatus     *fleetv1alpha1.AgentStatus
 	}{
 		"Agent Status array is empty": {
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{},
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{},
 			condition: metav1.Condition{
-				Type:   string(v1alpha1.AgentJoined),
+				Type:   string(fleetv1alpha1.AgentJoined),
 				Status: metav1.ConditionTrue,
 				Reason: eventReasonInternalMemberClusterJoined,
 			},
-			wantedAgentStatus: &v1alpha1.AgentStatus{
-				Type: v1alpha1.MemberAgent,
+			wantedAgentStatus: &fleetv1alpha1.AgentStatus{
+				Type: fleetv1alpha1.MemberAgent,
 				Conditions: []metav1.Condition{
 					{
-						Type:   string(v1alpha1.AgentJoined),
+						Type:   string(fleetv1alpha1.AgentJoined),
 						Status: metav1.ConditionTrue,
 						Reason: eventReasonInternalMemberClusterJoined,
 					},
@@ -202,26 +202,26 @@ func TestSetConditionWithType(t *testing.T) {
 			},
 		},
 		"Agent Status array is non-empty": {
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{
-				Status: v1alpha1.InternalMemberClusterStatus{
-					AgentStatus: []v1alpha1.AgentStatus{
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{
+				Status: fleetv1alpha1.InternalMemberClusterStatus{
+					AgentStatus: []fleetv1alpha1.AgentStatus{
 						{
-							Type:       v1alpha1.MultiClusterServiceAgent,
+							Type:       fleetv1alpha1.MultiClusterServiceAgent,
 							Conditions: []metav1.Condition{},
 						},
 					},
 				},
 			},
 			condition: metav1.Condition{
-				Type:   string(v1alpha1.AgentJoined),
+				Type:   string(fleetv1alpha1.AgentJoined),
 				Status: metav1.ConditionTrue,
 				Reason: eventReasonInternalMemberClusterJoined,
 			},
-			wantedAgentStatus: &v1alpha1.AgentStatus{
-				Type: v1alpha1.MemberAgent,
+			wantedAgentStatus: &fleetv1alpha1.AgentStatus{
+				Type: fleetv1alpha1.MemberAgent,
 				Conditions: []metav1.Condition{
 					{
-						Type:   string(v1alpha1.AgentJoined),
+						Type:   string(fleetv1alpha1.AgentJoined),
 						Status: metav1.ConditionTrue,
 						Reason: eventReasonInternalMemberClusterJoined,
 					},
@@ -229,14 +229,14 @@ func TestSetConditionWithType(t *testing.T) {
 			},
 		},
 		"Agent Status exists within Internal member cluster": {
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{
-				Status: v1alpha1.InternalMemberClusterStatus{
-					AgentStatus: []v1alpha1.AgentStatus{
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{
+				Status: fleetv1alpha1.InternalMemberClusterStatus{
+					AgentStatus: []fleetv1alpha1.AgentStatus{
 						{
-							Type: v1alpha1.MemberAgent,
+							Type: fleetv1alpha1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(v1alpha1.AgentJoined),
+									Type:   string(fleetv1alpha1.AgentJoined),
 									Status: metav1.ConditionTrue,
 									Reason: eventReasonInternalMemberClusterJoined,
 								},
@@ -246,20 +246,20 @@ func TestSetConditionWithType(t *testing.T) {
 				},
 			},
 			condition: metav1.Condition{
-				Type:   string(v1alpha1.AgentHealthy),
+				Type:   string(fleetv1alpha1.AgentHealthy),
 				Status: metav1.ConditionTrue,
 				Reason: eventReasonInternalMemberClusterHealthy,
 			},
-			wantedAgentStatus: &v1alpha1.AgentStatus{
-				Type: v1alpha1.MemberAgent,
+			wantedAgentStatus: &fleetv1alpha1.AgentStatus{
+				Type: fleetv1alpha1.MemberAgent,
 				Conditions: []metav1.Condition{
 					{
-						Type:   string(v1alpha1.AgentJoined),
+						Type:   string(fleetv1alpha1.AgentJoined),
 						Status: metav1.ConditionTrue,
 						Reason: eventReasonInternalMemberClusterJoined,
 					},
 					{
-						Type:   string(v1alpha1.AgentHealthy),
+						Type:   string(fleetv1alpha1.AgentHealthy),
 						Status: metav1.ConditionTrue,
 						Reason: eventReasonInternalMemberClusterHealthy,
 					},
@@ -270,27 +270,27 @@ func TestSetConditionWithType(t *testing.T) {
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			testCase.internalMemberCluster.SetConditionsWithType(v1alpha1.MemberAgent, testCase.condition)
-			assert.Equal(t, "", cmp.Diff(testCase.wantedAgentStatus, testCase.internalMemberCluster.GetAgentStatus(v1alpha1.MemberAgent), cmpopts.IgnoreTypes(time.Time{})))
+			testCase.internalMemberCluster.SetConditionsWithType(fleetv1alpha1.MemberAgent, testCase.condition)
+			assert.Equal(t, "", cmp.Diff(testCase.wantedAgentStatus, testCase.internalMemberCluster.GetAgentStatus(fleetv1alpha1.MemberAgent), cmpopts.IgnoreTypes(time.Time{})))
 		})
 	}
 }
 
 func TestGetConditionWithType(t *testing.T) {
 	testCases := map[string]struct {
-		internalMemberCluster *v1alpha1.InternalMemberCluster
+		internalMemberCluster *fleetv1alpha1.InternalMemberCluster
 		conditionType         string
 		wantedCondition       *metav1.Condition
 	}{
 		"Condition exists": {
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{
-				Status: v1alpha1.InternalMemberClusterStatus{
-					AgentStatus: []v1alpha1.AgentStatus{
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{
+				Status: fleetv1alpha1.InternalMemberClusterStatus{
+					AgentStatus: []fleetv1alpha1.AgentStatus{
 						{
-							Type: v1alpha1.MemberAgent,
+							Type: fleetv1alpha1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(v1alpha1.ConditionTypeMemberClusterJoined),
+									Type:   string(fleetv1alpha1.ConditionTypeMemberClusterJoined),
 									Status: metav1.ConditionTrue,
 									Reason: eventReasonInternalMemberClusterJoined,
 								},
@@ -299,22 +299,22 @@ func TestGetConditionWithType(t *testing.T) {
 					},
 				},
 			},
-			conditionType: string(v1alpha1.AgentJoined),
+			conditionType: string(fleetv1alpha1.AgentJoined),
 			wantedCondition: &metav1.Condition{
-				Type:   string(v1alpha1.ConditionTypeMemberClusterJoined),
+				Type:   string(fleetv1alpha1.ConditionTypeMemberClusterJoined),
 				Status: metav1.ConditionTrue,
 				Reason: eventReasonInternalMemberClusterJoined,
 			},
 		},
 		"Condition doesn't exist": {
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{
-				Status: v1alpha1.InternalMemberClusterStatus{
-					AgentStatus: []v1alpha1.AgentStatus{
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{
+				Status: fleetv1alpha1.InternalMemberClusterStatus{
+					AgentStatus: []fleetv1alpha1.AgentStatus{
 						{
-							Type: v1alpha1.MemberAgent,
+							Type: fleetv1alpha1.MemberAgent,
 							Conditions: []metav1.Condition{
 								{
-									Type:   string(v1alpha1.ConditionTypeMemberClusterJoined),
+									Type:   string(fleetv1alpha1.ConditionTypeMemberClusterJoined),
 									Status: metav1.ConditionTrue,
 									Reason: eventReasonInternalMemberClusterJoined,
 								},
@@ -323,21 +323,21 @@ func TestGetConditionWithType(t *testing.T) {
 					},
 				},
 			},
-			conditionType:   string(v1alpha1.AgentHealthy),
+			conditionType:   string(fleetv1alpha1.AgentHealthy),
 			wantedCondition: nil,
 		},
 		"Agent Status doesn't exist": {
-			internalMemberCluster: &v1alpha1.InternalMemberCluster{
-				Status: v1alpha1.InternalMemberClusterStatus{},
+			internalMemberCluster: &fleetv1alpha1.InternalMemberCluster{
+				Status: fleetv1alpha1.InternalMemberClusterStatus{},
 			},
-			conditionType:   string(v1alpha1.AgentJoined),
+			conditionType:   string(fleetv1alpha1.AgentJoined),
 			wantedCondition: nil,
 		},
 	}
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			actualCondition := testCase.internalMemberCluster.GetConditionWithType(v1alpha1.MemberAgent, testCase.conditionType)
+			actualCondition := testCase.internalMemberCluster.GetConditionWithType(fleetv1alpha1.MemberAgent, testCase.conditionType)
 			assert.Equal(t, testCase.wantedCondition, actualCondition)
 		})
 	}

--- a/pkg/controllers/internalmembercluster/v1alpha1/member_suite_test.go
+++ b/pkg/controllers/internalmembercluster/v1alpha1/member_suite_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+package v1alpha1
+
+import (
+	"flag"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
+
+	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
+)
+
+var (
+	cfg       *rest.Config
+	mgr       manager.Manager
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
+
+func TestInternalMemberCluster(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Member Cluster Controller Integration Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	done := make(chan interface{})
+	go func() {
+		// GinkgoRecover should be deferred at the top of any spawned goroutine that (may) call `Fail` Since Gomega
+		// assertions call fail, you should throw a `defer GinkgoRecover()` at the top of any goroutine that calls out
+		// to Gomega.
+		// Source: https://pkg.go.dev/github.com/onsi/ginkgo#GinkgoRecover
+		defer GinkgoRecover()
+
+		klog.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+		By("bootstrapping test environment")
+		testEnv = &envtest.Environment{
+			CRDDirectoryPaths:     []string{filepath.Join("../../../../", "config", "crd", "bases")},
+			ErrorIfCRDPathMissing: true,
+		}
+		var err error
+		cfg, err = testEnv.Start()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg).NotTo(BeNil())
+
+		err = fleetv1alpha1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = workv1alpha1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		//+kubebuilder:scaffold:scheme
+		By("construct the k8s client")
+		k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient).NotTo(BeNil())
+
+		By("Starting the controller manager")
+		klog.InitFlags(flag.CommandLine)
+		mgr, err = ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:             scheme.Scheme,
+			MetricsBindAddress: "0",
+			Logger:             klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)),
+			Port:               4848,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		close(done)
+	}()
+	Eventually(done, 60).Should(BeClosed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/pkg/controllers/internalmembercluster/v1beta1/member_controller_integration_test.go
+++ b/pkg/controllers/internalmembercluster/v1beta1/member_controller_integration_test.go
@@ -2,7 +2,7 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
-package internalmembercluster
+package v1beta1
 
 import (
 	"context"
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"go.goms.io/fleet/apis/v1alpha1"
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	workapi "go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/utils"
 )
@@ -81,7 +81,7 @@ var _ = Describe("Test Internal Member Cluster Controller", func() {
 		}
 
 		By("delete member cluster")
-		internalMemberCluster := v1alpha1.InternalMemberCluster{
+		internalMemberCluster := fleetv1beta1.InternalMemberCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      memberClusterName,
 				Namespace: memberClusterNamespace,
@@ -92,13 +92,13 @@ var _ = Describe("Test Internal Member Cluster Controller", func() {
 
 	Context("join", func() {
 		BeforeEach(func() {
-			internalMemberCluster := v1alpha1.InternalMemberCluster{
+			internalMemberCluster := fleetv1beta1.InternalMemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memberClusterName,
 					Namespace: memberClusterNamespace,
 				},
-				Spec: v1alpha1.InternalMemberClusterSpec{
-					State:                  v1alpha1.ClusterStateJoin,
+				Spec: fleetv1beta1.InternalMemberClusterSpec{
+					State:                  fleetv1beta1.ClusterStateJoin,
 					HeartbeatPeriodSeconds: int32(HBPeriod),
 				},
 			}
@@ -114,11 +114,11 @@ var _ = Describe("Test Internal Member Cluster Controller", func() {
 			Expect(result.RequeueAfter.Milliseconds() > (1000-1000*jitterPercent/2/100)*time.Millisecond.Milliseconds()*int64(HBPeriod)).Should(BeTrue())
 			Expect(err).Should(Not(HaveOccurred()))
 
-			var imc v1alpha1.InternalMemberCluster
+			var imc fleetv1beta1.InternalMemberCluster
 			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &imc)).Should(Succeed())
 
 			By("checking updated join condition")
-			updatedJoinedCond := imc.GetConditionWithType(v1alpha1.MemberAgent, string(v1alpha1.AgentJoined))
+			updatedJoinedCond := imc.GetConditionWithType(fleetv1beta1.MemberAgent, string(fleetv1beta1.AgentJoined))
 			Expect(updatedJoinedCond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(updatedJoinedCond.Reason).To(Equal(eventReasonInternalMemberClusterJoined))
 
@@ -127,7 +127,7 @@ var _ = Describe("Test Internal Member Cluster Controller", func() {
 			Expect(agentStatus.LastReceivedHeartbeat).ToNot(Equal(metav1.Now()))
 
 			By("checking updated health condition")
-			updatedHealthCond := imc.GetConditionWithType(v1alpha1.MemberAgent, string(v1alpha1.AgentHealthy))
+			updatedHealthCond := imc.GetConditionWithType(fleetv1beta1.MemberAgent, string(fleetv1beta1.AgentHealthy))
 			Expect(updatedHealthCond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(updatedHealthCond.Reason).To(Equal(eventReasonInternalMemberClusterHealthy))
 
@@ -146,10 +146,10 @@ var _ = Describe("Test Internal Member Cluster Controller", func() {
 			Expect(result.RequeueAfter.Milliseconds() > (1000-1000*jitterPercent/2/100)*time.Millisecond.Milliseconds()*int64(HBPeriod)).Should(BeTrue())
 			Expect(err).Should(Not(HaveOccurred()))
 
-			var imc v1alpha1.InternalMemberCluster
+			var imc fleetv1beta1.InternalMemberCluster
 			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &imc)).Should(Succeed())
 
-			memberAgentStatus := imc.GetAgentStatus(v1alpha1.MemberAgent)
+			memberAgentStatus := imc.GetAgentStatus(fleetv1beta1.MemberAgent)
 			lastReceivedHeartbeat := memberAgentStatus.LastReceivedHeartbeat
 
 			time.Sleep(time.Second)
@@ -170,21 +170,21 @@ var _ = Describe("Test Internal Member Cluster Controller", func() {
 	Context("leave", func() {
 		BeforeEach(func() {
 			By("create internalMemberCluster CR")
-			internalMemberCluster := v1alpha1.InternalMemberCluster{
+			internalMemberCluster := fleetv1beta1.InternalMemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      memberClusterName,
 					Namespace: memberClusterNamespace,
 				},
-				Spec: v1alpha1.InternalMemberClusterSpec{
-					State:                  v1alpha1.ClusterStateLeave,
+				Spec: fleetv1beta1.InternalMemberClusterSpec{
+					State:                  fleetv1beta1.ClusterStateLeave,
 					HeartbeatPeriodSeconds: int32(HBPeriod),
 				},
 			}
 			Expect(k8sClient.Create(ctx, &internalMemberCluster)).Should(Succeed())
 
 			By("update internalMemberCluster CR with random usage status")
-			internalMemberCluster.Status = v1alpha1.InternalMemberClusterStatus{
-				ResourceUsage: v1alpha1.ResourceUsage{
+			internalMemberCluster.Status = fleetv1beta1.InternalMemberClusterStatus{
+				ResourceUsage: fleetv1beta1.ResourceUsage{
 					Capacity:        utils.NewResourceList(),
 					Allocatable:     utils.NewResourceList(),
 					ObservationTime: metav1.Now(),
@@ -200,11 +200,11 @@ var _ = Describe("Test Internal Member Cluster Controller", func() {
 			Expect(result).Should(Equal(ctrl.Result{}))
 			Expect(err).Should(Not(HaveOccurred()))
 
-			var internalMemberCluster v1alpha1.InternalMemberCluster
+			var internalMemberCluster fleetv1beta1.InternalMemberCluster
 			Expect(k8sClient.Get(ctx, memberClusterNamespacedName, &internalMemberCluster)).Should(Succeed())
 
 			By("checking updated join condition")
-			updatedJoinedCond := internalMemberCluster.GetConditionWithType(v1alpha1.MemberAgent, string(v1alpha1.AgentJoined))
+			updatedJoinedCond := internalMemberCluster.GetConditionWithType(fleetv1beta1.MemberAgent, string(fleetv1beta1.AgentJoined))
 			Expect(updatedJoinedCond.Status).Should(Equal(metav1.ConditionFalse))
 			Expect(updatedJoinedCond.Reason).Should(Equal(eventReasonInternalMemberClusterLeft))
 		})

--- a/pkg/controllers/internalmembercluster/v1beta1/member_controller_test.go
+++ b/pkg/controllers/internalmembercluster/v1beta1/member_controller_test.go
@@ -1,0 +1,344 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/utils"
+)
+
+func TestMarkInternalMemberClusterJoined(t *testing.T) {
+	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
+	internalMemberCluster := &fleetv1beta1.InternalMemberCluster{}
+
+	r.markInternalMemberClusterJoined(internalMemberCluster)
+
+	// check that the correct event is emitted
+	event := <-r.recorder.(*record.FakeRecorder).Events
+	expected := utils.GetEventString(internalMemberCluster, corev1.EventTypeNormal, eventReasonInternalMemberClusterJoined, "internal member cluster joined")
+	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterJoined")
+
+	// Check expected condition.
+	expectedCondition := metav1.Condition{Type: string(fleetv1beta1.AgentJoined), Status: metav1.ConditionTrue, Reason: eventReasonInternalMemberClusterJoined}
+	actualCondition := internalMemberCluster.GetConditionWithType(fleetv1beta1.MemberAgent, expectedCondition.Type)
+	assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterJoined")
+}
+
+func TestMarkInternalMemberClusterLeft(t *testing.T) {
+	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
+	internalMemberCluster := &fleetv1beta1.InternalMemberCluster{}
+
+	r.markInternalMemberClusterLeft(internalMemberCluster)
+
+	// check that the correct event is emitted
+	event := <-r.recorder.(*record.FakeRecorder).Events
+	expected := utils.GetEventString(internalMemberCluster, corev1.EventTypeNormal, eventReasonInternalMemberClusterLeft, "internal member cluster left")
+	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterLeft")
+
+	// Check expected conditions.
+	expectedCondition := metav1.Condition{Type: string(fleetv1beta1.AgentJoined), Status: metav1.ConditionFalse, Reason: eventReasonInternalMemberClusterLeft}
+	actualCondition := internalMemberCluster.GetConditionWithType(fleetv1beta1.MemberAgent, expectedCondition.Type)
+	assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterLeft")
+}
+
+func TestUpdateMemberAgentHeartBeat(t *testing.T) {
+	internalMemberCluster := &fleetv1beta1.InternalMemberCluster{}
+
+	updateMemberAgentHeartBeat(internalMemberCluster)
+	lastReceivedHeartBeat := internalMemberCluster.Status.AgentStatus[0].LastReceivedHeartbeat
+	assert.NotNil(t, lastReceivedHeartBeat)
+
+	updateMemberAgentHeartBeat(internalMemberCluster)
+	newLastReceivedHeartBeat := internalMemberCluster.Status.AgentStatus[0].LastReceivedHeartbeat
+	assert.NotEqual(t, lastReceivedHeartBeat, newLastReceivedHeartBeat)
+}
+
+func TestMarkInternalMemberClusterHealthy(t *testing.T) {
+	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
+	internalMemberCluster := &fleetv1beta1.InternalMemberCluster{}
+
+	r.markInternalMemberClusterHealthy(internalMemberCluster)
+
+	// check that the correct event is emitted
+	event := <-r.recorder.(*record.FakeRecorder).Events
+	expected := utils.GetEventString(internalMemberCluster, corev1.EventTypeNormal, eventReasonInternalMemberClusterHealthy, "internal member cluster healthy")
+	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterHealthy")
+
+	// Check expected conditions.
+	expectedCondition := metav1.Condition{Type: string(fleetv1beta1.AgentHealthy), Status: metav1.ConditionTrue, Reason: eventReasonInternalMemberClusterHealthy}
+	actualCondition := internalMemberCluster.GetConditionWithType(fleetv1beta1.MemberAgent, expectedCondition.Type)
+	assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterHealthy")
+}
+
+func TestMarkInternalMemberClusterHeartbeatUnhealthy(t *testing.T) {
+	internalMemberCluster := &fleetv1beta1.InternalMemberCluster{}
+	err := errors.New("rand-err-msg")
+	r := Reconciler{recorder: utils.NewFakeRecorder(1)}
+
+	r.markInternalMemberClusterUnhealthy(internalMemberCluster, err)
+
+	// check that the correct event is emitted
+	event := <-r.recorder.(*record.FakeRecorder).Events
+	expected := utils.GetEventString(internalMemberCluster, corev1.EventTypeWarning, eventReasonInternalMemberClusterUnhealthy, "internal member cluster unhealthy")
+	assert.Equal(t, expected, event, utils.TestCaseMsg, "TestMarkInternalMemberClusterHeartbeatUnhealthy")
+
+	// Check expected conditions.
+	expectedCondition := metav1.Condition{Type: string(fleetv1beta1.AgentHealthy), Status: metav1.ConditionFalse, Reason: eventReasonInternalMemberClusterUnhealthy, Message: "rand-err-msg"}
+	actualCondition := internalMemberCluster.GetConditionWithType(fleetv1beta1.MemberAgent, expectedCondition.Type)
+	assert.Equal(t, "", cmp.Diff(expectedCondition, *(actualCondition), cmpopts.IgnoreTypes(time.Time{})), utils.TestCaseMsg, "TestMarkInternalMemberClusterHeartbeatUnhealthy")
+}
+
+func TestUpdateInternalMemberClusterWithRetry(t *testing.T) {
+	lessRetriesForRetriable := 0
+	lessRetriesForNonRetriable := 0
+	moreRetriesForRetriable := 0
+
+	testCases := map[string]struct {
+		r                     *Reconciler
+		internalMemberCluster *fleetv1beta1.InternalMemberCluster
+		retries               int
+		wantRetries           int
+		wantErr               error
+	}{
+		"succeed without retries if no errors": {
+			retries: 0,
+			r: &Reconciler{hubClient: &test.MockClient{
+				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					return nil
+				}}},
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{},
+			wantErr:               nil,
+		},
+		"succeed with retries for retriable errors: TooManyRequests": {
+			r: &Reconciler{hubClient: &test.MockClient{
+				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					lessRetriesForRetriable++
+					if lessRetriesForRetriable >= 3 {
+						return nil
+					}
+					return apierrors.NewTooManyRequests("", 0)
+				}}},
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{
+				Spec: fleetv1beta1.InternalMemberClusterSpec{HeartbeatPeriodSeconds: int32(3)},
+			},
+			wantErr: nil,
+		},
+		"fail without retries for non-retriable errors: Invalid": {
+			r: &Reconciler{hubClient: &test.MockClient{
+				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					lessRetriesForNonRetriable++
+					if lessRetriesForNonRetriable >= 3 {
+						return nil
+					}
+					return apierrors.NewInvalid(schema.GroupKind{}, "", field.ErrorList{})
+				}}},
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{},
+			wantErr:               apierrors.NewInvalid(schema.GroupKind{}, "", field.ErrorList{}),
+		},
+		"fail if too many retries for retirable errors: TooManyRequests": {
+			r: &Reconciler{hubClient: &test.MockClient{
+				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+					moreRetriesForRetriable++
+					if moreRetriesForRetriable >= 100 {
+						return nil
+					}
+					return apierrors.NewTooManyRequests("", 0)
+				}}},
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{},
+			wantErr:               apierrors.NewTooManyRequests("", 0),
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			err := testCase.r.updateInternalMemberClusterWithRetry(context.Background(), testCase.internalMemberCluster)
+			assert.Equal(t, testCase.wantErr, err, utils.TestCaseMsg, testName)
+		})
+	}
+}
+
+func TestSetConditionWithType(t *testing.T) {
+	testCases := map[string]struct {
+		internalMemberCluster *fleetv1beta1.InternalMemberCluster
+		condition             metav1.Condition
+		wantedAgentStatus     *fleetv1beta1.AgentStatus
+	}{
+		"Agent Status array is empty": {
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{},
+			condition: metav1.Condition{
+				Type:   string(fleetv1beta1.AgentJoined),
+				Status: metav1.ConditionTrue,
+				Reason: eventReasonInternalMemberClusterJoined,
+			},
+			wantedAgentStatus: &fleetv1beta1.AgentStatus{
+				Type: fleetv1beta1.MemberAgent,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(fleetv1beta1.AgentJoined),
+						Status: metav1.ConditionTrue,
+						Reason: eventReasonInternalMemberClusterJoined,
+					},
+				},
+			},
+		},
+		"Agent Status array is non-empty": {
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{
+				Status: fleetv1beta1.InternalMemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type:       fleetv1beta1.MultiClusterServiceAgent,
+							Conditions: []metav1.Condition{},
+						},
+					},
+				},
+			},
+			condition: metav1.Condition{
+				Type:   string(fleetv1beta1.AgentJoined),
+				Status: metav1.ConditionTrue,
+				Reason: eventReasonInternalMemberClusterJoined,
+			},
+			wantedAgentStatus: &fleetv1beta1.AgentStatus{
+				Type: fleetv1beta1.MemberAgent,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(fleetv1beta1.AgentJoined),
+						Status: metav1.ConditionTrue,
+						Reason: eventReasonInternalMemberClusterJoined,
+					},
+				},
+			},
+		},
+		"Agent Status exists within Internal member cluster": {
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{
+				Status: fleetv1beta1.InternalMemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.AgentJoined),
+									Status: metav1.ConditionTrue,
+									Reason: eventReasonInternalMemberClusterJoined,
+								},
+							},
+						},
+					},
+				},
+			},
+			condition: metav1.Condition{
+				Type:   string(fleetv1beta1.AgentHealthy),
+				Status: metav1.ConditionTrue,
+				Reason: eventReasonInternalMemberClusterHealthy,
+			},
+			wantedAgentStatus: &fleetv1beta1.AgentStatus{
+				Type: fleetv1beta1.MemberAgent,
+				Conditions: []metav1.Condition{
+					{
+						Type:   string(fleetv1beta1.AgentJoined),
+						Status: metav1.ConditionTrue,
+						Reason: eventReasonInternalMemberClusterJoined,
+					},
+					{
+						Type:   string(fleetv1beta1.AgentHealthy),
+						Status: metav1.ConditionTrue,
+						Reason: eventReasonInternalMemberClusterHealthy,
+					},
+				},
+			},
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			testCase.internalMemberCluster.SetConditionsWithType(fleetv1beta1.MemberAgent, testCase.condition)
+			assert.Equal(t, "", cmp.Diff(testCase.wantedAgentStatus, testCase.internalMemberCluster.GetAgentStatus(fleetv1beta1.MemberAgent), cmpopts.IgnoreTypes(time.Time{})))
+		})
+	}
+}
+
+func TestGetConditionWithType(t *testing.T) {
+	testCases := map[string]struct {
+		internalMemberCluster *fleetv1beta1.InternalMemberCluster
+		conditionType         string
+		wantedCondition       *metav1.Condition
+	}{
+		"Condition exists": {
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{
+				Status: fleetv1beta1.InternalMemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.ConditionTypeMemberClusterJoined),
+									Status: metav1.ConditionTrue,
+									Reason: eventReasonInternalMemberClusterJoined,
+								},
+							},
+						},
+					},
+				},
+			},
+			conditionType: string(fleetv1beta1.AgentJoined),
+			wantedCondition: &metav1.Condition{
+				Type:   string(fleetv1beta1.ConditionTypeMemberClusterJoined),
+				Status: metav1.ConditionTrue,
+				Reason: eventReasonInternalMemberClusterJoined,
+			},
+		},
+		"Condition doesn't exist": {
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{
+				Status: fleetv1beta1.InternalMemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.ConditionTypeMemberClusterJoined),
+									Status: metav1.ConditionTrue,
+									Reason: eventReasonInternalMemberClusterJoined,
+								},
+							},
+						},
+					},
+				},
+			},
+			conditionType:   string(fleetv1beta1.AgentHealthy),
+			wantedCondition: nil,
+		},
+		"Agent Status doesn't exist": {
+			internalMemberCluster: &fleetv1beta1.InternalMemberCluster{
+				Status: fleetv1beta1.InternalMemberClusterStatus{},
+			},
+			conditionType:   string(fleetv1beta1.AgentJoined),
+			wantedCondition: nil,
+		},
+	}
+
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			actualCondition := testCase.internalMemberCluster.GetConditionWithType(fleetv1beta1.MemberAgent, testCase.conditionType)
+			assert.Equal(t, testCase.wantedCondition, actualCondition)
+		})
+	}
+}

--- a/pkg/controllers/internalmembercluster/v1beta1/member_suite_test.go
+++ b/pkg/controllers/internalmembercluster/v1beta1/member_suite_test.go
@@ -2,7 +2,7 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
-package internalmembercluster
+package v1beta1
 
 import (
 	"flag"
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
-	"go.goms.io/fleet/apis/v1alpha1"
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 )
 
 var (
@@ -50,7 +50,7 @@ var _ = BeforeSuite(func() {
 
 		By("bootstrapping test environment")
 		testEnv = &envtest.Environment{
-			CRDDirectoryPaths:     []string{filepath.Join("../../../", "config", "crd", "bases")},
+			CRDDirectoryPaths:     []string{filepath.Join("../../../../", "config", "crd", "bases")},
 			ErrorIfCRDPathMissing: true,
 		}
 		var err error
@@ -58,7 +58,7 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cfg).NotTo(BeNil())
 
-		err = v1alpha1.AddToScheme(scheme.Scheme)
+		err = fleetv1beta1.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = workv1alpha1.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

![image](https://github.com/Azure/fleet/assets/17449572/9db974f8-776a-4bd3-8f24-0037d4d01bd2)
v1beta1 IMC with status 
![image](https://github.com/Azure/fleet/assets/17449572/dc5242f4-0bc1-4f4a-8c09-8248f9dc1772)


### Special notes for your reviewer

- The assumption from the RP side is that the member agent is installed for a managed cluster that joins the fleet, so when the member agent is installed RP get the associated member cluster CR name and passes it as a ENV variable 
-> Which is use to construct the member cluster namespaces name that gets passed 
-> To the hubOptions which get used to create the hub config for the hub client used by the member agent 
-> Meaning the member agent runs under the assumption that it's targeting one Member cluster CR's namespace. 

- Link: https://github.com/Azure/fleet/blob/main/cmd/memberagent/main.go#L80. But in our case we have two versions of controllers for v1alpha1 & v1beta1 but the caveat is that they can only target member cluster CRs (v1alpha1, v1beta1 CRs) with the same name that's passed when the member agent was installed 

- Another concern is we use the same work controller for both versions of the IMC controllers

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
