### PR TITLE
feat: update cycle state to allow queries for obsolete bindings

### DIFF
--- a/pkg/scheduler/framework/cyclestateutils.go
+++ b/pkg/scheduler/framework/cyclestateutils.go
@@ -9,17 +9,29 @@ import (
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 )
 
-// prepareScheduledOrBoundMap returns a map that allows quick lookup of whether a cluster
+// prepareScheduledOrBoundBindingsMap returns a map that allows quick lookup of whether a cluster
 // already has a binding of the scheduled or bound state relevant to the current scheduling
 // cycle.
-func prepareScheduledOrBoundMap(scheduledOrBoundBindings ...[]*fleetv1beta1.ClusterResourceBinding) map[string]bool {
-	scheduledOrBound := make(map[string]bool)
+func prepareScheduledOrBoundBindingsMap(scheduledOrBoundBindings ...[]*fleetv1beta1.ClusterResourceBinding) map[string]bool {
+	bm := make(map[string]bool)
 
 	for _, bindingSet := range scheduledOrBoundBindings {
 		for _, binding := range bindingSet {
-			scheduledOrBound[binding.Spec.TargetCluster] = true
+			bm[binding.Spec.TargetCluster] = true
 		}
 	}
 
-	return scheduledOrBound
+	return bm
+}
+
+// prepareObsoleteBindingsMap returns a map that allows quick lookup of whether a cluster
+// already has an obsolete binding relevant to the current scheduling cycle.
+func prepareObsoleteBindingsMap(obsoleteBindings []*fleetv1beta1.ClusterResourceBinding) map[string]bool {
+	bm := make(map[string]bool)
+
+	for _, binding := range obsoleteBindings {
+		bm[binding.Spec.TargetCluster] = true
+	}
+
+	return bm
 }

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -256,7 +256,7 @@ func (f *framework) RunSchedulingCycleFor(ctx context.Context, crpName string, p
 	// Note that this state is shared between all plugins and the scheduler framework itself (though some fields are reserved by
 	// the framework). These resevered fields are never accessed concurrently, as each scheduling run has its own cycle and a run
 	// is always executed in one single goroutine; plugin access to the state is guarded by sync.Map.
-	state := NewCycleState(clusters, bound, scheduled)
+	state := NewCycleState(clusters, obsolete, bound, scheduled)
 
 	switch policy.Spec.Policy.PlacementType {
 	case fleetv1beta1.PickAllPlacementType:

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -1100,9 +1100,9 @@ func TestCrossReferencePickedCustersAndObsoleteBindings(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:   int(topologySpreadScore1),
-				AffinityScore:         int(affinityScore1),
-				BoundOrScheduledScore: 1,
+				TopologySpreadScore:       int(topologySpreadScore1),
+				AffinityScore:             int(affinityScore1),
+				PrevBoundOrScheduledScore: 1,
 			},
 		},
 		{
@@ -1112,9 +1112,9 @@ func TestCrossReferencePickedCustersAndObsoleteBindings(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:   int(topologySpreadScore2),
-				AffinityScore:         int(affinityScore2),
-				BoundOrScheduledScore: 0,
+				TopologySpreadScore:       int(topologySpreadScore2),
+				AffinityScore:             int(affinityScore2),
+				PrevBoundOrScheduledScore: 0,
 			},
 		},
 		{
@@ -1124,9 +1124,9 @@ func TestCrossReferencePickedCustersAndObsoleteBindings(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:   int(topologySpreadScore3),
-				AffinityScore:         int(affinityScore3),
-				BoundOrScheduledScore: 1,
+				TopologySpreadScore:       int(topologySpreadScore3),
+				AffinityScore:             int(affinityScore3),
+				PrevBoundOrScheduledScore: 1,
 			},
 		},
 	}
@@ -4178,9 +4178,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:   1,
-				AffinityScore:         20,
-				BoundOrScheduledScore: 0,
+				TopologySpreadScore:       1,
+				AffinityScore:             20,
+				PrevBoundOrScheduledScore: 0,
 			},
 		},
 		{
@@ -4190,9 +4190,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:   2,
-				AffinityScore:         10,
-				BoundOrScheduledScore: 1,
+				TopologySpreadScore:       2,
+				AffinityScore:             10,
+				PrevBoundOrScheduledScore: 1,
 			},
 		},
 	}
@@ -4227,9 +4227,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 						},
 					},
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       2,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
@@ -4239,9 +4239,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 						},
 					},
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         20,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       1,
+						AffinityScore:             20,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 			},
@@ -4258,9 +4258,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 						},
 					},
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       2,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 			},

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -1100,9 +1100,9 @@ func TestCrossReferencePickedCustersAndObsoleteBindings(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:       int(topologySpreadScore1),
-				AffinityScore:             int(affinityScore1),
-				PrevBoundOrScheduledScore: 1,
+				TopologySpreadScore:            int(topologySpreadScore1),
+				AffinityScore:                  int(affinityScore1),
+				ObsoletePlacementAffinityScore: 1,
 			},
 		},
 		{
@@ -1112,9 +1112,9 @@ func TestCrossReferencePickedCustersAndObsoleteBindings(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:       int(topologySpreadScore2),
-				AffinityScore:             int(affinityScore2),
-				PrevBoundOrScheduledScore: 0,
+				TopologySpreadScore:            int(topologySpreadScore2),
+				AffinityScore:                  int(affinityScore2),
+				ObsoletePlacementAffinityScore: 0,
 			},
 		},
 		{
@@ -1124,9 +1124,9 @@ func TestCrossReferencePickedCustersAndObsoleteBindings(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:       int(topologySpreadScore3),
-				AffinityScore:             int(affinityScore3),
-				PrevBoundOrScheduledScore: 1,
+				TopologySpreadScore:            int(topologySpreadScore3),
+				AffinityScore:                  int(affinityScore3),
+				ObsoletePlacementAffinityScore: 1,
 			},
 		},
 	}
@@ -4178,9 +4178,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:       1,
-				AffinityScore:             20,
-				PrevBoundOrScheduledScore: 0,
+				TopologySpreadScore:            1,
+				AffinityScore:                  20,
+				ObsoletePlacementAffinityScore: 0,
 			},
 		},
 		{
@@ -4190,9 +4190,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 				},
 			},
 			Score: &ClusterScore{
-				TopologySpreadScore:       2,
-				AffinityScore:             10,
-				PrevBoundOrScheduledScore: 1,
+				TopologySpreadScore:            2,
+				AffinityScore:                  10,
+				ObsoletePlacementAffinityScore: 1,
 			},
 		},
 	}
@@ -4227,9 +4227,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 						},
 					},
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            2,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
@@ -4239,9 +4239,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 						},
 					},
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             20,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            1,
+						AffinityScore:                  20,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 			},
@@ -4258,9 +4258,9 @@ func TestPickTopNScoredClusters(t *testing.T) {
 						},
 					},
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            2,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 			},

--- a/pkg/scheduler/framework/plugins/clusteraffinity/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/clusteraffinity/filtering_test.go
@@ -240,7 +240,7 @@ func TestPreFilter(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			state := framework.NewCycleState(nil)
+			state := framework.NewCycleState(nil, nil)
 			snapshot := &fleetv1beta1.ClusterSchedulingPolicySnapshot{
 				Spec: fleetv1beta1.SchedulingPolicySnapshotSpec{
 					Policy: tc.policy,
@@ -326,7 +326,7 @@ func TestFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := New()
-			state := framework.NewCycleState(nil)
+			state := framework.NewCycleState(nil, nil)
 			if !tc.notSetPluginState {
 				state.Write(framework.StateKey(p.Name()), tc.ps)
 			}

--- a/pkg/scheduler/framework/plugins/clusteraffinity/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/clusteraffinity/scoring_test.go
@@ -89,7 +89,7 @@ func TestPreScore(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := New()
-			state := framework.NewCycleState(nil)
+			state := framework.NewCycleState(nil, nil)
 			if !tc.notSetPluginState {
 				state.Write(framework.StateKey(p.Name()), tc.ps)
 			}
@@ -164,7 +164,7 @@ func TestPluginScore(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			p := New()
-			state := framework.NewCycleState(nil)
+			state := framework.NewCycleState(nil, nil)
 			if !tc.notSetPluginState {
 				state.Write(framework.StateKey(p.Name()), tc.ps)
 			}

--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/plugin_test.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/plugin_test.go
@@ -311,7 +311,7 @@ func TestPreFilter(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			state := framework.NewCycleState(tc.clusters, tc.bindings)
+			state := framework.NewCycleState(tc.clusters, nil, tc.bindings)
 			status := plugin.PreFilter(ctx, state, tc.policy)
 			// It is safe to compare unexported fields here as the struct is owned by the project.
 			if diff := cmp.Diff(status, tc.wantStatus, cmp.AllowUnexported(framework.Status{}), ignoreStatusErrorField); diff != "" {

--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils.go
@@ -36,7 +36,7 @@ func countByDomain(clusters []fleetv1beta1.MemberCluster, state framework.CycleS
 			counter[name] = 0
 		}
 
-		if state.IsClusterScheduledOrBound(cluster.Name) {
+		if state.HasScheduledOrBoundBindingFor(cluster.Name) {
 			// The cluster under inspection owns a scheduled or bound binding.
 			counter[name] = count + 1
 		}

--- a/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils_test.go
+++ b/pkg/scheduler/framework/plugins/topologyspreadconstraints/utils_test.go
@@ -510,7 +510,7 @@ func TestCountByDomain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			state := framework.NewCycleState(tc.clusters, tc.bindings)
+			state := framework.NewCycleState(tc.clusters, nil, tc.bindings)
 			counter := countByDomain(tc.clusters, state, topologyKey1)
 			if diff := cmp.Diff(counter, tc.wantBindingCounterByDomain, cmp.AllowUnexported(bindingCounterByDomain{})); diff != "" {
 				t.Errorf("countByDomain() diff (-got, +want): %s", diff)
@@ -1602,7 +1602,7 @@ func TestEvaluateAllConstraints(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			state := framework.NewCycleState(tc.clusters, tc.bindings)
+			state := framework.NewCycleState(tc.clusters, nil, tc.bindings)
 
 			violations, scores, err := evaluateAllConstraints(state, tc.doNotSchedule, tc.scheduleAnyway)
 			if err != nil {
@@ -2018,7 +2018,7 @@ func TestPrepareTopologySpreadConstraintsPluginState(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			state := framework.NewCycleState(tc.clusters, tc.bindings)
+			state := framework.NewCycleState(tc.clusters, nil, tc.bindings)
 			genPluginState, err := prepareTopologySpreadConstraintsPluginState(state, tc.policy)
 			if err != nil {
 				t.Fatalf("prepareTopologySpreadConstraintsPluginState() = %v, want no error", err)

--- a/pkg/scheduler/framework/score.go
+++ b/pkg/scheduler/framework/score.go
@@ -17,14 +17,14 @@ type ClusterScore struct {
 	// AffinityScore determines how much a binding would satisfy the affinity terms
 	// specified by the user.
 	AffinityScore int
-	// PrevBoundOrScheduledScore reflects if there has already been an obsolete binding from
+	// ObsoletePlacementAffinityScore reflects if there has already been an obsolete binding from
 	// the same cluster resource placement associated with the cluster; it value range should
 	// be [0, 1], where 1 signals that an obsolete binding is present.
 	//
 	// Note that this score is for internal usage only; it serves the purpose of implementing
 	// a preference for already selected clusters when all the other conditions are the same,
 	// so as to minimize interruption between different scheduling runs.
-	PrevBoundOrScheduledScore int
+	ObsoletePlacementAffinityScore int
 }
 
 // Add adds a ClusterScore to another ClusterScore.
@@ -33,7 +33,7 @@ type ClusterScore struct {
 func (s1 *ClusterScore) Add(s2 *ClusterScore) {
 	s1.TopologySpreadScore += s2.TopologySpreadScore
 	s1.AffinityScore += s2.AffinityScore
-	s1.PrevBoundOrScheduledScore += s2.PrevBoundOrScheduledScore
+	s1.ObsoletePlacementAffinityScore += s2.ObsoletePlacementAffinityScore
 }
 
 // Equal returns true if a ClusterScore is equal to another.
@@ -49,7 +49,7 @@ func (s1 *ClusterScore) Equal(s2 *ClusterScore) bool {
 		// Both are not nils.
 		return s1.TopologySpreadScore == s2.TopologySpreadScore &&
 			s1.AffinityScore == s2.AffinityScore &&
-			s1.PrevBoundOrScheduledScore == s2.PrevBoundOrScheduledScore
+			s1.ObsoletePlacementAffinityScore == s2.ObsoletePlacementAffinityScore
 	}
 }
 
@@ -65,7 +65,7 @@ func (s1 *ClusterScore) Less(s2 *ClusterScore) bool {
 		return s1.AffinityScore < s2.AffinityScore
 	}
 
-	return s1.PrevBoundOrScheduledScore < s2.PrevBoundOrScheduledScore
+	return s1.ObsoletePlacementAffinityScore < s2.ObsoletePlacementAffinityScore
 }
 
 // ScoredCluster is a cluster with a score.

--- a/pkg/scheduler/framework/score.go
+++ b/pkg/scheduler/framework/score.go
@@ -17,14 +17,14 @@ type ClusterScore struct {
 	// AffinityScore determines how much a binding would satisfy the affinity terms
 	// specified by the user.
 	AffinityScore int
-	// BoundOrScheduledScore reflects if there has already been an active/creating binding from
+	// PrevBoundOrScheduledScore reflects if there has already been an obsolete binding from
 	// the same cluster resource placement associated with the cluster; it value range should
-	// be [0, 1], where 1 signals that an active/creating binding is present.
+	// be [0, 1], where 1 signals that an obsolete binding is present.
 	//
 	// Note that this score is for internal usage only; it serves the purpose of implementing
 	// a preference for already selected clusters when all the other conditions are the same,
 	// so as to minimize interruption between different scheduling runs.
-	BoundOrScheduledScore int
+	PrevBoundOrScheduledScore int
 }
 
 // Add adds a ClusterScore to another ClusterScore.
@@ -33,7 +33,7 @@ type ClusterScore struct {
 func (s1 *ClusterScore) Add(s2 *ClusterScore) {
 	s1.TopologySpreadScore += s2.TopologySpreadScore
 	s1.AffinityScore += s2.AffinityScore
-	s1.BoundOrScheduledScore += s2.BoundOrScheduledScore
+	s1.PrevBoundOrScheduledScore += s2.PrevBoundOrScheduledScore
 }
 
 // Equal returns true if a ClusterScore is equal to another.
@@ -49,7 +49,7 @@ func (s1 *ClusterScore) Equal(s2 *ClusterScore) bool {
 		// Both are not nils.
 		return s1.TopologySpreadScore == s2.TopologySpreadScore &&
 			s1.AffinityScore == s2.AffinityScore &&
-			s1.BoundOrScheduledScore == s2.BoundOrScheduledScore
+			s1.PrevBoundOrScheduledScore == s2.PrevBoundOrScheduledScore
 	}
 }
 
@@ -65,7 +65,7 @@ func (s1 *ClusterScore) Less(s2 *ClusterScore) bool {
 		return s1.AffinityScore < s2.AffinityScore
 	}
 
-	return s1.BoundOrScheduledScore < s2.BoundOrScheduledScore
+	return s1.PrevBoundOrScheduledScore < s2.PrevBoundOrScheduledScore
 }
 
 // ScoredCluster is a cluster with a score.

--- a/pkg/scheduler/framework/score_test.go
+++ b/pkg/scheduler/framework/score_test.go
@@ -18,22 +18,22 @@ import (
 // TestClusterScoreToAdd tests the Add() method of ClusterScore.
 func TestClusterScoreAdd(t *testing.T) {
 	s1 := &ClusterScore{
-		TopologySpreadScore:   0,
-		AffinityScore:         0,
-		BoundOrScheduledScore: 0,
+		TopologySpreadScore:       0,
+		AffinityScore:             0,
+		PrevBoundOrScheduledScore: 0,
 	}
 
 	s2 := &ClusterScore{
-		TopologySpreadScore:   1,
-		AffinityScore:         5,
-		BoundOrScheduledScore: 1,
+		TopologySpreadScore:       1,
+		AffinityScore:             5,
+		PrevBoundOrScheduledScore: 1,
 	}
 
 	s1.Add(s2)
 	want := &ClusterScore{
-		TopologySpreadScore:   1,
-		AffinityScore:         5,
-		BoundOrScheduledScore: 1,
+		TopologySpreadScore:       1,
+		AffinityScore:             5,
+		PrevBoundOrScheduledScore: 1,
 	}
 	if diff := cmp.Diff(s1, want); diff != "" {
 		t.Fatalf("Add() diff (-got, +want): %s", diff)
@@ -51,44 +51,44 @@ func TestClusterScoreEqual(t *testing.T) {
 		{
 			name: "s1 is equal to s2",
 			s1: &ClusterScore{
-				TopologySpreadScore:   1,
-				AffinityScore:         5,
-				BoundOrScheduledScore: 1,
+				TopologySpreadScore:       1,
+				AffinityScore:             5,
+				PrevBoundOrScheduledScore: 1,
 			},
 			s2: &ClusterScore{
-				TopologySpreadScore:   1,
-				AffinityScore:         5,
-				BoundOrScheduledScore: 1,
+				TopologySpreadScore:       1,
+				AffinityScore:             5,
+				PrevBoundOrScheduledScore: 1,
 			},
 			want: true,
 		},
 		{
 			name: "s1 is not equal to s2",
 			s1: &ClusterScore{
-				TopologySpreadScore:   2,
-				AffinityScore:         5,
-				BoundOrScheduledScore: 1,
+				TopologySpreadScore:       2,
+				AffinityScore:             5,
+				PrevBoundOrScheduledScore: 1,
 			},
 			s2: &ClusterScore{
-				TopologySpreadScore:   1,
-				AffinityScore:         7,
-				BoundOrScheduledScore: 0,
+				TopologySpreadScore:       1,
+				AffinityScore:             7,
+				PrevBoundOrScheduledScore: 0,
 			},
 		},
 		{
 			name: "s1 is nil",
 			s2: &ClusterScore{
-				TopologySpreadScore:   1,
-				AffinityScore:         7,
-				BoundOrScheduledScore: 0,
+				TopologySpreadScore:       1,
+				AffinityScore:             7,
+				PrevBoundOrScheduledScore: 0,
 			},
 		},
 		{
 			name: "s2 is nil",
 			s1: &ClusterScore{
-				TopologySpreadScore:   2,
-				AffinityScore:         5,
-				BoundOrScheduledScore: 1,
+				TopologySpreadScore:       2,
+				AffinityScore:             5,
+				PrevBoundOrScheduledScore: 1,
 			},
 		},
 		{
@@ -140,14 +140,14 @@ func TestClusterScoreLess(t *testing.T) {
 		{
 			name: "s1 is less than s2 in active or creating binding score",
 			s1: &ClusterScore{
-				TopologySpreadScore:   1,
-				AffinityScore:         10,
-				BoundOrScheduledScore: 0,
+				TopologySpreadScore:       1,
+				AffinityScore:             10,
+				PrevBoundOrScheduledScore: 0,
 			},
 			s2: &ClusterScore{
-				TopologySpreadScore:   1,
-				AffinityScore:         10,
-				BoundOrScheduledScore: 1,
+				TopologySpreadScore:       1,
+				AffinityScore:             10,
+				PrevBoundOrScheduledScore: 1,
 			},
 			want: true,
 		},
@@ -168,15 +168,15 @@ func TestClusterScoreLess(t *testing.T) {
 
 func TestClusterScoreLessWhenEqual(t *testing.T) {
 	s1 := &ClusterScore{
-		TopologySpreadScore:   0,
-		AffinityScore:         0,
-		BoundOrScheduledScore: 0,
+		TopologySpreadScore:       0,
+		AffinityScore:             0,
+		PrevBoundOrScheduledScore: 0,
 	}
 
 	s2 := &ClusterScore{
-		TopologySpreadScore:   0,
-		AffinityScore:         0,
-		BoundOrScheduledScore: 0,
+		TopologySpreadScore:       0,
+		AffinityScore:             0,
+		PrevBoundOrScheduledScore: 0,
 	}
 
 	if s1.Less(s2) || s2.Less(s1) {
@@ -222,41 +222,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       1,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         20,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       1,
+						AffinityScore:             20,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         30,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       2,
+						AffinityScore:             30,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 			},
@@ -264,41 +264,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         30,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       2,
+						AffinityScore:             30,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         20,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       1,
+						AffinityScore:             20,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       1,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 			},
@@ -309,41 +309,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         30,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       2,
+						AffinityScore:             30,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         30,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       2,
+						AffinityScore:             30,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         20,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       1,
+						AffinityScore:             20,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       1,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 			},
@@ -351,41 +351,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         30,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       2,
+						AffinityScore:             30,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         30,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       2,
+						AffinityScore:             30,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         20,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       1,
+						AffinityScore:             20,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       1,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 			},
@@ -396,41 +396,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         20,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       1,
+						AffinityScore:             20,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         30,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       2,
+						AffinityScore:             30,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       1,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 			},
@@ -438,41 +438,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:   2,
-						AffinityScore:         30,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       2,
+						AffinityScore:             30,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         20,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       1,
+						AffinityScore:             20,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:   1,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       1,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 1,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 1,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         10,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       0,
+						AffinityScore:             10,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 			},
@@ -483,17 +483,17 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         0,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       0,
+						AffinityScore:             0,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         0,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       0,
+						AffinityScore:             0,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 			},
@@ -501,17 +501,17 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         0,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       0,
+						AffinityScore:             0,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:   0,
-						AffinityScore:         0,
-						BoundOrScheduledScore: 0,
+						TopologySpreadScore:       0,
+						AffinityScore:             0,
+						PrevBoundOrScheduledScore: 0,
 					},
 				},
 			},

--- a/pkg/scheduler/framework/score_test.go
+++ b/pkg/scheduler/framework/score_test.go
@@ -18,22 +18,22 @@ import (
 // TestClusterScoreToAdd tests the Add() method of ClusterScore.
 func TestClusterScoreAdd(t *testing.T) {
 	s1 := &ClusterScore{
-		TopologySpreadScore:       0,
-		AffinityScore:             0,
-		PrevBoundOrScheduledScore: 0,
+		TopologySpreadScore:            0,
+		AffinityScore:                  0,
+		ObsoletePlacementAffinityScore: 0,
 	}
 
 	s2 := &ClusterScore{
-		TopologySpreadScore:       1,
-		AffinityScore:             5,
-		PrevBoundOrScheduledScore: 1,
+		TopologySpreadScore:            1,
+		AffinityScore:                  5,
+		ObsoletePlacementAffinityScore: 1,
 	}
 
 	s1.Add(s2)
 	want := &ClusterScore{
-		TopologySpreadScore:       1,
-		AffinityScore:             5,
-		PrevBoundOrScheduledScore: 1,
+		TopologySpreadScore:            1,
+		AffinityScore:                  5,
+		ObsoletePlacementAffinityScore: 1,
 	}
 	if diff := cmp.Diff(s1, want); diff != "" {
 		t.Fatalf("Add() diff (-got, +want): %s", diff)
@@ -51,44 +51,44 @@ func TestClusterScoreEqual(t *testing.T) {
 		{
 			name: "s1 is equal to s2",
 			s1: &ClusterScore{
-				TopologySpreadScore:       1,
-				AffinityScore:             5,
-				PrevBoundOrScheduledScore: 1,
+				TopologySpreadScore:            1,
+				AffinityScore:                  5,
+				ObsoletePlacementAffinityScore: 1,
 			},
 			s2: &ClusterScore{
-				TopologySpreadScore:       1,
-				AffinityScore:             5,
-				PrevBoundOrScheduledScore: 1,
+				TopologySpreadScore:            1,
+				AffinityScore:                  5,
+				ObsoletePlacementAffinityScore: 1,
 			},
 			want: true,
 		},
 		{
 			name: "s1 is not equal to s2",
 			s1: &ClusterScore{
-				TopologySpreadScore:       2,
-				AffinityScore:             5,
-				PrevBoundOrScheduledScore: 1,
+				TopologySpreadScore:            2,
+				AffinityScore:                  5,
+				ObsoletePlacementAffinityScore: 1,
 			},
 			s2: &ClusterScore{
-				TopologySpreadScore:       1,
-				AffinityScore:             7,
-				PrevBoundOrScheduledScore: 0,
+				TopologySpreadScore:            1,
+				AffinityScore:                  7,
+				ObsoletePlacementAffinityScore: 0,
 			},
 		},
 		{
 			name: "s1 is nil",
 			s2: &ClusterScore{
-				TopologySpreadScore:       1,
-				AffinityScore:             7,
-				PrevBoundOrScheduledScore: 0,
+				TopologySpreadScore:            1,
+				AffinityScore:                  7,
+				ObsoletePlacementAffinityScore: 0,
 			},
 		},
 		{
 			name: "s2 is nil",
 			s1: &ClusterScore{
-				TopologySpreadScore:       2,
-				AffinityScore:             5,
-				PrevBoundOrScheduledScore: 1,
+				TopologySpreadScore:            2,
+				AffinityScore:                  5,
+				ObsoletePlacementAffinityScore: 1,
 			},
 		},
 		{
@@ -140,14 +140,14 @@ func TestClusterScoreLess(t *testing.T) {
 		{
 			name: "s1 is less than s2 in active or creating binding score",
 			s1: &ClusterScore{
-				TopologySpreadScore:       1,
-				AffinityScore:             10,
-				PrevBoundOrScheduledScore: 0,
+				TopologySpreadScore:            1,
+				AffinityScore:                  10,
+				ObsoletePlacementAffinityScore: 0,
 			},
 			s2: &ClusterScore{
-				TopologySpreadScore:       1,
-				AffinityScore:             10,
-				PrevBoundOrScheduledScore: 1,
+				TopologySpreadScore:            1,
+				AffinityScore:                  10,
+				ObsoletePlacementAffinityScore: 1,
 			},
 			want: true,
 		},
@@ -168,15 +168,15 @@ func TestClusterScoreLess(t *testing.T) {
 
 func TestClusterScoreLessWhenEqual(t *testing.T) {
 	s1 := &ClusterScore{
-		TopologySpreadScore:       0,
-		AffinityScore:             0,
-		PrevBoundOrScheduledScore: 0,
+		TopologySpreadScore:            0,
+		AffinityScore:                  0,
+		ObsoletePlacementAffinityScore: 0,
 	}
 
 	s2 := &ClusterScore{
-		TopologySpreadScore:       0,
-		AffinityScore:             0,
-		PrevBoundOrScheduledScore: 0,
+		TopologySpreadScore:            0,
+		AffinityScore:                  0,
+		ObsoletePlacementAffinityScore: 0,
 	}
 
 	if s1.Less(s2) || s2.Less(s1) {
@@ -222,41 +222,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            1,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             20,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            1,
+						AffinityScore:                  20,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             30,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            2,
+						AffinityScore:                  30,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 			},
@@ -264,41 +264,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             30,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            2,
+						AffinityScore:                  30,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             20,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            1,
+						AffinityScore:                  20,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            1,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 			},
@@ -309,41 +309,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             30,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            2,
+						AffinityScore:                  30,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             30,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            2,
+						AffinityScore:                  30,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             20,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            1,
+						AffinityScore:                  20,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            1,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 			},
@@ -351,41 +351,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             30,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            2,
+						AffinityScore:                  30,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             30,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            2,
+						AffinityScore:                  30,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             20,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            1,
+						AffinityScore:                  20,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            1,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 			},
@@ -396,41 +396,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             20,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            1,
+						AffinityScore:                  20,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             30,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            2,
+						AffinityScore:                  30,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            1,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 			},
@@ -438,41 +438,41 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:       2,
-						AffinityScore:             30,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            2,
+						AffinityScore:                  30,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             20,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            1,
+						AffinityScore:                  20,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterB,
 					Score: &ClusterScore{
-						TopologySpreadScore:       1,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            1,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterE,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 1,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 1,
 					},
 				},
 				{
 					Cluster: clusterA,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             10,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            0,
+						AffinityScore:                  10,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 			},
@@ -483,17 +483,17 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             0,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            0,
+						AffinityScore:                  0,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             0,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            0,
+						AffinityScore:                  0,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 			},
@@ -501,17 +501,17 @@ func TestScoredClustersSort(t *testing.T) {
 				{
 					Cluster: clusterD,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             0,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            0,
+						AffinityScore:                  0,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 				{
 					Cluster: clusterC,
 					Score: &ClusterScore{
-						TopologySpreadScore:       0,
-						AffinityScore:             0,
-						PrevBoundOrScheduledScore: 0,
+						TopologySpreadScore:            0,
+						AffinityScore:                  0,
+						ObsoletePlacementAffinityScore: 0,
 					},
 				},
 			},


### PR DESCRIPTION
### Description of your changes

This PR updates the scheduler cycle state to allow easy queries of obsolete bindings.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests

### Special notes for your reviewer

This PR includes some naming change to better convey the usage; please let me know if the new names are less than ideal.
