### PR TITLE
feat: scheduler (18/): add more scheduler logic

### DIFF
--- a/apis/placement/v1beta1/membercluster_types.go
+++ b/apis/placement/v1beta1/membercluster_types.go
@@ -123,6 +123,27 @@ func (m *MemberCluster) RemoveCondition(conditionType string) {
 	meta.RemoveStatusCondition(&m.Status.Conditions, conditionType)
 }
 
+// GetAgentStatus retrieves the status of a specific member agent from the MemberCluster object.
+//
+// If the specificed agent does not exist, or it has not updated its status with the hub cluster
+// yet, this function returns nil.
+func (m *MemberCluster) GetAgentStatus(agentType AgentType) *AgentStatus {
+	for _, s := range m.Status.AgentStatus {
+		if s.Type == agentType {
+			return &s
+		}
+	}
+	return nil
+}
+
+// GetAgentCondition queries the conditions in an agent status for a specific condition type.
+func (m *MemberCluster) GetAgentCondition(agentType AgentType, conditionType AgentConditionType) *metav1.Condition {
+	if s := m.GetAgentStatus(agentType); s != nil {
+		return meta.FindStatusCondition(s.Conditions, string(conditionType))
+	}
+	return nil
+}
+
 func init() {
 	SchemeBuilder.Register(&MemberCluster{}, &MemberClusterList{})
 }

--- a/pkg/scheduler/clustereligibilitychecker/checker.go
+++ b/pkg/scheduler/clustereligibilitychecker/checker.go
@@ -50,9 +50,9 @@ type checkerOptions struct {
 // Option helps set up the plugin.
 type Option func(*checkerOptions)
 
-// WithClusterHeartbeatTimeout sets the timeout value this plugin uses for checking
+// WithClusterHeartbeatCheckTimeout sets the timeout value this plugin uses for checking
 // if a cluster has been disconnected from the fleet for a prolonged period of time.
-func WithClusterHeartbeatTimeout(timeout time.Duration) Option {
+func WithClusterHeartbeatCheckTimeout(timeout time.Duration) Option {
 	return func(o *checkerOptions) {
 		o.clusterHeartbeatCheckTimeout = timeout
 	}

--- a/pkg/scheduler/clustereligibilitychecker/checker.go
+++ b/pkg/scheduler/clustereligibilitychecker/checker.go
@@ -1,0 +1,150 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+// Package clustereligibilitychecker features a utility for verifying if a member cluster is
+// eligible for resource placement.
+package clustereligibilitychecker
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+const (
+	// defaultClusterHeartbeatTimeout is the default timeout value this checker uses for checking
+	// if a cluster has been disconnected from the fleet for a prolonged period of time.
+	defaultClusterHeartbeatTimeout = time.Minute * 5
+
+	// defaultClusterHealthCheckTimeout is the default timeout value this checker uses for checking
+	// if a cluster is still in a healthy state.
+	defaultClusterHealthCheckTimeout = time.Minute * 5
+)
+
+type ClusterEligibilityChecker struct {
+	// The timeout value this checker uses for checking if a cluster has been disconnected
+	// from the fleet for a prolonged period of time.
+	clusterHeartbeatTimeout time.Duration
+
+	// The timeout value this checker uses for checking if a cluster is still in a healthy state.
+	clusterHealthCheckTimeout time.Duration
+}
+
+// checkerOptions is the options for this checker.
+type checkerOptions struct {
+	// The timeout value this checker uses for checking if a cluster has been disconnected
+	// from the fleet for a prolonged period of time.
+	clusterHeartbeatTimeout time.Duration
+
+	// The timeout value this checker uses for checking if a cluster is still in a healthy state.
+	clusterHealthCheckTimeout time.Duration
+}
+
+// Option helps set up the plugin.
+type Option func(*checkerOptions)
+
+// WithClusterHeartbeatTimeout sets the timeout value this plugin uses for checking
+// if a cluster has been disconnected from the fleet for a prolonged period of time.
+func WithClusterHeartbeatTimeout(timeout time.Duration) Option {
+	return func(o *checkerOptions) {
+		o.clusterHeartbeatTimeout = timeout
+	}
+}
+
+// WithClusterHealthCheckTimeout sets the timeout value this plugin uses for checking
+// if a cluster is still in a healthy state.
+func WithClusterHealthCheckTimeout(timeout time.Duration) Option {
+	return func(o *checkerOptions) {
+		o.clusterHealthCheckTimeout = timeout
+	}
+}
+
+// defaultPluginOptions is the default options for this plugin.
+var defaultCheckerOptions = checkerOptions{
+	clusterHeartbeatTimeout:   defaultClusterHeartbeatTimeout,
+	clusterHealthCheckTimeout: defaultClusterHealthCheckTimeout,
+}
+
+// New returns a new cluster eligibility checker.
+func New(opts ...Option) *ClusterEligibilityChecker {
+	options := defaultCheckerOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return &ClusterEligibilityChecker{
+		clusterHeartbeatTimeout:   options.clusterHeartbeatTimeout,
+		clusterHealthCheckTimeout: options.clusterHealthCheckTimeout,
+	}
+}
+
+// IsEligible returns if a cluster is eligible for resource placement; if not, it will
+// also return the reason.
+func (checker *ClusterEligibilityChecker) IsEligible(cluster *fleetv1beta1.MemberCluster) (eligible bool, reason string) {
+	// Filter out clusters that have left the fleet.
+	if cluster.Spec.State == fleetv1beta1.ClusterStateLeave {
+		return false, "cluster has left the fleet"
+	}
+
+	// Note that the following checks are performed against one specific agent, i.e., the member
+	// agent, which is critical for the work orchestration related tasks in the fleet; non-related
+	// agents (e.g., networking) are not accounted for in this plugin.
+
+	// Filter out clusters that are no longer connected to the fleet, i.e., its heartbeat signals
+	// have stopped for a prolonged period of time.
+	memberAgentStatus := cluster.GetAgentStatus(fleetv1beta1.MemberAgent)
+	if memberAgentStatus == nil {
+		// The member agent has not updated its status with the hub cluster yet.
+		return false, "cluster is not connected to the fleet: member agent not online yet"
+	}
+
+	sinceLastHeartbeat := time.Since(memberAgentStatus.LastReceivedHeartbeat.Time)
+	if sinceLastHeartbeat > checker.clusterHeartbeatTimeout {
+		// The member agent has not sent heartbeat signals for a prolonged period of time.
+		//
+		// Note that this plugin assumes minimum clock drifts between clusters in the fleet.
+		return false, fmt.Sprintf("cluster is not connected to the fleet: no recent heartbeat signals (last received %.2f minutes ago)", sinceLastHeartbeat.Minutes())
+	}
+
+	memberAgentJoinedCond := cluster.GetAgentCondition(fleetv1beta1.MemberAgent, fleetv1beta1.AgentJoined)
+	if memberAgentJoinedCond == nil || memberAgentJoinedCond.Status != metav1.ConditionTrue {
+		// The member agent has not joined yet; i.e., some of the controllers have not been
+		// spun up.
+		//
+		// Note that here no generation check is performed, as
+		// a) the member cluster object spec is most of the time not touched after creation; and
+		// b) as long as the heartbeat signal does not timeout, a little drift in genrations
+		//    should not exclude a cluster from resource scheduling.
+		return false, "cluster is not connected to the fleet: member agent not joined yet"
+	}
+
+	memberAgentHealthyCond := cluster.GetAgentCondition(fleetv1beta1.MemberAgent, fleetv1beta1.AgentHealthy)
+	if memberAgentHealthyCond == nil {
+		// The health condition is absent.
+		return false, "cluster is not connected to the fleet: health condition not available"
+	}
+
+	sinceLastTransition := time.Since(memberAgentHealthyCond.LastTransitionTime.Time)
+	if memberAgentHealthyCond.Status != metav1.ConditionTrue && sinceLastTransition > checker.clusterHealthCheckTimeout {
+		// The cluster health check fails.
+		//
+		// Note that sporadic (isolated) health check failures will not preclude a cluster.
+		//
+		// Also note that at this moment, the member cluster will report a cluster as unhealth if
+		// and only if it fails to list all the nodes in the cluster; this could simply be the
+		// result of a temporary network issue, and the report will be disregarded by this plugin
+		// if the health check passes within a reasonable amount of time.
+		//
+		// Note that this plugin assumes minimum clock drifts between clusters in the fleet.
+		//
+		// Also note that no generation check is performed here, for the same reason as above.
+		return false, fmt.Sprintf("cluster is not connected to the fleet: unhealthy for a prolonged period of time (last transitioned %.2f minutes ago)", sinceLastTransition.Minutes())
+	}
+
+	return true, ""
+}

--- a/pkg/scheduler/clustereligibilitychecker/checker_test.go
+++ b/pkg/scheduler/clustereligibilitychecker/checker_test.go
@@ -21,11 +21,11 @@ const (
 
 // TestIsClusterEligible tests the IsClusterEligible function.
 func TestIsClusterEligible(t *testing.T) {
-	clusterHeartbeatTimeout := time.Minute * 15
+	clusterHeartbeatCheckTimeout := time.Minute * 15
 	clusterHealthCheckTimeout := time.Minute * 15
 	checker := New(
-		WithClusterHeartbeatTimeout(clusterHeartbeatTimeout),
-		WithClusterHeartbeatTimeout(clusterHealthCheckTimeout),
+		WithClusterHeartbeatCheckTimeout(clusterHeartbeatCheckTimeout),
+		WithClusterHealthCheckTimeout(clusterHealthCheckTimeout),
 	)
 
 	testCases := []struct {

--- a/pkg/scheduler/clustereligibilitychecker/checker_test.go
+++ b/pkg/scheduler/clustereligibilitychecker/checker_test.go
@@ -1,0 +1,266 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package clustereligibilitychecker
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+const (
+	clusterName = "bravelion"
+)
+
+// TestIsClusterEligible tests the IsClusterEligible function.
+func TestIsClusterEligible(t *testing.T) {
+	clusterHeartbeatTimeout := time.Minute * 15
+	clusterHealthCheckTimeout := time.Minute * 15
+	checker := New(
+		WithClusterHeartbeatTimeout(clusterHeartbeatTimeout),
+		WithClusterHeartbeatTimeout(clusterHealthCheckTimeout),
+	)
+
+	testCases := []struct {
+		name             string
+		cluster          *fleetv1beta1.MemberCluster
+		wantEligible     bool
+		wantReasonPrefix string
+	}{
+		{
+			name: "cluster left",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateLeave,
+				},
+			},
+			wantReasonPrefix: "cluster has left the fleet",
+		},
+		{
+			name: "no member agent status",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateJoin,
+				},
+				Status: fleetv1beta1.MemberClusterStatus{},
+			},
+			wantReasonPrefix: "cluster is not connected to the fleet: member agent not online yet",
+		},
+		{
+			name: "no member agent joined condition",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateJoin,
+				},
+				Status: fleetv1beta1.MemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type:                  fleetv1beta1.MemberAgent,
+							LastReceivedHeartbeat: metav1.Now(),
+						},
+					},
+				},
+			},
+			wantReasonPrefix: "cluster is not connected to the fleet: member agent not joined yet",
+		},
+		{
+			name: "joined condition is false",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateJoin,
+				},
+				Status: fleetv1beta1.MemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.AgentJoined),
+									Status: metav1.ConditionFalse,
+								},
+							},
+							LastReceivedHeartbeat: metav1.Now(),
+						},
+					},
+				},
+			},
+			wantReasonPrefix: "cluster is not connected to the fleet: member agent not joined yet",
+		},
+		{
+			name: "no recent heartbeat signals",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateJoin,
+				},
+				Status: fleetv1beta1.MemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.AgentJoined),
+									Status: metav1.ConditionTrue,
+								},
+							},
+							LastReceivedHeartbeat: metav1.NewTime(time.Now().Add(time.Minute * (-20))),
+						},
+					},
+				},
+			},
+			wantReasonPrefix: "cluster is not connected to the fleet: no recent heartbeat signals",
+		},
+		{
+			name: "no health check signals",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateJoin,
+				},
+				Status: fleetv1beta1.MemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.AgentJoined),
+									Status: metav1.ConditionTrue,
+								},
+							},
+							LastReceivedHeartbeat: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			wantReasonPrefix: "cluster is not connected to the fleet: health condition not available",
+		},
+		{
+			name: "health check fails for a long period",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateJoin,
+				},
+				Status: fleetv1beta1.MemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.AgentJoined),
+									Status: metav1.ConditionTrue,
+								},
+								{
+									Type:               string(fleetv1beta1.AgentHealthy),
+									Status:             metav1.ConditionFalse,
+									LastTransitionTime: metav1.NewTime(time.Now().Add(time.Minute * (-20))),
+								},
+							},
+							LastReceivedHeartbeat: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			wantReasonPrefix: "cluster is not connected to the fleet: unhealthy for a prolonged period of time",
+		},
+		{
+			name: "recent health check failure",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateJoin,
+				},
+				Status: fleetv1beta1.MemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.AgentJoined),
+									Status: metav1.ConditionTrue,
+								},
+								{
+									Type:               string(fleetv1beta1.AgentHealthy),
+									Status:             metav1.ConditionFalse,
+									LastTransitionTime: metav1.NewTime(time.Now().Add(time.Minute * (-1))),
+								},
+							},
+							LastReceivedHeartbeat: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			wantEligible: true,
+		},
+		{
+			name: "normal cluster",
+			cluster: &fleetv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterName,
+				},
+				Spec: fleetv1beta1.MemberClusterSpec{
+					State: fleetv1beta1.ClusterStateJoin,
+				},
+				Status: fleetv1beta1.MemberClusterStatus{
+					AgentStatus: []fleetv1beta1.AgentStatus{
+						{
+							Type: fleetv1beta1.MemberAgent,
+							Conditions: []metav1.Condition{
+								{
+									Type:   string(fleetv1beta1.AgentJoined),
+									Status: metav1.ConditionTrue,
+								},
+								{
+									Type:               string(fleetv1beta1.AgentHealthy),
+									Status:             metav1.ConditionFalse,
+									LastTransitionTime: metav1.NewTime(time.Now()),
+								},
+							},
+							LastReceivedHeartbeat: metav1.NewTime(time.Now()),
+						},
+					},
+				},
+			},
+			wantEligible: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eligible, reason := checker.IsEligible(tc.cluster)
+			if eligible != tc.wantEligible {
+				t.Errorf("IsClusterEligible() eligible = %t, want %t", eligible, tc.wantEligible)
+			}
+			if !eligible && !strings.HasPrefix(reason, tc.wantReasonPrefix) {
+				t.Errorf("IsClusterEligible() reason = %s, want %s", reason, tc.wantReasonPrefix)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -669,7 +669,7 @@ func (f *framework) updatePolicySnapshotStatusFromBindings(
 	// Retrieve the corresponding CRP generation.
 	observedCRPGeneration, err := utils.ExtractObservedCRPGenerationFromPolicySnapshot(policy)
 	if err != nil {
-		klog.ErrorS(err, "Failed to retrieve CRP generation from annoation")
+		klog.ErrorS(err, "Failed to retrieve CRP generation from annoation", "clusterSchedulingPolicySnapshot", policyRef)
 		return controller.NewUnexpectedBehaviorError(err)
 	}
 
@@ -1251,7 +1251,7 @@ func (f *framework) updatePolicySnapshotStatusFromTargetClusters(
 	// Retrieve the corresponding CRP generation.
 	observedCRPGeneration, err := utils.ExtractObservedCRPGenerationFromPolicySnapshot(policy)
 	if err != nil {
-		klog.ErrorS(err, "Failed to retrieve CRP generation from annoation")
+		klog.ErrorS(err, "Failed to retrieve CRP generation from annoation", "clusterSchedulingPolicySnapshot", policyRef)
 		return controller.NewUnexpectedBehaviorError(err)
 	}
 

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -22,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/scheduler/clustereligibilitychecker"
 	"go.goms.io/fleet/pkg/scheduler/framework/parallelizer"
 	"go.goms.io/fleet/pkg/utils"
 	"go.goms.io/fleet/pkg/utils/condition"
@@ -32,12 +34,16 @@ const (
 	// eventRecorderNameTemplate is the template used to format event recorder name for a scheduler framework.
 	eventRecorderNameTemplate = "scheduler-framework-%s"
 
-	// pickedByPolicyReason is the reason to use for scheduling decision when a cluster is picked.
-	pickedByPolicyReason = "picked by scheduling policy"
+	// The reasons to use for scheduling decisions.
+	pickedByPolicyReason                           = "picked by scheduling policy"
+	fixedSetOfClustersInvalidClusterReasonTemplate = "cluster is not eligible for resource placement yet: %s"
+	fixedSetOfClustersNotFoundClusterReason        = "specified cluster is not found"
 
 	// The reasons and messages for scheduled conditions.
-	fullyScheduledReason  = "SchedulingCompleted"
-	fullyScheduledMessage = "all required number of bindings have been created"
+	fullyScheduledReason     = "SchedulingPolicyFulfilled"
+	notFullyScheduledReason  = "SchedulingPolicyUnfulfilled"
+	fullyScheduledMessage    = "found all the clusters needed as specified by the scheduling policy"
+	notFullyScheduledMessage = "could not find all the clusters needed as specified by the scheduling policy"
 
 	// The array length limit of the cluster decision array in the scheduling policy snapshot
 	// status API.
@@ -88,6 +94,9 @@ type framework struct {
 	// parallelizer is a utility which helps run tasks in parallel.
 	parallelizer *parallelizer.Parallerlizer
 
+	// eligibilityChecker is a utility which helps determine if a cluster is eligible for resource placement.
+	clusterEligibilityChecker *clustereligibilitychecker.ClusterEligibilityChecker
+
 	// maxUnselectedClusterDecisionCount controls the maximum number of decisions for unselected clusters
 	// added to the policy snapshot status.
 	//
@@ -109,6 +118,10 @@ type frameworkOptions struct {
 	// maxUnselectedClusterDecisionCount controls the maximum number of decisions for
 	// unselected clusters added to the policy snapshot status.
 	maxUnselectedClusterDecisionCount int
+
+	// checker is the cluster eligibility checker the scheduler framework will use to check
+	// if a cluster is eligibile for resource placement.
+	clusterEligibilityChecker *clustereligibilitychecker.ClusterEligibilityChecker
 }
 
 // Option is the function for configuring a scheduler framework.
@@ -118,6 +131,7 @@ type Option func(*frameworkOptions)
 var defaultFrameworkOptions = frameworkOptions{
 	numOfWorkers:                      parallelizer.DefaultNumOfWorkers,
 	maxUnselectedClusterDecisionCount: 20,
+	clusterEligibilityChecker:         clustereligibilitychecker.New(),
 }
 
 // WithNumOfWorkers sets the number of workers to use for a scheduler framework.
@@ -131,6 +145,13 @@ func WithNumOfWorkers(numOfWorkers int) Option {
 func WithMaxClusterDecisionCount(maxUnselectedClusterDecisionCount int) Option {
 	return func(fo *frameworkOptions) {
 		fo.maxUnselectedClusterDecisionCount = maxUnselectedClusterDecisionCount
+	}
+}
+
+// WithClusterEligibilityChecker sets the cluster eligibility checker for a scheduler framework.
+func WithClusterEligibilityChecker(checker *clustereligibilitychecker.ClusterEligibilityChecker) Option {
+	return func(fo *frameworkOptions) {
+		fo.clusterEligibilityChecker = checker
 	}
 }
 
@@ -162,6 +183,7 @@ func NewFramework(profile *Profile, manager ctrl.Manager, opts ...Option) Framew
 		eventRecorder:                     manager.GetEventRecorderFor(fmt.Sprintf(eventRecorderNameTemplate, profile.Name())),
 		parallelizer:                      parallelizer.NewParallelizer(options.numOfWorkers),
 		maxUnselectedClusterDecisionCount: options.maxUnselectedClusterDecisionCount,
+		clusterEligibilityChecker:         options.clusterEligibilityChecker,
 	}
 }
 
@@ -258,11 +280,19 @@ func (f *framework) RunSchedulingCycleFor(ctx context.Context, crpName string, p
 	// is always executed in one single goroutine; plugin access to the state is guarded by sync.Map.
 	state := NewCycleState(clusters, obsolete, bound, scheduled)
 
-	switch policy.Spec.Policy.PlacementType {
-	case fleetv1beta1.PickAllPlacementType:
+	switch {
+	case policy.Spec.Policy == nil:
+		// The placement policy is not set; in such cases the policy is considered to be of
+		// the PickAll placement type.
+		return f.runSchedulingCycleForPickAllPlacementType(ctx, state, crpName, policy, clusters, bound, scheduled, obsolete)
+	case len(policy.Spec.Policy.ClusterNames) != 0:
+		// The placement policy features a fixed set of clusters to select; in such cases, the
+		// scheduler will bind to these clusters directly.
+		return f.runSchedulingCycleForFixedSetOfClusters(ctx, crpName, policy, clusters, bound, scheduled, obsolete)
+	case policy.Spec.Policy.PlacementType == fleetv1beta1.PickAllPlacementType:
 		// Run the scheduling cycle for policy of the PickAll placement type.
 		return f.runSchedulingCycleForPickAllPlacementType(ctx, state, crpName, policy, clusters, bound, scheduled, obsolete)
-	case fleetv1beta1.PickNPlacementType:
+	case policy.Spec.Policy.PlacementType == fleetv1beta1.PickNPlacementType:
 		// Run the scheduling cycle for policy of the PickN placement type.
 		return f.runSchedulingCycleForPickNPlacementType(ctx, state, crpName, policy, clusters, bound, scheduled, obsolete)
 	default:
@@ -370,7 +400,11 @@ func (f *framework) runSchedulingCycleForPickAllPlacementType(
 
 	// Update policy snapshot status with the latest scheduling decisions and condition.
 	klog.V(2).InfoS("Updating policy snapshot status", "clusterSchedulingPolicySnapshot", policyRef)
-	if err := f.updatePolicySnapshotStatusFrom(ctx, policy, filtered, toCreate, patched, scheduled, bound); err != nil {
+
+	// With the PickAll placement type, the desired number of clusters to select always matches
+	// with the count of scheduled + bound bindings.
+	numOfClusters := len(toCreate) + len(patched) + len(scheduled) + len(bound)
+	if err := f.updatePolicySnapshotStatusFromBindings(ctx, policy, numOfClusters, filtered, toCreate, patched, scheduled, bound); err != nil {
 		klog.ErrorS(err, "Failed to update latest scheduling decisions and condition", "clusterSchedulingPolicySnapshot", policyRef)
 		return ctrl.Result{}, err
 	}
@@ -601,21 +635,23 @@ func (f *framework) patchBindings(ctx context.Context, toPatch []*bindingWithPat
 	return nil
 }
 
-// updatePolicySnapshotStatusFrom updates the policy snapshot status, in accordance with the list of
+// updatePolicySnapshotStatusFromBindings updates the policy snapshot status, in accordance with the list of
 // clusters filtered out by the scheduler, and the list of bindings provisioned by the scheduler.
-func (f *framework) updatePolicySnapshotStatusFrom(
+func (f *framework) updatePolicySnapshotStatusFromBindings(
 	ctx context.Context,
 	policy *fleetv1beta1.ClusterSchedulingPolicySnapshot,
+	numOfClusters int,
 	filtered []*filteredClusterWithStatus,
 	existing ...[]*fleetv1beta1.ClusterResourceBinding,
 ) error {
 	policyRef := klog.KObj(policy)
 
 	// Prepare new scheduling decisions.
-	newDecisions := newSchedulingDecisionsFrom(f.maxUnselectedClusterDecisionCount, filtered, existing...)
+	newDecisions := newSchedulingDecisionsFromBindings(f.maxUnselectedClusterDecisionCount, filtered, existing...)
 	// Prepare new scheduling condition.
-	newCondition := fullyScheduledCondition(policy)
+	newCondition := newScheduledConditionFromBindings(policy, numOfClusters, existing...)
 
+	// Compare the new decisions + condition with the old ones.
 	currentDecisions := policy.Status.ClusterDecisions
 	currentCondition := meta.FindStatusCondition(policy.Status.Conditions, string(fleetv1beta1.PolicySnapshotScheduled))
 	if equalDecisions(currentDecisions, newDecisions) && condition.EqualCondition(currentCondition, &newCondition) {
@@ -623,7 +659,16 @@ func (f *framework) updatePolicySnapshotStatusFrom(
 		return nil
 	}
 
+	// Retrieve the corresponding CRP generation.
+	observedCRPGeneration, err := utils.ExtractObservedCRPGenerationFromPolicySnapshot(policy)
+	if err != nil {
+		klog.ErrorS(err, "Failed to retrieve CRP generation from annoation")
+		return controller.NewUnexpectedBehaviorError(err)
+	}
+
+	// Update the status.
 	policy.Status.ClusterDecisions = newDecisions
+	policy.Status.ObservedCRPGeneration = observedCRPGeneration
 	meta.SetStatusCondition(&policy.Status.Conditions, newCondition)
 	if err := f.client.Status().Update(ctx, policy, &client.UpdateOptions{}); err != nil {
 		klog.ErrorS(err, "Failed to update policy snapshot status", "clusterSchedulingPolicySnapshot", policyRef)
@@ -634,15 +679,13 @@ func (f *framework) updatePolicySnapshotStatusFrom(
 
 // runSchedulingCycleForPickNPlacementType runs the scheduling cycle for a scheduling policy of the PickN
 // placement type.
-//
-// TO-DO (chenyu1): remove the nolint directives once the function is implemented.
 func (f *framework) runSchedulingCycleForPickNPlacementType(
-	ctx context.Context, //nolint: revive
-	state *CycleState, //nolint: revive
-	crpName string, //nolint: revive
-	policy *fleetv1beta1.ClusterSchedulingPolicySnapshot, //nolint: revive
-	clusters []fleetv1beta1.MemberCluster, //nolint: revive
-	bound, scheduled, obsolete []*fleetv1beta1.ClusterResourceBinding, //nolint: revive
+	ctx context.Context,
+	state *CycleState,
+	crpName string,
+	policy *fleetv1beta1.ClusterSchedulingPolicySnapshot,
+	clusters []fleetv1beta1.MemberCluster,
+	bound, scheduled, obsolete []*fleetv1beta1.ClusterResourceBinding,
 ) (result ctrl.Result, err error) {
 	policyRef := klog.KObj(policy)
 
@@ -696,7 +739,7 @@ func (f *framework) runSchedulingCycleForPickNPlacementType(
 		// Note that since there is no reliable way to determine the validity of old decisions added
 		// to the policy snapshot status, we will only update the status with the known facts, i.e.,
 		// the clusters that are currently selected.
-		if err := f.updatePolicySnapshotStatusFrom(ctx, policy, nil, scheduled, bound); err != nil {
+		if err := f.updatePolicySnapshotStatusFromBindings(ctx, policy, numOfClusters, nil, scheduled, bound); err != nil {
 			klog.ErrorS(err, "Failed to update latest scheduling decisions and condition when downscaling", "clusterSchedulingPolicySnapshot", policyRef)
 			return ctrl.Result{}, err
 		}
@@ -716,7 +759,7 @@ func (f *framework) runSchedulingCycleForPickNPlacementType(
 		// Note that since there is no reliable way to determine the validity of old decisions added
 		// to the policy snapshot status, we will only update the status with the known facts, i.e.,
 		// the clusters that are currently selected.
-		if err := f.updatePolicySnapshotStatusFrom(ctx, policy, nil, bound, scheduled); err != nil {
+		if err := f.updatePolicySnapshotStatusFromBindings(ctx, policy, numOfClusters, nil, bound, scheduled); err != nil {
 			klog.ErrorS(err, "Failed to update latest scheduling decisions and condition when no scheduling run is needed", "clusterSchedulingPolicySnapshot", policyRef)
 			return ctrl.Result{}, err
 		}
@@ -804,7 +847,7 @@ func (f *framework) runSchedulingCycleForPickNPlacementType(
 
 	// Update policy snapshot status with the latest scheduling decisions and condition.
 	klog.V(2).InfoS("Updating policy snapshot status", "clusterSchedulingPolicySnapshot", policyRef)
-	if err := f.updatePolicySnapshotStatusFrom(ctx, policy, filtered, toCreate, patched, scheduled, bound); err != nil {
+	if err := f.updatePolicySnapshotStatusFromBindings(ctx, policy, numOfClusters, filtered, toCreate, patched, scheduled, bound); err != nil {
 		klog.ErrorS(err, "Failed to update latest scheduling decisions and condition", "clusterSchedulingPolicySnapshot", policyRef)
 		return ctrl.Result{}, err
 	}
@@ -1101,4 +1144,181 @@ func (f *framework) runScorePlugins(ctx context.Context, state *CycleState, poli
 	scoredClusters = scoredClusters[:scoredClustersIdx+1]
 
 	return scoredClusters, nil
+}
+
+// invalidClusterWithReason is struct that documents a cluster that is, though present in
+// the list of current clusters, not valid for resource placement (e.g., it is experiencing
+// a network partition)
+// along with a plugin status, which documents why a cluster is filtered out.
+//
+// This struct is used for the purpose of keeping reasons for returning scheduling decision to
+// the user.
+type invalidClusterWithReason struct {
+	cluster *fleetv1beta1.MemberCluster
+	reason  string
+}
+
+// crossReferenceClustersWithTargetNames cross-references the current list of clusters in the fleet
+// and the list of target clusters user specifies in the placement policy.
+func (f *framework) crossReferenceClustersWithTargetNames(current []fleetv1beta1.MemberCluster, target []string) (valid []*fleetv1beta1.MemberCluster, invalid []*invalidClusterWithReason, notFound []string) {
+	// Pre-allocate with a reasonable capacity.
+	valid = make([]*fleetv1beta1.MemberCluster, 0, len(target))
+	invalid = make([]*invalidClusterWithReason, 0, len(target))
+	notFound = make([]string, 0, len(target))
+
+	// Build a map of current clusters for quick lookup.
+	currentMap := make(map[string]fleetv1beta1.MemberCluster)
+	for idx := range current {
+		cluster := current[idx]
+		currentMap[cluster.Name] = cluster
+	}
+
+	for idx := range target {
+		targetName := target[idx]
+		cluster, ok := currentMap[targetName]
+		if !ok {
+			// The target cluster is not found in the list of current clusters.
+			notFound = append(notFound, targetName)
+			continue
+		}
+
+		eligible, reason := f.clusterEligibilityChecker.IsEligible(&cluster)
+		if !eligible {
+			// The target cluster is found, but it is not a valid target (ineligible for resource placement).
+			invalid = append(invalid, &invalidClusterWithReason{
+				cluster: &cluster,
+				reason:  reason,
+			})
+			continue
+		}
+
+		// The target cluster is found, and it is a valid target (eligible for resource placement).
+		valid = append(valid, &cluster)
+	}
+
+	return valid, invalid, notFound
+}
+
+// updatePolicySnapshotStatusFromTargetClusters updates the policy snapshot status with
+// the latest scheduling decisions and condition when there is a fixed set of clusters to
+// select.
+//
+// Note that due to the nature of scheduling to a fixed set of clusters, in the function
+// the scheduler prepares the scheduling related status based on the different types of
+// target clusters ather than the final outcome (i.e., the actual list of bindings created).
+// The correctness is still guaranteed as the outcome of the scheduling cycle is deterministic
+// when given a set of fixed clusters to schedule resources to, as long as
+//   - there is no manipulation of the scheduling result (e.g., binding directly created by
+//     the user) without acknowledge from the scheduler;and
+//   - the status is only added after the actual binding manipulation has been completed without
+//     an error.
+func (f *framework) updatePolicySnapshotStatusFromTargetClusters(
+	ctx context.Context,
+	policy *fleetv1beta1.ClusterSchedulingPolicySnapshot,
+	valid []*fleetv1beta1.MemberCluster,
+	invalid []*invalidClusterWithReason,
+	notFound []string,
+) error {
+	policyRef := klog.KObj(policy)
+
+	// Prepare new scheduling decisions.
+	newDecisions := newSchedulingDecisionsFromTargetClusters(valid, invalid, notFound)
+	// Prepare new scheduling condition.
+	var newCondition metav1.Condition
+	if len(invalid)+len(notFound) == 0 {
+		// The scheduler has selected all the clusters, as the scheduling policy dictates.
+		newCondition = newScheduledCondition(policy, metav1.ConditionTrue, fullyScheduledReason, fullyScheduledMessage)
+	} else {
+		// Some of the targets cannot be selected.
+		newCondition = newScheduledCondition(policy, metav1.ConditionFalse, notFullyScheduledReason, notFullyScheduledMessage)
+	}
+
+	// Compare new decisions + condition with the old ones.
+	currentDecisions := policy.Status.ClusterDecisions
+	currentCondition := meta.FindStatusCondition(policy.Status.Conditions, string(fleetv1beta1.PolicySnapshotScheduled))
+	if equalDecisions(currentDecisions, newDecisions) && condition.EqualCondition(currentCondition, &newCondition) {
+		// Skip if there is no change in decisions and conditions.
+		return nil
+	}
+
+	// Retrieve the corresponding CRP generation.
+	observedCRPGeneration, err := utils.ExtractObservedCRPGenerationFromPolicySnapshot(policy)
+	if err != nil {
+		klog.ErrorS(err, "Failed to retrieve CRP generation from annoation")
+		return controller.NewUnexpectedBehaviorError(err)
+	}
+
+	// Update the status.
+	policy.Status.ClusterDecisions = newDecisions
+	policy.Status.ObservedCRPGeneration = observedCRPGeneration
+	meta.SetStatusCondition(&policy.Status.Conditions, newCondition)
+	if err := f.client.Status().Update(ctx, policy, &client.UpdateOptions{}); err != nil {
+		klog.ErrorS(err, "Failed to update policy snapshot status", "clusterSchedulingPolicySnapshot", policyRef)
+		return controller.NewAPIServerError(false, err)
+	}
+
+	return nil
+}
+
+// runSchedulingCycleForFixedSetOfClusters runs the scheduling cycle when there is a fixed
+// set of clusters to select in the placement policy.
+func (f *framework) runSchedulingCycleForFixedSetOfClusters(
+	ctx context.Context,
+	crpName string,
+	policy *fleetv1beta1.ClusterSchedulingPolicySnapshot,
+	clusters []fleetv1beta1.MemberCluster,
+	bound, scheduled, obsolete []*fleetv1beta1.ClusterResourceBinding,
+) (ctrl.Result, error) {
+	policyRef := klog.KObj(policy)
+
+	targetClusterNames := policy.Spec.Policy.ClusterNames
+	if len(targetClusterNames) == 0 {
+		// Skip the cycle if the list of target clusters is empty; normally this should not
+		// occur.
+		klog.V(2).InfoS("No scheduling is needed: list of target clusters is empty", "clusterSchedulingPolicySnapshot", policyRef)
+		return ctrl.Result{}, nil
+	}
+
+	// Cross-reference the current list of clusters with the list of target cluster names to
+	// find out:
+	// * valid targets, i.e., cluster that is both present in the list of current clusters in
+	//   the fleet and the list of target clusters, and is eligible for resource placement;
+	// * invalid targets, i.e., cluster that is present in the list of current clusters in the
+	//   fleet and the list of target clusters, but is not eligible for resource placement;
+	// * not found targets, i.e., cluster that is present in the list of target clusters, but
+	//   is not present in the list of current clusters in the fleet.
+	valid, invalid, notFound := f.crossReferenceClustersWithTargetNames(clusters, targetClusterNames)
+
+	// Cross-reference the valid target clusters with obsolete bindings; find out
+	//
+	// * bindings that should be created, i.e., create a binding for every cluster that is a valid target
+	//   and does not have a binding associated with;
+	// * bindings that should be patched, i.e., associate a binding whose target cluster is a valid target
+	//   in the current run with the latest score and the latest scheduling policy snapshot;
+	// * bindings that should be deleted, i.e., mark a binding as unschedulable if its target cluster is no
+	//   longer picked in the current run.
+	//
+	// Fields in the returned bindings are fulfilled and/or refreshed as applicable.
+	klog.V(2).InfoS("Cross-referencing bindings with valid target clusters", "clusterSchedulingPolicySnapshot", policyRef)
+	toCreate, toDelete, toPatch, err := crossReferenceValidTargetsWithBindings(crpName, policy, valid, bound, scheduled, obsolete)
+	if err != nil {
+		klog.ErrorS(err, "Failed to cross-reference bindings with valid targets", "clusterSchedulingPolicySnapshot", policyRef)
+		return ctrl.Result{}, err
+	}
+
+	// Manipulate bindings accordingly.
+	klog.V(2).InfoS("Manipulating bindings", "clusterSchedulingPolicySnapshot", policyRef)
+	if err := f.manipulateBindings(ctx, policy, toCreate, toDelete, toPatch); err != nil {
+		klog.ErrorS(err, "Failed to manipulate bindings", "clusterSchedulingPolicySnapshot", policyRef)
+		return ctrl.Result{}, err
+	}
+
+	// Update policy snapshot status with the latest scheduling decisions and condition.
+	if err := f.updatePolicySnapshotStatusFromTargetClusters(ctx, policy, valid, invalid, notFound); err != nil {
+		klog.ErrorS(err, "Failed to update latest scheduling decisions and condition", "clusterSchedulingPolicySnapshot", policyRef)
+		return ctrl.Result{}, err
+	}
+
+	// The scheduling cycle is completed.
+	return ctrl.Result{}, nil
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -289,3 +289,18 @@ func ExtractSubindexFromClusterResourceSnapshot(snapshot *fleetv1beta1.ClusterRe
 
 	return true, subindex, nil
 }
+
+func ExtractObservedCRPGenerationFromPolicySnapshot(policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) (int64, error) {
+	crpGeneartionStr, ok := policy.Annotations[fleetv1beta1.CRPGenerationAnnotation]
+	if !ok {
+		return 0, fmt.Errorf("cannot find annotation %s", fleetv1beta1.CRPGenerationAnnotation)
+	}
+
+	// Cast the annotation to an integer; throw an error if the cast cannot be completed or the value is negative.
+	observedCRPGeneration, err := strconv.Atoi(crpGeneartionStr)
+	if err != nil || observedCRPGeneration < 0 {
+		return 0, fmt.Errorf("invalid annotation %s: %s is not a valid value: %w", fleetv1beta1.CRPGenerationAnnotation, crpGeneartionStr, err)
+	}
+
+	return int64(observedCRPGeneration), nil
+}

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -291,15 +291,15 @@ func ExtractSubindexFromClusterResourceSnapshot(snapshot *fleetv1beta1.ClusterRe
 }
 
 func ExtractObservedCRPGenerationFromPolicySnapshot(policy *fleetv1beta1.ClusterSchedulingPolicySnapshot) (int64, error) {
-	crpGeneartionStr, ok := policy.Annotations[fleetv1beta1.CRPGenerationAnnotation]
+	crpGenerationStr, ok := policy.Annotations[fleetv1beta1.CRPGenerationAnnotation]
 	if !ok {
 		return 0, fmt.Errorf("cannot find annotation %s", fleetv1beta1.CRPGenerationAnnotation)
 	}
 
 	// Cast the annotation to an integer; throw an error if the cast cannot be completed or the value is negative.
-	observedCRPGeneration, err := strconv.Atoi(crpGeneartionStr)
+	observedCRPGeneration, err := strconv.Atoi(crpGenerationStr)
 	if err != nil || observedCRPGeneration < 0 {
-		return 0, fmt.Errorf("invalid annotation %s: %s is not a valid value: %w", fleetv1beta1.CRPGenerationAnnotation, crpGeneartionStr, err)
+		return 0, fmt.Errorf("invalid annotation %s: %s is not a valid value: %w", fleetv1beta1.CRPGenerationAnnotation, crpGenerationStr, err)
 	}
 
 	return int64(observedCRPGeneration), nil


### PR DESCRIPTION
### Description of your changes

This PR is part of the PRs that implement the Fleet workload scheduling.

It features logic for scheduling CRPs with a fixed set of target clusters; it also updates the logic of status handling in the scheduler framework.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests


### Special notes for your reviewer

- This PR overlaps with some of the other PRs, specifically the cluster eligibility checking logic
- Some the unit tests are kept out to control the PR size; they will be sent in a separate PR.
