### PR TITLE
interface: add a new placement type for a fixed set of clusters

### DIFF
--- a/apis/placement/v1beta1/zz_generated.deepcopy.go
+++ b/apis/placement/v1beta1/zz_generated.deepcopy.go
@@ -12,7 +12,7 @@ package v1beta1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.azure.com_clusterresourceplacements.yaml
@@ -75,6 +75,7 @@ spec:
                   affinity:
                     description: Affinity contains cluster affinity scheduling rules.
                       Defines which member clusters to place the selected resources.
+                      Only valid if the placement type is "PickAll" or "PickN".
                     properties:
                       clusterAffinity:
                         description: ClusterAffinity contains cluster affinity scheduling
@@ -250,9 +251,8 @@ spec:
                     type: object
                   clusterNames:
                     description: ClusterNames contains a list of names of MemberCluster
-                      to place the selected resources. If the list is not empty, `PlacementType`,
-                      `NumberOfClusters`, `Affinity`, and `TopologySpreadConstraints`
-                      are ignored.
+                      to place the selected resources. Only valid if the placement
+                      type is "PickFixed"
                     items:
                       type: string
                     maxItems: 100
@@ -265,17 +265,19 @@ spec:
                     type: integer
                   placementType:
                     default: PickAll
-                    description: Type of placement. Can be "PickAll" or "PickN". Default
-                      is PickAll.
+                    description: Type of placement. Can be "PickAll", "PickN" or "PickFixed".
+                      Default is PickAll.
                     enum:
                     - PickAll
                     - PickN
+                    - PickFixed
                     type: string
                   topologySpreadConstraints:
                     description: TopologySpreadConstraints describes how a group of
                       resources ought to spread across multiple topology domains.
                       Scheduler will schedule resources in a way which abides by the
-                      constraints. All topologySpreadConstraints are ANDed.
+                      constraints. All topologySpreadConstraints are ANDed. Only valid
+                      if the placement type is "PickN".
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         resources among the given cluster topology.
@@ -554,9 +556,10 @@ spec:
                   on the clusters that are selected by PlacementPolicy. Each selected
                   cluster according to the latest resource placement is guaranteed
                   to have a corresponding placementStatuses. In the pickN case, there
-                  are N placement statuses where N = NumberOfClusters. Some of them
-                  may not have assigned clusters when we cannot fill the required
-                  number of clusters.
+                  are N placement statuses where N = NumberOfClusters; Or in the pickFixed
+                  case, there are N placement statuses where N = ClusterNames. In
+                  these cases, some of them may not have assigned clusters when we
+                  cannot fill the required number of clusters.
                 items:
                   description: ResourcePlacementStatus represents the placement status
                     of selected resources for one target cluster.

--- a/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.azure.com_clusterschedulingpolicysnapshots.yaml
@@ -59,6 +59,7 @@ spec:
                   affinity:
                     description: Affinity contains cluster affinity scheduling rules.
                       Defines which member clusters to place the selected resources.
+                      Only valid if the placement type is "PickAll" or "PickN".
                     properties:
                       clusterAffinity:
                         description: ClusterAffinity contains cluster affinity scheduling
@@ -234,9 +235,8 @@ spec:
                     type: object
                   clusterNames:
                     description: ClusterNames contains a list of names of MemberCluster
-                      to place the selected resources. If the list is not empty, `PlacementType`,
-                      `NumberOfClusters`, `Affinity`, and `TopologySpreadConstraints`
-                      are ignored.
+                      to place the selected resources. Only valid if the placement
+                      type is "PickFixed"
                     items:
                       type: string
                     maxItems: 100
@@ -249,17 +249,19 @@ spec:
                     type: integer
                   placementType:
                     default: PickAll
-                    description: Type of placement. Can be "PickAll" or "PickN". Default
-                      is PickAll.
+                    description: Type of placement. Can be "PickAll", "PickN" or "PickFixed".
+                      Default is PickAll.
                     enum:
                     - PickAll
                     - PickN
+                    - PickFixed
                     type: string
                   topologySpreadConstraints:
                     description: TopologySpreadConstraints describes how a group of
                       resources ought to spread across multiple topology domains.
                       Scheduler will schedule resources in a way which abides by the
-                      constraints. All topologySpreadConstraints are ANDed.
+                      constraints. All topologySpreadConstraints are ANDed. Only valid
+                      if the placement type is "PickN".
                     items:
                       description: TopologySpreadConstraint specifies how to spread
                         resources among the given cluster topology.


### PR DESCRIPTION
### Description of your changes
[ClusterNames ](https://github.com/Azure/fleet/blob/main/apis/placement/v1beta1/clusterresourceplacement_types.go#L137) is a special case in the current API.

Feel it will be better to create it as a separate type to make the API clean.

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
