### PR TITLE
fix: run scheduler in a separate goroutine

### DIFF
--- a/cmd/hubagent/main.go
+++ b/cmd/hubagent/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"os"
 	"strings"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -42,6 +43,8 @@ var (
 		handleExitFunc()
 		os.Exit(1)
 	}
+
+	wg sync.WaitGroup
 )
 
 const (
@@ -135,17 +138,28 @@ func main() {
 	}
 
 	ctx := ctrl.SetupSignalHandler()
-	if err := workload.SetupControllers(ctx, mgr, config, opts); err != nil {
+	if err := workload.SetupControllers(ctx, &wg, mgr, config, opts); err != nil {
 		klog.ErrorS(err, "unable to set up ready check")
 		exitWithErrorFunc()
 	}
 
 	// +kubebuilder:scaffold:builder
 
-	if err := mgr.Start(ctx); err != nil {
-		klog.ErrorS(err, "problem starting manager")
-		exitWithErrorFunc()
-	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Start() is a blocking call and it is set to exit on context cancellation.
+		if err := mgr.Start(ctx); err != nil {
+			klog.ErrorS(err, "problem starting manager")
+			exitWithErrorFunc()
+		}
+
+		klog.InfoS("The controller manager has exited")
+	}()
+
+	// Wait for the controller manager and the scheduler to exit.
+	wg.Wait()
 }
 
 // SetupWebhook generates the webhook cert and then set up the webhook configurator.

--- a/cmd/hubagent/main.go
+++ b/cmd/hubagent/main.go
@@ -43,8 +43,6 @@ var (
 		handleExitFunc()
 		os.Exit(1)
 	}
-
-	wg sync.WaitGroup
 )
 
 const (
@@ -65,6 +63,9 @@ func init() {
 }
 
 func main() {
+	// The wait group for synchronizing the steps (esp. the exit) of the controller manager and the scheduler.
+	var wg sync.WaitGroup
+
 	opts := options.NewOptions()
 	opts.AddFlags(flag.CommandLine)
 

--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -188,7 +188,10 @@ func SetupControllers(ctx context.Context, mgr ctrl.Manager, config *rest.Config
 		defaultSchedulingQueue := queue.NewSimpleClusterResourcePlacementSchedulingQueue()
 		defaultScheduler := scheduler.NewScheduler("DefaultScheduler", defaultFramework, defaultSchedulingQueue, mgr)
 		klog.Info("Starting the scheduler")
-		defaultScheduler.Run(ctx)
+		// Scheduler must run in a separate goroutine as Run() is a blocking call.
+		go func() {
+			defaultScheduler.Run(ctx)
+		}()
 
 		// Set up the watchers for the controller
 		klog.Info("Setting up the clusterResourcePlacement watcher for scheduler")

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -105,7 +105,7 @@ var _ = BeforeSuite(func() {
 	By("Setup custom controllers")
 	opts := options.NewOptions()
 	opts.LeaderElection.LeaderElect = false
-	err = workload.SetupControllers(ctx, mgr, cfg, opts)
+	err = workload.SetupControllers(ctx, nil, mgr, cfg, opts)
 	Expect(err).Should(Succeed())
 
 	By("Start the controller manager")


### PR DESCRIPTION
### Description of your changes

This PR features a simple fix that runs the scheduler in a separate goroutine; otherwise the main function will be blocked.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

