### PR TITLE
feat: add API version toggles in hub agent helm charts

### DIFF
--- a/charts/hub-agent/templates/deployment.yaml
+++ b/charts/hub-agent/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
             - --webhook-client-connection-type={{.Values.webhookClientConnectionType}}
             - --v={{ .Values.logVerbosity }}
             - -add_dir_header
+            {{- if .Values.enableV1Alpha1APIs }}
+            - --enable-v1alpha1-apis
+            {{- end }}
+            {{- if .Values.enableV1Beta1APIs }}
+            - --enable-v1beta1-apis
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/charts/hub-agent/values.yaml
+++ b/charts/hub-agent/values.yaml
@@ -33,3 +33,6 @@ affinity: {}
 
 secret:
   name: hub-kubeconfig-secret
+
+enableV1Alpha1APIs: true
+enableV1Beta1APIs: false


### PR DESCRIPTION
### Description of your changes

This PR adds toggles for API versions in the hub agent helm chart to allow usage of v1beta1 APIs on the upstream end.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer
