### PR TITLE
feat: remove the state in the member cluster CRD

### DIFF
--- a/apis/cluster/v1beta1/membercluster_types.go
+++ b/apis/cluster/v1beta1/membercluster_types.go
@@ -35,10 +35,6 @@ type MemberCluster struct {
 type MemberClusterSpec struct {
 	// +kubebuilder:validation:Required,Enum=Join;Leave
 
-	// The desired state of the member cluster. Possible values: Join, Leave.
-	// +required
-	State ClusterState `json:"state"`
-
 	// The identity used by the member cluster to access the hub cluster.
 	// The hub agents deployed on the hub cluster will automatically grant the minimal required permissions to this identity for the member agents deployed on the member cluster to access the hub cluster.
 	// +required

--- a/apis/interface.go
+++ b/apis/interface.go
@@ -1,4 +1,10 @@
-package v1beta1
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+// Package apis contains API interfaces for the fleet API group.
+package apis
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/apis/placement/v1beta1/commons.go
+++ b/apis/placement/v1beta1/commons.go
@@ -11,6 +11,9 @@ const (
 	// See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#label-selector-and-annotation-conventions
 	fleetPrefix = "kubernetes-fleet.io/"
 
+	// MemberClusterFinalizer is used to make sure that we handle gc of all the member cluster resources on the hub cluster.
+	MemberClusterFinalizer = fleetPrefix + "membercluster-finalizer"
+
 	// CRPTrackingLabel is the label that points to the cluster resource policy that creates a resource binding.
 	CRPTrackingLabel = fleetPrefix + "parentCRP"
 

--- a/apis/v1alpha1/commons.go
+++ b/apis/v1alpha1/commons.go
@@ -13,8 +13,9 @@ import (
 type ClusterState string
 
 const (
-	ClusterStateJoin  ClusterState = "Join"
-	ClusterStateLeave ClusterState = "Leave"
+	ClusterStateJoin       ClusterState = "Join"
+	ClusterStateLeave      ClusterState = "Leave"
+	MemberClusterFinalizer              = "work.fleet.azure.com/membercluster-finalizer"
 )
 
 const (

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -1,3 +1,8 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
 package v1alpha1
 
 import (
@@ -5,27 +10,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// A Conditioned may have conditions set or retrieved. Conditions typically
-// indicate the status of both a resource and its reconciliation process.
-// +kubebuilder:object:generate=false
-type Conditioned interface {
-	SetConditions(...metav1.Condition)
-	GetCondition(string) *metav1.Condition
-}
-
 // A ConditionedWithType may have conditions set or retrieved based on agent type. Conditions typically
 // indicate the status of both a resource and its reconciliation process.
 // +kubebuilder:object:generate=false
 type ConditionedWithType interface {
 	SetConditionsWithType(AgentType, ...metav1.Condition)
 	GetConditionWithType(AgentType, string) *metav1.Condition
-}
-
-// A ConditionedObj is for kubernetes resource with conditions.
-// +kubebuilder:object:generate=false
-type ConditionedObj interface {
-	client.Object
-	Conditioned
 }
 
 // A ConditionedAgentObj is for kubernetes resources where multiple agents can set and update conditions within AgentStatus.

--- a/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
+++ b/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
@@ -85,13 +85,8 @@ spec:
                 - name
                 type: object
                 x-kubernetes-map-type: atomic
-              state:
-                description: 'The desired state of the member cluster. Possible values:
-                  Join, Leave.'
-                type: string
             required:
             - identity
-            - state
             type: object
           status:
             description: The observed status of MemberCluster.

--- a/pkg/controllers/internalmembercluster/v1beta1/member_controller.go
+++ b/pkg/controllers/internalmembercluster/v1beta1/member_controller.go
@@ -26,6 +26,7 @@ import (
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	workapi "go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/metrics"
+	"go.goms.io/fleet/pkg/utils/condition"
 )
 
 // Reconciler reconciles a InternalMemberCluster object in the member cluster.
@@ -319,8 +320,7 @@ func (r *Reconciler) markInternalMemberClusterLeaveFailed(imc clusterv1beta1.Con
 	}
 
 	// Joined status changed.
-	existingCondition := imc.GetConditionWithType(clusterv1beta1.MemberAgent, newCondition.Type)
-	if existingCondition == nil || existingCondition.ObservedGeneration != imc.GetGeneration() || existingCondition.Status != newCondition.Status {
+	if !condition.IsConditionStatusTrue(imc.GetConditionWithType(clusterv1beta1.MemberAgent, newCondition.Type), imc.GetGeneration()) {
 		r.recorder.Event(imc, corev1.EventTypeNormal, eventReasonInternalMemberClusterFailedToLeave, "internal member cluster failed to leave")
 		klog.ErrorS(err, "agent leave failed", "InternalMemberCluster", klog.KObj(imc))
 	}

--- a/pkg/controllers/membercluster/v1alpha1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1alpha1/membercluster_controller.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
+	"go.goms.io/fleet/apis"
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
 	"go.goms.io/fleet/pkg/metrics"
@@ -477,7 +478,7 @@ func (r *Reconciler) aggregateJoinedCondition(mc *fleetv1alpha1.MemberCluster) {
 }
 
 // markMemberClusterReadyToJoin is used to update the ReadyToJoin condition as true of member cluster.
-func markMemberClusterReadyToJoin(recorder record.EventRecorder, mc fleetv1alpha1.ConditionedObj) {
+func markMemberClusterReadyToJoin(recorder record.EventRecorder, mc apis.ConditionedObj) {
 	klog.V(2).InfoS("markMemberClusterReadyToJoin", "memberCluster", klog.KObj(mc))
 	newCondition := metav1.Condition{
 		Type:               string(fleetv1alpha1.ConditionTypeMemberClusterReadyToJoin),
@@ -497,7 +498,7 @@ func markMemberClusterReadyToJoin(recorder record.EventRecorder, mc fleetv1alpha
 }
 
 // markMemberClusterJoined is used to the update the status of the member cluster to have the joined condition.
-func markMemberClusterJoined(recorder record.EventRecorder, mc fleetv1alpha1.ConditionedObj) {
+func markMemberClusterJoined(recorder record.EventRecorder, mc apis.ConditionedObj) {
 	klog.V(2).InfoS("markMemberClusterJoined", "memberCluster", klog.KObj(mc))
 	newCondition := metav1.Condition{
 		Type:               string(fleetv1alpha1.ConditionTypeMemberClusterJoined),
@@ -518,7 +519,7 @@ func markMemberClusterJoined(recorder record.EventRecorder, mc fleetv1alpha1.Con
 }
 
 // markMemberClusterLeft is used to update the status of the member cluster to have the left condition and mark member cluster as not ready to join.
-func markMemberClusterLeft(recorder record.EventRecorder, mc fleetv1alpha1.ConditionedObj) {
+func markMemberClusterLeft(recorder record.EventRecorder, mc apis.ConditionedObj) {
 	klog.V(2).InfoS("markMemberClusterLeft", "memberCluster", klog.KObj(mc))
 	newCondition := metav1.Condition{
 		Type:               string(fleetv1alpha1.ConditionTypeMemberClusterJoined),
@@ -545,7 +546,7 @@ func markMemberClusterLeft(recorder record.EventRecorder, mc fleetv1alpha1.Condi
 }
 
 // markMemberClusterUnknown is used to update the status of the member cluster to have the left condition.
-func markMemberClusterUnknown(recorder record.EventRecorder, mc fleetv1alpha1.ConditionedObj) {
+func markMemberClusterUnknown(recorder record.EventRecorder, mc apis.ConditionedObj) {
 	klog.V(2).InfoS("markMemberClusterUnknown", "memberCluster", klog.KObj(mc))
 	newCondition := metav1.Condition{
 		Type:               string(fleetv1alpha1.ConditionTypeMemberClusterJoined),

--- a/pkg/controllers/membercluster/v1alpha1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1alpha1/membercluster_controller.go
@@ -158,17 +158,17 @@ func (r *Reconciler) garbageCollectWork(ctx context.Context, mc *fleetv1alpha1.M
 	}
 	klog.V(2).InfoS("successfully removed all the work finalizers in the cluster namespace",
 		"memberCluster", klog.KObj(mc), "number of work", len(works.Items))
-	controllerutil.RemoveFinalizer(mc, utils.MemberClusterFinalizer)
+	controllerutil.RemoveFinalizer(mc, fleetv1alpha1.MemberClusterFinalizer)
 	return ctrl.Result{}, r.Update(ctx, mc, &client.UpdateOptions{})
 }
 
 // ensureFinalizer makes sure that the member cluster CR has a finalizer on it
 func (r *Reconciler) ensureFinalizer(ctx context.Context, mc *fleetv1alpha1.MemberCluster) error {
-	if controllerutil.ContainsFinalizer(mc, utils.MemberClusterFinalizer) {
+	if controllerutil.ContainsFinalizer(mc, fleetv1alpha1.MemberClusterFinalizer) {
 		return nil
 	}
 	klog.InfoS("add the member cluster finalizer", "memberCluster", klog.KObj(mc))
-	controllerutil.AddFinalizer(mc, utils.MemberClusterFinalizer)
+	controllerutil.AddFinalizer(mc, fleetv1alpha1.MemberClusterFinalizer)
 	return r.Update(ctx, mc, client.FieldOwner(utils.MCControllerFieldManagerName))
 }
 

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -82,17 +82,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		klog.ErrorS(err, "failed to add the finalizer to member cluster", "memberCluster", mcObjRef)
 		return ctrl.Result{}, err
 	}
-	currentImc, err := r.getInternalMemberCluster(ctx, mc.GetName())
+	currentIMC, err := r.getInternalMemberCluster(ctx, mc.GetName())
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.join(ctx, &mc, currentImc); err != nil {
+	if err := r.join(ctx, &mc, currentIMC); err != nil {
 		klog.ErrorS(err, "failed to join", "memberCluster", mcObjRef)
 		return ctrl.Result{}, err
 	}
 
 	// Copy status from InternalMemberCluster to MemberCluster.
-	r.syncInternalMemberClusterStatus(currentImc, &mc)
+	r.syncInternalMemberClusterStatus(currentIMC, &mc)
 	if err := r.updateMemberClusterStatus(ctx, &mc); err != nil {
 		if apierrors.IsConflict(err) {
 			klog.V(2).InfoS("failed to update status due to conflicts", "memberCluster", mcObjRef)
@@ -105,8 +105,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
-// handle the delete event of the member cluster, make sure the agent has finished leaving the fleet first and
-// then garbage collect all the resources in the cluster namespace
+// handleDelete handles the delete event of the member cluster, makes sure the agent has finished leaving the fleet first and
+// then garbage collects all the resources in the cluster namespace.
 func (r *Reconciler) handleDelete(ctx context.Context, mc *clusterv1beta1.MemberCluster) (ctrl.Result, error) {
 	mcObjRef := klog.KObj(mc)
 	if !controllerutil.ContainsFinalizer(mc, placementv1beta1.MemberClusterFinalizer) {

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
+	"go.goms.io/fleet/apis"
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/metrics"
@@ -501,7 +502,7 @@ func (r *Reconciler) aggregateJoinedCondition(mc *clusterv1beta1.MemberCluster) 
 }
 
 // markMemberClusterReadyToJoin is used to update the ReadyToJoin condition as true of member cluster.
-func markMemberClusterReadyToJoin(recorder record.EventRecorder, mc placementv1beta1.ConditionedObj) {
+func markMemberClusterReadyToJoin(recorder record.EventRecorder, mc apis.ConditionedObj) {
 	klog.V(2).InfoS("markMemberClusterReadyToJoin", "memberCluster", klog.KObj(mc))
 	newCondition := metav1.Condition{
 		Type:               string(clusterv1beta1.ConditionTypeMemberClusterReadyToJoin),
@@ -521,7 +522,7 @@ func markMemberClusterReadyToJoin(recorder record.EventRecorder, mc placementv1b
 }
 
 // markMemberClusterJoined is used to the update the status of the member cluster to have the joined condition.
-func markMemberClusterJoined(recorder record.EventRecorder, mc placementv1beta1.ConditionedObj) {
+func markMemberClusterJoined(recorder record.EventRecorder, mc apis.ConditionedObj) {
 	klog.V(2).InfoS("markMemberClusterJoined", "memberCluster", klog.KObj(mc))
 	newCondition := metav1.Condition{
 		Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
@@ -542,7 +543,7 @@ func markMemberClusterJoined(recorder record.EventRecorder, mc placementv1beta1.
 }
 
 // markMemberClusterLeft is used to update the status of the member cluster to have the left condition and mark member cluster as not ready to join.
-func markMemberClusterLeft(recorder record.EventRecorder, mc placementv1beta1.ConditionedObj) {
+func markMemberClusterLeft(recorder record.EventRecorder, mc apis.ConditionedObj) {
 	klog.V(2).InfoS("markMemberClusterLeft", "memberCluster", klog.KObj(mc))
 	newCondition := metav1.Condition{
 		Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),
@@ -569,7 +570,7 @@ func markMemberClusterLeft(recorder record.EventRecorder, mc placementv1beta1.Co
 }
 
 // markMemberClusterUnknown is used to update the status of the member cluster to have the left condition.
-func markMemberClusterUnknown(recorder record.EventRecorder, mc placementv1beta1.ConditionedObj) {
+func markMemberClusterUnknown(recorder record.EventRecorder, mc apis.ConditionedObj) {
 	klog.V(2).InfoS("markMemberClusterUnknown", "memberCluster", klog.KObj(mc))
 	newCondition := metav1.Condition{
 		Type:               string(clusterv1beta1.ConditionTypeMemberClusterJoined),

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -32,6 +32,7 @@ import (
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/metrics"
 	"go.goms.io/fleet/pkg/utils"
+	"go.goms.io/fleet/pkg/utils/controller"
 )
 
 const (
@@ -62,61 +63,36 @@ type Reconciler struct {
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	klog.V(2).InfoS("Reconcile", "memberCluster", req.NamespacedName)
-	var oldMC clusterv1beta1.MemberCluster
-	if err := r.Client.Get(ctx, req.NamespacedName, &oldMC); err != nil {
+	var mc clusterv1beta1.MemberCluster
+	mcObjRef := klog.KObj(&mc)
+	if err := r.Client.Get(ctx, req.NamespacedName, &mc); err != nil {
 		klog.ErrorS(err, "failed to get member cluster", "memberCluster", req.Name)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Handle deleting member cluster, garbage collect all the resources in the cluster namespace
-	if !oldMC.DeletionTimestamp.IsZero() {
-		klog.V(2).InfoS("the member cluster is in the process of being deleted", "memberCluster", klog.KObj(&oldMC))
-		return r.garbageCollectWork(ctx, &oldMC)
+	// Handle deleting/leaving member cluster, garbage collect all the resources in the cluster namespace
+	if !mc.DeletionTimestamp.IsZero() {
+		klog.V(2).InfoS("the member cluster is leaving", "memberCluster", mcObjRef)
+		return r.handleDelete(ctx, mc.DeepCopy())
 	}
 
-	mc := oldMC.DeepCopy()
-	mcObjRef := klog.KObj(mc)
 	// Add the finalizer to the member cluster
-	if err := r.ensureFinalizer(ctx, mc); err != nil {
+	if err := r.ensureFinalizer(ctx, &mc); err != nil {
 		klog.ErrorS(err, "failed to add the finalizer to member cluster", "memberCluster", mcObjRef)
 		return ctrl.Result{}, err
 	}
-
-	// Get current internal member cluster.
-	namespaceName := fmt.Sprintf(utils.NamespaceNameFormat, mc.Name)
-	imcNamespacedName := types.NamespacedName{Namespace: namespaceName, Name: mc.Name}
-	var imc clusterv1beta1.InternalMemberCluster
-	currentImc := &imc
-	if err := r.Client.Get(ctx, imcNamespacedName, &imc); err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.ErrorS(err, "failed to get internal member cluster", "internalMemberCluster", imcNamespacedName)
-			return ctrl.Result{}, err
-		}
-		// Not found.
-		currentImc = nil
+	currentImc, err := r.getInternalMemberCluster(ctx, mc.GetName())
+	if err != nil {
+		return ctrl.Result{}, err
 	}
-
-	switch mc.Spec.State {
-	case clusterv1beta1.ClusterStateJoin:
-		if err := r.join(ctx, mc, currentImc); err != nil {
-			klog.ErrorS(err, "failed to join", "memberCluster", mcObjRef)
-			return ctrl.Result{}, err
-		}
-
-	case clusterv1beta1.ClusterStateLeave:
-		if err := r.leave(ctx, mc, currentImc); err != nil {
-			klog.ErrorS(err, "failed to leave", "memberCluster", mcObjRef)
-			return ctrl.Result{}, err
-		}
-
-	default:
-		klog.Errorf("encountered a fatal error. unknown state %v in MemberCluster: %s", mc.Spec.State, mcObjRef)
-		return ctrl.Result{}, nil
+	if err := r.join(ctx, &mc, currentImc); err != nil {
+		klog.ErrorS(err, "failed to join", "memberCluster", mcObjRef)
+		return ctrl.Result{}, err
 	}
 
 	// Copy status from InternalMemberCluster to MemberCluster.
-	r.syncInternalMemberClusterStatus(currentImc, mc)
-	if err := r.updateMemberClusterStatus(ctx, mc); err != nil {
+	r.syncInternalMemberClusterStatus(currentImc, &mc)
+	if err := r.updateMemberClusterStatus(ctx, &mc); err != nil {
 		if apierrors.IsConflict(err) {
 			klog.V(2).InfoS("failed to update status due to conflicts", "memberCluster", mcObjRef)
 		} else {
@@ -126,6 +102,54 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// handle the delete event of the member cluster, make sure the agent has finished leaving the fleet first and
+// then garbage collect all the resources in the cluster namespace
+func (r *Reconciler) handleDelete(ctx context.Context, mc *clusterv1beta1.MemberCluster) (ctrl.Result, error) {
+	mcObjRef := klog.KObj(mc)
+	if !controllerutil.ContainsFinalizer(mc, placementv1beta1.MemberClusterFinalizer) {
+		klog.V(2).InfoS("No need to do anything for the deleting member cluster without a finalizer", "memberCluster", mcObjRef)
+		return ctrl.Result{}, nil
+	}
+	currentImc, err := r.getInternalMemberCluster(ctx, mc.GetName())
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// calculate the current status of the member cluster from imc status
+	r.syncInternalMemberClusterStatus(currentImc, mc)
+	cond := meta.FindStatusCondition(mc.Status.Conditions, string(clusterv1beta1.AgentJoined))
+	// cluster never joined or already left
+	if cond != nil && cond.Status == metav1.ConditionFalse && cond.ObservedGeneration == mc.GetGeneration() {
+		klog.V(2).InfoS("No need to wait for agent leave, start garbage collecting", "memberCluster", mcObjRef)
+		return r.garbageCollectWork(ctx, mc)
+	}
+
+	// mark the imc as left again to make sure the agent is leaving the fleet
+	if err := r.leave(ctx, mc, currentImc); err != nil {
+		klog.ErrorS(err, "failed to leave", "memberCluster", mcObjRef)
+		return ctrl.Result{}, err
+	}
+	// update the mc status while we wait for all the agents to leave
+	err = r.updateMemberClusterStatus(ctx, mc)
+	return ctrl.Result{}, controller.NewUpdateIgnoreConflictError(err)
+}
+
+func (r *Reconciler) getInternalMemberCluster(ctx context.Context, name string) (*clusterv1beta1.InternalMemberCluster, error) {
+	// Get current internal member cluster.
+	namespaceName := fmt.Sprintf(utils.NamespaceNameFormat, name)
+	imcNamespacedName := types.NamespacedName{Namespace: namespaceName, Name: name}
+	var imc clusterv1beta1.InternalMemberCluster
+	currentImc := &imc
+	if err := r.Client.Get(ctx, imcNamespacedName, &imc); err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.ErrorS(err, "failed to get internal member cluster", "internalMemberCluster", imcNamespacedName)
+			return nil, err
+		}
+		// Not found.
+		currentImc = nil
+	}
+	return currentImc, nil
 }
 
 // garbageCollectWork remove all the finalizers on the work that are in the cluster namespace
@@ -158,17 +182,17 @@ func (r *Reconciler) garbageCollectWork(ctx context.Context, mc *clusterv1beta1.
 	}
 	klog.V(2).InfoS("successfully removed all the work finalizers in the cluster namespace",
 		"memberCluster", klog.KObj(mc), "number of work", len(works.Items))
-	controllerutil.RemoveFinalizer(mc, utils.MemberClusterFinalizer)
+	controllerutil.RemoveFinalizer(mc, placementv1beta1.MemberClusterFinalizer)
 	return ctrl.Result{}, r.Update(ctx, mc, &client.UpdateOptions{})
 }
 
 // ensureFinalizer makes sure that the member cluster CR has a finalizer on it
 func (r *Reconciler) ensureFinalizer(ctx context.Context, mc *clusterv1beta1.MemberCluster) error {
-	if controllerutil.ContainsFinalizer(mc, utils.MemberClusterFinalizer) {
+	if controllerutil.ContainsFinalizer(mc, placementv1beta1.MemberClusterFinalizer) {
 		return nil
 	}
 	klog.InfoS("add the member cluster finalizer", "memberCluster", klog.KObj(mc))
-	controllerutil.AddFinalizer(mc, utils.MemberClusterFinalizer)
+	controllerutil.AddFinalizer(mc, placementv1beta1.MemberClusterFinalizer)
 	return r.Update(ctx, mc, client.FieldOwner(utils.MCControllerFieldManagerName))
 }
 
@@ -211,10 +235,6 @@ func (r *Reconciler) join(ctx context.Context, mc *clusterv1beta1.MemberCluster,
 // Note that leave doesn't delete any of the resources created by join(). Instead, deleting MemberCluster will delete them.
 func (r *Reconciler) leave(ctx context.Context, mc *clusterv1beta1.MemberCluster, imc *clusterv1beta1.InternalMemberCluster) error {
 	klog.V(2).InfoS("leave", "memberCluster", klog.KObj(mc))
-	// Never joined successfully before.
-	if imc == nil {
-		return nil
-	}
 
 	// Copy spec from member cluster to internal member cluster.
 	namespaceName := fmt.Sprintf(utils.NamespaceNameFormat, mc.Name)
@@ -371,9 +391,13 @@ func (r *Reconciler) syncInternalMemberCluster(ctx context.Context, mc *clusterv
 			OwnerReferences: []metav1.OwnerReference{*toOwnerReference(mc)},
 		},
 		Spec: clusterv1beta1.InternalMemberClusterSpec{
-			State:                  mc.Spec.State,
 			HeartbeatPeriodSeconds: mc.Spec.HeartbeatPeriodSeconds,
 		},
+	}
+	if mc.GetDeletionTimestamp().IsZero() {
+		expectedImc.Spec.State = clusterv1beta1.ClusterStateJoin
+	} else {
+		expectedImc.Spec.State = clusterv1beta1.ClusterStateLeave
 	}
 
 	// Creates internal member cluster if not found.

--- a/pkg/controllers/membercluster/v1beta1/membercluster_suite_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_suite_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
@@ -55,6 +56,8 @@ var _ = BeforeSuite(func() {
 		err = placementv1beta1.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 		err = clusterv1beta1.AddToScheme(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+		err = workv1alpha1.AddToScheme(scheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 
 		//+kubebuilder:scaffold:scheme

--- a/pkg/scheduler/clustereligibilitychecker/checker.go
+++ b/pkg/scheduler/clustereligibilitychecker/checker.go
@@ -89,7 +89,7 @@ func New(opts ...Option) *ClusterEligibilityChecker {
 // also return the reason.
 func (checker *ClusterEligibilityChecker) IsEligible(cluster *clusterv1beta1.MemberCluster) (eligible bool, reason string) {
 	// Filter out clusters that have left the fleet.
-	if cluster.Spec.State == clusterv1beta1.ClusterStateLeave {
+	if !cluster.GetDeletionTimestamp().IsZero() {
 		return false, "cluster has left the fleet"
 	}
 

--- a/pkg/scheduler/clustereligibilitychecker/checker_test.go
+++ b/pkg/scheduler/clustereligibilitychecker/checker_test.go
@@ -27,7 +27,7 @@ func TestIsClusterEligible(t *testing.T) {
 		WithClusterHeartbeatCheckTimeout(clusterHeartbeatCheckTimeout),
 		WithClusterHealthCheckTimeout(clusterHealthCheckTimeout),
 	)
-
+	deleteTime := metav1.Now()
 	testCases := []struct {
 		name             string
 		cluster          *clusterv1beta1.MemberCluster
@@ -38,10 +38,8 @@ func TestIsClusterEligible(t *testing.T) {
 			name: "cluster left",
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateLeave,
+					Name:              clusterName,
+					DeletionTimestamp: &deleteTime,
 				},
 			},
 			wantReasonPrefix: "cluster has left the fleet",
@@ -52,9 +50,6 @@ func TestIsClusterEligible(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
-				},
 				Status: clusterv1beta1.MemberClusterStatus{},
 			},
 			wantReasonPrefix: "cluster is not connected to the fleet: member agent not online yet",
@@ -64,9 +59,6 @@ func TestIsClusterEligible(t *testing.T) {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
 				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
@@ -84,9 +76,6 @@ func TestIsClusterEligible(t *testing.T) {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
 				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
@@ -111,9 +100,6 @@ func TestIsClusterEligible(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
-				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
 						{
@@ -137,9 +123,6 @@ func TestIsClusterEligible(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
-				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
 						{
@@ -162,9 +145,6 @@ func TestIsClusterEligible(t *testing.T) {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
 				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
@@ -194,9 +174,6 @@ func TestIsClusterEligible(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
-				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
 						{
@@ -224,9 +201,6 @@ func TestIsClusterEligible(t *testing.T) {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
 				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -230,6 +230,7 @@ func TestClassifyBindings(t *testing.T) {
 			Name: policyName,
 		},
 	}
+	deleteTime := metav1.Now()
 
 	clusterName1 := fmt.Sprintf(clusterNameTemplate, 1)
 	clusterName2 := fmt.Sprintf(clusterNameTemplate, 2)
@@ -240,24 +241,16 @@ func TestClassifyBindings(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterName1,
 			},
-			Spec: clusterv1beta1.MemberClusterSpec{
-				State: clusterv1beta1.ClusterStateJoin,
-			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterName2,
 			},
-			Spec: clusterv1beta1.MemberClusterSpec{
-				State: clusterv1beta1.ClusterStateJoin,
-			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: clusterName3,
-			},
-			Spec: clusterv1beta1.MemberClusterSpec{
-				State: clusterv1beta1.ClusterStateLeave,
+				Name:              clusterName3,
+				DeletionTimestamp: &deleteTime,
 			},
 		},
 	}
@@ -4344,6 +4337,8 @@ func TestShouldRequeue(t *testing.T) {
 
 // TestCrossReferenceClustersWithTargetNames tests the crossReferenceClustersWithTargetNames method.
 func TestCrossReferenceClustersWithTargetNames(t *testing.T) {
+	deleteTime := metav1.Now()
+
 	clusterName1 := fmt.Sprintf(clusterNameTemplate, 1)
 	clusterName2 := fmt.Sprintf(clusterNameTemplate, 2)
 	clusterName3 := fmt.Sprintf(clusterNameTemplate, 3)
@@ -4355,9 +4350,6 @@ func TestCrossReferenceClustersWithTargetNames(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterName1,
-			},
-			Spec: clusterv1beta1.MemberClusterSpec{
-				State: clusterv1beta1.ClusterStateJoin,
 			},
 			Status: clusterv1beta1.MemberClusterStatus{
 				AgentStatus: []clusterv1beta1.AgentStatus{
@@ -4382,9 +4374,6 @@ func TestCrossReferenceClustersWithTargetNames(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: clusterName2,
-			},
-			Spec: clusterv1beta1.MemberClusterSpec{
-				State: clusterv1beta1.ClusterStateJoin,
 			},
 			Status: clusterv1beta1.MemberClusterStatus{
 				AgentStatus: []clusterv1beta1.AgentStatus{
@@ -4413,10 +4402,8 @@ func TestCrossReferenceClustersWithTargetNames(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: clusterName4,
-			},
-			Spec: clusterv1beta1.MemberClusterSpec{
-				State: clusterv1beta1.ClusterStateLeave,
+				Name:              clusterName4,
+				DeletionTimestamp: &deleteTime,
 			},
 		},
 	}

--- a/pkg/scheduler/framework/frameworkutils.go
+++ b/pkg/scheduler/framework/frameworkutils.go
@@ -56,7 +56,7 @@ func classifyBindings(policy *placementv1beta1.ClusterSchedulingPolicySnapshot, 
 			// unscheduled bindings are disregarded by the scheduler.
 		case binding.Spec.State == placementv1beta1.BindingStateUnscheduled:
 			// Ignore any binding that is of the unscheduled state.
-		case !isTargetClusterPresent || targetCluster.Spec.State == clusterv1beta1.ClusterStateLeave:
+		case !isTargetClusterPresent || !targetCluster.GetDeletionTimestamp().IsZero():
 			// Check if the binding is now dangling, i.e., it is associated with a cluster that
 			// is no longer in normal operations, but is still of a scheduled or bound state.
 			//

--- a/pkg/scheduler/framework/plugins/clustereligibility/plugin_test.go
+++ b/pkg/scheduler/framework/plugins/clustereligibility/plugin_test.go
@@ -62,7 +62,7 @@ func TestFilter(t *testing.T) {
 			Name: policyName,
 		},
 	}
-
+	deleteTime := metav1.Now()
 	testCases := []struct {
 		name    string
 		cluster *clusterv1beta1.MemberCluster
@@ -72,10 +72,8 @@ func TestFilter(t *testing.T) {
 			name: "cluster left",
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateLeave,
+					Name:              clusterName,
+					DeletionTimestamp: &deleteTime,
 				},
 			},
 			want: framework.NewNonErrorStatus(framework.ClusterUnschedulable, defaultPluginName, ""),
@@ -86,9 +84,6 @@ func TestFilter(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
-				},
 				Status: clusterv1beta1.MemberClusterStatus{},
 			},
 			want: framework.NewNonErrorStatus(framework.ClusterUnschedulable, defaultPluginName, ""),
@@ -98,9 +93,6 @@ func TestFilter(t *testing.T) {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
 				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
@@ -118,9 +110,6 @@ func TestFilter(t *testing.T) {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
 				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
@@ -145,9 +134,6 @@ func TestFilter(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
-				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
 						{
@@ -171,9 +157,6 @@ func TestFilter(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
-				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
 						{
@@ -196,9 +179,6 @@ func TestFilter(t *testing.T) {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
 				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
@@ -228,9 +208,6 @@ func TestFilter(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
 				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
-				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{
 						{
@@ -257,9 +234,6 @@ func TestFilter(t *testing.T) {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,
-				},
-				Spec: clusterv1beta1.MemberClusterSpec{
-					State: clusterv1beta1.ClusterStateJoin,
 				},
 				Status: clusterv1beta1.MemberClusterStatus{
 					AgentStatus: []clusterv1beta1.AgentStatus{

--- a/pkg/scheduler/watchers/membercluster/controller.go
+++ b/pkg/scheduler/watchers/membercluster/controller.go
@@ -193,8 +193,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// Capture label changes.
 			//
 			clusterKObj := klog.KObj(newCluster)
-			// The cluster is to be deleted.
-			if !newCluster.GetDeletionTimestamp().IsZero() {
+			// The cluster is being deleted.
+			if oldCluster.GetDeletionTimestamp().IsZero() && !newCluster.GetDeletionTimestamp().IsZero() {
 				klog.V(2).InfoS("A member cluster is leaving the fleet", "memberCluster", clusterKObj)
 				return true
 			}

--- a/pkg/scheduler/watchers/membercluster/suite_test.go
+++ b/pkg/scheduler/watchers/membercluster/suite_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -48,13 +49,10 @@ var (
 )
 
 var (
-	newMemberCluster = func(name string, state clusterv1beta1.ClusterState) *clusterv1beta1.MemberCluster {
+	newMemberCluster = func(name string) *clusterv1beta1.MemberCluster {
 		return &clusterv1beta1.MemberCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,
-			},
-			Spec: clusterv1beta1.MemberClusterSpec{
-				State: state,
 			},
 		}
 	}
@@ -81,9 +79,7 @@ func TestAPIs(t *testing.T) {
 // setupResources adds resources required for this test suite to the hub cluster.
 func setupResources() {
 	// Create a member cluster that has just joined the fleet.
-	Expect(hubClient.Create(ctx, newMemberCluster(clusterName1, clusterv1beta1.ClusterStateJoin))).Should(Succeed(), "Failed to create member cluster")
-	// Create a member cluster that has left the fleet.
-	Expect(hubClient.Create(ctx, newMemberCluster(clusterName2, clusterv1beta1.ClusterStateLeave))).Should(Succeed(), "Failed to create member cluster")
+	Expect(hubClient.Create(ctx, newMemberCluster(clusterName1))).Should(Succeed(), "Failed to create member cluster")
 
 	// Create a CRP that has no placement policy specified.
 	Expect(hubClient.Create(ctx, newCRP(crpName1, nil))).Should(Succeed(), "Failed to create CRP")

--- a/pkg/scheduler/watchers/membercluster/utils_test.go
+++ b/pkg/scheduler/watchers/membercluster/utils_test.go
@@ -24,7 +24,6 @@ const (
 	crpName4     = "crp-4"
 	crpName5     = "crp-5"
 	crpName6     = "crp-6"
-	crpName7     = "crp-7"
 )
 
 var (

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -48,6 +48,7 @@ const (
 	MCControllerFieldManagerName = "member-cluster-controller"
 )
 
+// TODO(ryanzhang): move this to the api directory
 const (
 	// LabelFleetObj is a label key indicate the resource is created by the fleet.
 	LabelFleetObj      = "kubernetes.azure.com/managed-by"
@@ -56,9 +57,6 @@ const (
 	// LabelWorkPlacementName is used to indicate which placement created the work.
 	// This label aims to enable different work objects to be managed by different placement.
 	LabelWorkPlacementName = "work.fleet.azure.com/placement-name"
-
-	// MemberClusterFinalizer is used to make sure that we handle gc of all the member cluster resources on the hub cluster.
-	MemberClusterFinalizer = "work.fleet.azure.com/membercluster-finalizer"
 
 	// LastWorkUpdateTimeAnnotationKey is used to mark the last update time on a work object.
 	LastWorkUpdateTimeAnnotationKey = "work.fleet.azure.com/last-update-time"


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

All the existing UT/IT/E2E should work

### Special notes for your reviewer

I am not sure the mc watcher for scheduler need to enqueue all the CRPs when a cluster left the fleet.
