### PR TITLE
fix: use the cluster API group for owner reference in member cluster controller

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -402,7 +402,7 @@ func (r *Reconciler) syncInternalMemberCluster(ctx context.Context, mc *clusterv
 }
 
 func toOwnerReference(memberCluster *clusterv1beta1.MemberCluster) *metav1.OwnerReference {
-	return &metav1.OwnerReference{APIVersion: placementv1beta1.GroupVersion.String(), Kind: clusterv1beta1.MemberClusterKind,
+	return &metav1.OwnerReference{APIVersion: clusterv1beta1.GroupVersion.String(), Kind: clusterv1beta1.MemberClusterKind,
 		Name: memberCluster.Name, UID: memberCluster.UID, Controller: pointer.Bool(true)}
 }
 
@@ -413,7 +413,7 @@ func (r *Reconciler) syncInternalMemberClusterStatus(imc *clusterv1beta1.Interna
 		return
 	}
 
-	// TODO: We didn't handle condition type: placementv1beta1.ConditionTypeMemberClusterHealthy.
+	// TODO: We didn't handle condition type: clusterv1beta1.ConditionTypeMemberClusterHealthy.
 	// Copy Agent status.
 	mc.Status.AgentStatus = imc.Status.AgentStatus
 	r.aggregateJoinedCondition(mc)


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue in member cluster controller where the wrong API group in owner reference may lead to events (e.g., InternalMemberCluster status updates) not being reconciled.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

