### PR TITLE
fix: use InfoS for logs with keys/values

### DIFF
--- a/pkg/scheduler/watchers/membercluster/controller.go
+++ b/pkg/scheduler/watchers/membercluster/controller.go
@@ -165,13 +165,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// CRPs anyway, which will account for any missing updates on the cluster side
 			// during the downtime; in other words, notifications from this controller is not
 			// necessary.
-			klog.V(2).Info("Ignoring create events for member cluster objects", "eventObject", klog.KObj(e.Object))
+			klog.V(2).InfoS("Ignoring create events for member cluster objects", "eventObject", klog.KObj(e.Object))
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Ignore deletion events; the removal of a cluster is first signaled by the join
 			// state change (join -> leave), which is already handled separately.
-			klog.V(2).Info("Ignoring delete events for member cluster objects", "eventObject", klog.KObj(e.Object))
+			klog.V(2).InfoS("Ignoring delete events for member cluster objects", "eventObject", klog.KObj(e.Object))
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -195,13 +195,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// Note that the controller runs only when label changes happen on joined clusters.
 			clusterKObj := klog.KObj(newCluster)
 			if newCluster.Spec.State == clusterv1beta1.ClusterStateJoin && !reflect.DeepEqual(oldCluster.Labels, newCluster.Labels) {
-				klog.V(2).Info("An member cluster label change has been detected", "memberCluster", clusterKObj)
+				klog.V(2).InfoS("An member cluster label change has been detected", "memberCluster", clusterKObj)
 				return true
 			}
 
 			// The cluster has left.
 			if oldCluster.Spec.State == clusterv1beta1.ClusterStateJoin && newCluster.Spec.State == clusterv1beta1.ClusterStateLeave {
-				klog.V(2).Info("A member cluster has left the fleet", "memberCluster", clusterKObj)
+				klog.V(2).InfoS("A member cluster has left the fleet", "memberCluster", clusterKObj)
 				return true
 			}
 
@@ -213,12 +213,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				// The cluster becomes eligible for resource placement, i.e., match for case 1b).
 				//
 				// The reverse, i.e., eligible -> ineligible, is ignored (case 2b)).
-				klog.V(2).Info("A member cluster may become eligible for resource placement", "memberCluster", clusterKObj)
+				klog.V(2).InfoS("A member cluster may become eligible for resource placement", "memberCluster", clusterKObj)
 				return true
 			}
 
 			// All the other changes are ignored.
-			klog.V(2).Info("Ignoring update events that are irrelevant to the scheduler", "memberCluster", clusterKObj)
+			klog.V(2).InfoS("Ignoring update events that are irrelevant to the scheduler", "memberCluster", clusterKObj)
 			return false
 		},
 	}


### PR DESCRIPTION
### Description of your changes

This PR fixes a minor issue where logs with keys + values are recorded with `Info` rather than `InfoS`, which may lead to malformed texts.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

