### PR TITLE
fix: report in logs when the CRP controller fails to select resources

### DIFF
--- a/pkg/controllers/clusterresourceplacement/controller.go
+++ b/pkg/controllers/clusterresourceplacement/controller.go
@@ -155,6 +155,7 @@ func (r *Reconciler) handleUpdate(ctx context.Context, crp *fleetv1beta1.Cluster
 	}
 	selectedResources, selectedResourceIDs, err := r.selectResourcesForPlacement(crp)
 	if err != nil {
+		klog.ErrorS(err, "Failed to select resources for placement", "clusterResourcePlacement", crpKObj)
 		return ctrl.Result{}, err
 	}
 	resourceSnapshotSpec := fleetv1beta1.ResourceSnapshotSpec{


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where the CRP controller will not emit any log when resources cannot be selected.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

