### PR TITLE
feat: declare v1beta1 work related const in the api folder

### DIFF
--- a/apis/placement/v1beta1/binding_types.go
+++ b/apis/placement/v1beta1/binding_types.go
@@ -10,11 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// WorkFinalizer is used to make sure that the binding is not deleted until the work objects it generates are all deleted.
-	WorkFinalizer = fleetPrefix + "work-cleanup"
-)
-
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,categories={fleet,fleet-placement},shortName=rb
 // +kubebuilder:subresource:status

--- a/apis/placement/v1beta1/commons.go
+++ b/apis/placement/v1beta1/commons.go
@@ -14,6 +14,11 @@ const (
 	// MemberClusterFinalizer is used to make sure that we handle gc of all the member cluster resources on the hub cluster.
 	MemberClusterFinalizer = fleetPrefix + "membercluster-finalizer"
 
+	// WorkFinalizer is used by the work generator to make sure that the binding is not deleted until the work objects
+	// it generates are all deleted, or used by the work controller to make sure the work has been deleted in the member
+	// cluster.
+	WorkFinalizer = fleetPrefix + "work-cleanup"
+
 	// CRPTrackingLabel is the label that points to the cluster resource policy that creates a resource binding.
 	CRPTrackingLabel = fleetPrefix + "parentCRP"
 

--- a/apis/placement/v1beta1/work_types.go
+++ b/apis/placement/v1beta1/work_types.go
@@ -26,6 +26,20 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// The following definitions are declared in the manager.go file.
+const (
+	// ManifestHashAnnotation is the annotation that indicates whether the spec of the object has been changed or not.
+	ManifestHashAnnotation = fleetPrefix + "spec-hash"
+
+	// LastAppliedConfigAnnotation is to record the last applied configuration on the object.
+	LastAppliedConfigAnnotation = fleetPrefix + "last-applied-configuration"
+
+	// WorkConditionTypeApplied represents workload in Work is applied successfully on the spoke cluster.
+	WorkConditionTypeApplied = "Applied"
+	// WorkConditionTypeAvailable represents workload in Work exists on the spoke cluster.
+	WorkConditionTypeAvailable = "Available"
+)
+
 // This api is copied from https://github.com/kubernetes-sigs/work-api/blob/master/pkg/apis/v1alpha1/work_types.go.
 // Renamed original "ResourceIdentifier" so that it won't conflict with ResourceIdentifier defined in the clusterresourceplacement_types.go.
 

--- a/pkg/controllers/clusterresourceplacement/placement_status.go
+++ b/pkg/controllers/clusterresourceplacement/placement_status.go
@@ -16,7 +16,6 @@ import (
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
-	workapi "go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/utils"
 	"go.goms.io/fleet/pkg/utils/annotations"
 	"go.goms.io/fleet/pkg/utils/controller"
@@ -273,7 +272,7 @@ func buildWorkAppliedCondition(crp *fleetv1beta1.ClusterResourcePlacement, hasPe
 func buildFailedResourcePlacements(work *workv1alpha1.Work) (isPending bool, res []fleetv1beta1.FailedResourcePlacement) {
 	// check the overall condition
 	workKObj := klog.KObj(work)
-	appliedCond := meta.FindStatusCondition(work.Status.Conditions, workapi.ConditionTypeApplied)
+	appliedCond := meta.FindStatusCondition(work.Status.Conditions, fleetv1beta1.WorkConditionTypeApplied)
 	if appliedCond == nil {
 		klog.V(3).InfoS("The work is never picked up by the member cluster", "work", workKObj)
 		return true, nil
@@ -290,7 +289,7 @@ func buildFailedResourcePlacements(work *workv1alpha1.Work) (isPending bool, res
 
 	res = make([]fleetv1beta1.FailedResourcePlacement, 0, len(work.Status.ManifestConditions))
 	for _, manifestCondition := range work.Status.ManifestConditions {
-		appliedCond = meta.FindStatusCondition(manifestCondition.Conditions, workapi.ConditionTypeApplied)
+		appliedCond = meta.FindStatusCondition(manifestCondition.Conditions, fleetv1beta1.WorkConditionTypeApplied)
 		// collect if there is an explicit fail
 		if appliedCond != nil && appliedCond.Status != metav1.ConditionTrue {
 			klog.V(2).InfoS("Find a failed to apply manifest",

--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -33,7 +33,6 @@ import (
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
-	workapi "go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/utils"
 	"go.goms.io/fleet/pkg/utils/condition"
 	"go.goms.io/fleet/pkg/utils/controller"
@@ -417,7 +416,7 @@ func getWorkNameFromSnapshotName(resourceSnapshot *fleetv1beta1.ClusterResourceS
 func buildAllWorkAppliedCondition(works map[string]*workv1alpha1.Work, binding *fleetv1beta1.ClusterResourceBinding) metav1.Condition {
 	allApplied := true
 	for _, work := range works {
-		if !condition.IsConditionStatusTrue(meta.FindStatusCondition(work.Status.Conditions, workapi.ConditionTypeApplied), work.GetGeneration()) {
+		if !condition.IsConditionStatusTrue(meta.FindStatusCondition(work.Status.Conditions, fleetv1beta1.WorkConditionTypeApplied), work.GetGeneration()) {
 			allApplied = false
 			break
 		}
@@ -493,8 +492,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 						"Failed to process an update event for work object")
 					return
 				}
-				oldAppliedStatus := meta.FindStatusCondition(oldWork.Status.Conditions, workapi.ConditionTypeApplied)
-				newAppliedStatus := meta.FindStatusCondition(newWork.Status.Conditions, workapi.ConditionTypeApplied)
+				oldAppliedStatus := meta.FindStatusCondition(oldWork.Status.Conditions, fleetv1beta1.WorkConditionTypeApplied)
+				newAppliedStatus := meta.FindStatusCondition(newWork.Status.Conditions, fleetv1beta1.WorkConditionTypeApplied)
 				// we only need to handle the case the applied condition is flipped between true and NOT true between the
 				// new and old work objects. Otherwise, it won't affect the binding applied condition
 				if condition.IsConditionStatusTrue(oldAppliedStatus, oldWork.GetGeneration()) == condition.IsConditionStatusTrue(newAppliedStatus, newWork.GetGeneration()) {

--- a/pkg/controllers/workgenerator/controller_integration_test.go
+++ b/pkg/controllers/workgenerator/controller_integration_test.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
-	workapi "go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/utils"
 	"go.goms.io/fleet/pkg/utils/condition"
 )
@@ -751,7 +750,7 @@ func markWorkApplied(work *v1alpha1.Work) {
 	work.Status.Conditions = []metav1.Condition{
 		{
 			Status:             metav1.ConditionTrue,
-			Type:               workapi.ConditionTypeApplied,
+			Type:               fleetv1beta1.WorkConditionTypeApplied,
 			Reason:             "appliedManifest",
 			Message:            "fake apply manifest",
 			ObservedGeneration: work.Generation,

--- a/pkg/controllers/workgenerator/controller_test.go
+++ b/pkg/controllers/workgenerator/controller_test.go
@@ -15,7 +15,6 @@ import (
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
-	workapi "go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/utils/controller"
 )
 
@@ -140,7 +139,7 @@ func Test_buildAllWorkAppliedCondition(t *testing.T) {
 					Status: workv1alpha1.WorkStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               workapi.ConditionTypeApplied,
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
 								Status:             metav1.ConditionTrue,
 								ObservedGeneration: 123,
 							},
@@ -155,7 +154,7 @@ func Test_buildAllWorkAppliedCondition(t *testing.T) {
 					Status: workv1alpha1.WorkStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               workapi.ConditionTypeApplied,
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
 								Status:             metav1.ConditionTrue,
 								ObservedGeneration: 12,
 							},
@@ -181,7 +180,7 @@ func Test_buildAllWorkAppliedCondition(t *testing.T) {
 					Status: workv1alpha1.WorkStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               workapi.ConditionTypeApplied,
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
 								Status:             metav1.ConditionTrue,
 								ObservedGeneration: 122, // not the latest generation
 							},
@@ -196,7 +195,7 @@ func Test_buildAllWorkAppliedCondition(t *testing.T) {
 					Status: workv1alpha1.WorkStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               workapi.ConditionTypeApplied,
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
 								Status:             metav1.ConditionTrue,
 								ObservedGeneration: 12,
 							},
@@ -222,7 +221,7 @@ func Test_buildAllWorkAppliedCondition(t *testing.T) {
 					Status: workv1alpha1.WorkStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               workapi.ConditionTypeApplied,
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
 								Status:             metav1.ConditionTrue,
 								ObservedGeneration: 122, // not the latest generation
 							},
@@ -254,7 +253,7 @@ func Test_buildAllWorkAppliedCondition(t *testing.T) {
 					Status: workv1alpha1.WorkStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               workapi.ConditionTypeApplied,
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
 								Status:             metav1.ConditionUnknown,
 								ObservedGeneration: 123,
 							},
@@ -269,7 +268,7 @@ func Test_buildAllWorkAppliedCondition(t *testing.T) {
 					Status: workv1alpha1.WorkStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               workapi.ConditionTypeApplied,
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
 								Status:             metav1.ConditionTrue,
 								ObservedGeneration: 12,
 							},


### PR DESCRIPTION
### Description of your changes

- declare the work related const in the api folder, so that
    - v1beta1 controllers won't need to import work controller package any more.
    - the annotations can use shared fleet prefix.

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
