### PR TITLE
fix: use new forked Work API in member cluster controller

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
 	"go.goms.io/fleet/apis"
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
@@ -155,7 +154,7 @@ func (r *Reconciler) getInternalMemberCluster(ctx context.Context, name string) 
 
 // garbageCollectWork remove all the finalizers on the work that are in the cluster namespace
 func (r *Reconciler) garbageCollectWork(ctx context.Context, mc *clusterv1beta1.MemberCluster) (ctrl.Result, error) {
-	var works workv1alpha1.WorkList
+	var works placementv1beta1.WorkList
 	var clusterNS corev1.Namespace
 	// check if the namespace still exist
 	namespaceName := fmt.Sprintf(utils.NamespaceNameFormat, mc.Name)


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue in member cluster where it uses the old Work API.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests
- [x] E2E tests (upstream)

### Special notes for your reviewer

