### PR TITLE
fix: use correct CRD availability check when v1beta1 API is enabled + install only relevant CRDs in E2E tests

### DIFF
--- a/apis/placement/v1beta1/appliedwork_types.go
+++ b/apis/placement/v1beta1/appliedwork_types.go
@@ -29,8 +29,6 @@ import (
 // This api is copied from https://github.com/kubernetes-sigs/work-api/blob/master/pkg/apis/v1alpha1/appliedwork_type.go.
 // Fixed the typo in the "AppliedtWorkStatus".
 
-const AppliedWorkKind = "AppliedWork"
-
 // AppliedWorkSpec represents the desired configuration of AppliedWork.
 type AppliedWorkSpec struct {
 	// WorkName represents the name of the related work on the hub.

--- a/apis/placement/v1beta1/commons.go
+++ b/apis/placement/v1beta1/commons.go
@@ -6,6 +6,15 @@ Licensed under the MIT license.
 package v1beta1
 
 const (
+	ClusterResourcePlacementKind        = "ClusterResourcePlacement"
+	ClusterResourceBindingKind          = "ClusterResourceBinding"
+	ClusterResourceSnapshotKind         = "ClusterResourceSnapshot"
+	ClusterSchedulingPolicySnapshotKind = "ClusterSchedulingPolicySnapshot"
+	WorkKind                            = "Work"
+	AppliedWorkKind                     = "AppliedWork"
+)
+
+const (
 	// Unprefixed labels/annotations are reserved for end-users
 	// we will add a kubernetes-fleet.io to designate these labels/annotations as official fleet labels/annotations.
 	// See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#label-selector-and-annotation-conventions

--- a/apis/placement/v1beta1/work_types.go
+++ b/apis/placement/v1beta1/work_types.go
@@ -43,9 +43,6 @@ const (
 // This api is copied from https://github.com/kubernetes-sigs/work-api/blob/master/pkg/apis/v1alpha1/work_types.go.
 // Renamed original "ResourceIdentifier" so that it won't conflict with ResourceIdentifier defined in the clusterresourceplacement_types.go.
 
-const WorkKind = "Work"
-const WorkResource = "works"
-
 // WorkSpec defines the desired state of Work.
 type WorkSpec struct {
 	// Workload represents the manifest workload to be deployed on spoke cluster

--- a/apis/v1alpha1/commons.go
+++ b/apis/v1alpha1/commons.go
@@ -22,6 +22,7 @@ const (
 	MemberClusterKind                = "MemberCluster"
 	MemberClusterResource            = "memberclusters"
 	InternalMemberClusterKind        = "InternalMemberCluster"
+	ClusterResourcePlacementKind     = "ClusterResourcePlacement"
 	ClusterResourcePlacementResource = "clusterresourceplacements"
 )
 

--- a/charts/hub-agent/crdbases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml
+++ b/charts/hub-agent/crdbases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml

--- a/charts/hub-agent/crdbases/cluster.kubernetes-fleet.io_memberclusters.yaml
+++ b/charts/hub-agent/crdbases/cluster.kubernetes-fleet.io_memberclusters.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml

--- a/charts/hub-agent/crdbases/fleet.azure.com_clusterresourceplacements.yaml
+++ b/charts/hub-agent/crdbases/fleet.azure.com_clusterresourceplacements.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/fleet.azure.com_clusterresourceplacements.yaml

--- a/charts/hub-agent/crdbases/fleet.azure.com_internalmemberclusters.yaml
+++ b/charts/hub-agent/crdbases/fleet.azure.com_internalmemberclusters.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/fleet.azure.com_internalmemberclusters.yaml

--- a/charts/hub-agent/crdbases/fleet.azure.com_memberclusters.yaml
+++ b/charts/hub-agent/crdbases/fleet.azure.com_memberclusters.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/fleet.azure.com_memberclusters.yaml

--- a/charts/hub-agent/crdbases/multicluster.x-k8s.io_works.yaml
+++ b/charts/hub-agent/crdbases/multicluster.x-k8s.io_works.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/multicluster.x-k8s.io_works.yaml

--- a/charts/hub-agent/crdbases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/charts/hub-agent/crdbases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml

--- a/charts/hub-agent/crdbases/placement.kubernetes-fleet.io_works.yaml
+++ b/charts/hub-agent/crdbases/placement.kubernetes-fleet.io_works.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/placement.kubernetes-fleet.io_works.yaml

--- a/charts/hub-agent/templates/crds/cluster.kubernetes-fleet.io_internalmemberclusters.yaml
+++ b/charts/hub-agent/templates/crds/cluster.kubernetes-fleet.io_internalmemberclusters.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml

--- a/charts/hub-agent/templates/crds/cluster.kubernetes-fleet.io_memberclusters.yaml
+++ b/charts/hub-agent/templates/crds/cluster.kubernetes-fleet.io_memberclusters.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml

--- a/charts/hub-agent/templates/crds/crps.yaml
+++ b/charts/hub-agent/templates/crds/crps.yaml
@@ -1,0 +1,8 @@
+{{ $files := .Files }}
+{{ if .Values.enableV1Alpha1APIs }}
+    {{ $files.Get "crdbases/fleet.azure.com_clusterresourceplacements.yaml" }}
+{{ end }}
+---
+{{ if .Values.enableV1Beta1APIs }}
+    {{ $files.Get "crdbases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml" }}
+{{ end }}

--- a/charts/hub-agent/templates/crds/fleet.azure.com_clusterresourceplacements.yaml
+++ b/charts/hub-agent/templates/crds/fleet.azure.com_clusterresourceplacements.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/fleet.azure.com_clusterresourceplacements.yaml

--- a/charts/hub-agent/templates/crds/fleet.azure.com_internalmemberclusters.yaml
+++ b/charts/hub-agent/templates/crds/fleet.azure.com_internalmemberclusters.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/fleet.azure.com_internalmemberclusters.yaml

--- a/charts/hub-agent/templates/crds/fleet.azure.com_memberclusters.yaml
+++ b/charts/hub-agent/templates/crds/fleet.azure.com_memberclusters.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/fleet.azure.com_memberclusters.yaml

--- a/charts/hub-agent/templates/crds/internalmemberclusters.yaml
+++ b/charts/hub-agent/templates/crds/internalmemberclusters.yaml
@@ -1,0 +1,8 @@
+{{ $files := .Files }}
+{{ if .Values.enableV1Alpha1APIs }}
+    {{ $files.Get "crdbases/fleet.azure.com_internalmemberclusters.yaml" }}
+{{ end }}
+---
+{{ if .Values.enableV1Beta1APIs }}
+    {{ $files.Get "crdbases/cluster.kubernetes-fleet.io_internalmemberclusters.yaml" }}
+{{ end }}

--- a/charts/hub-agent/templates/crds/memberclusters.yaml
+++ b/charts/hub-agent/templates/crds/memberclusters.yaml
@@ -1,0 +1,8 @@
+{{ $files := .Files }}
+{{ if .Values.enableV1Alpha1APIs }}
+    {{ $files.Get "crdbases/fleet.azure.com_memberclusters.yaml" }}
+{{ end }}
+---
+{{ if .Values.enableV1Beta1APIs }}
+    {{ $files.Get "crdbases/cluster.kubernetes-fleet.io_memberclusters.yaml" }}
+{{ end }}

--- a/charts/hub-agent/templates/crds/multicluster.x-k8s.io_works.yaml
+++ b/charts/hub-agent/templates/crds/multicluster.x-k8s.io_works.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/multicluster.x-k8s.io_works.yaml

--- a/charts/hub-agent/templates/crds/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/charts/hub-agent/templates/crds/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml

--- a/charts/hub-agent/templates/crds/placement.kubernetes-fleet.io_works.yaml
+++ b/charts/hub-agent/templates/crds/placement.kubernetes-fleet.io_works.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/placement.kubernetes-fleet.io_works.yaml

--- a/charts/hub-agent/templates/crds/works.yaml
+++ b/charts/hub-agent/templates/crds/works.yaml
@@ -1,0 +1,8 @@
+{{ $files := .Files }}
+{{ if .Values.enableV1Alpha1APIs }}
+    {{ $files.Get "crdbases/multicluster.x-k8s.io_works.yaml" }}
+{{ end }}
+---
+{{ if .Values.enableV1Beta1APIs }}
+    {{ $files.Get "crdbases/placement.kubernetes-fleet.io_works.yaml" }}
+{{ end }}

--- a/charts/member-agent/crdbases/multicluster.x-k8s.io_appliedworks.yaml
+++ b/charts/member-agent/crdbases/multicluster.x-k8s.io_appliedworks.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/multicluster.x-k8s.io_appliedworks.yaml

--- a/charts/member-agent/crdbases/placement.kubernetes-fleet.io_appliedworks.yaml
+++ b/charts/member-agent/crdbases/placement.kubernetes-fleet.io_appliedworks.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/bases/placement.kubernetes-fleet.io_appliedworks.yaml

--- a/charts/member-agent/templates/crds/appliedworks.yaml
+++ b/charts/member-agent/templates/crds/appliedworks.yaml
@@ -1,0 +1,8 @@
+{{ $files := .Files }}
+{{ if .Values.enableV1Alpha1APIs }}
+    {{ $files.Get "crdbases/multicluster.x-k8s.io_appliedworks.yaml" }}
+{{ end }}
+---
+{{ if .Values.enableV1Beta1APIs }}
+    {{ $files.Get "crdbases/placement.kubernetes-fleet.io_appliedworks.yaml" }}
+{{ end }}

--- a/charts/member-agent/templates/crds/multicluster.x-k8s.io_appliedworks.yaml
+++ b/charts/member-agent/templates/crds/multicluster.x-k8s.io_appliedworks.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/multicluster.x-k8s.io_appliedworks.yaml

--- a/charts/member-agent/templates/crds/placement.kubernetes-fleet.io_appliedworks.yaml
+++ b/charts/member-agent/templates/crds/placement.kubernetes-fleet.io_appliedworks.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/placement.kubernetes-fleet.io_appliedworks.yaml

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
 	"go.goms.io/fleet/apis"
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
@@ -155,7 +154,7 @@ func (r *Reconciler) getInternalMemberCluster(ctx context.Context, name string) 
 
 // garbageCollectWork remove all the finalizers on the work that are in the cluster namespace
 func (r *Reconciler) garbageCollectWork(ctx context.Context, mc *clusterv1beta1.MemberCluster) (ctrl.Result, error) {
-	var works workv1alpha1.WorkList
+	var works placementv1beta1.WorkList
 	var clusterNS corev1.Namespace
 	// check if the namespace still exist
 	namespaceName := fmt.Sprintf(utils.NamespaceNameFormat, mc.Name)

--- a/test/e2e/v1alpha1/webhook_test.go
+++ b/test/e2e/v1alpha1/webhook_test.go
@@ -504,7 +504,7 @@ var _ = Describe("Fleet's CRD Resource Handler webhook tests", func() {
 	Context("CRD validation webhook", func() {
 		It("should deny CREATE operation on Fleet CRD for user not in system:masters group", func() {
 			var crd v1.CustomResourceDefinition
-			Expect(utils.GetObjectFromManifest("./charts/hub-agent/templates/crds/fleet.azure.com_clusterresourceplacements.yaml", &crd)).Should(Succeed())
+			Expect(utils.GetObjectFromManifest("./config/crd/bases/fleet.azure.com_clusterresourceplacements.yaml", &crd)).Should(Succeed())
 
 			By("expecting denial of operation CREATE of CRD")
 			err := HubCluster.ImpersonateKubeClient.Create(ctx, &crd)


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where the hub agent will check for v1alpha1 API even when v1beta1 API is enabled exclusively.

It also updates the upstream E2E tests to install CRDs selectively depending on the API version enabled.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] E2E tests (upstream)

### Special notes for your reviewer

This PR includes the fix from #526.
