### PR TITLE
fix: address an issue where empty reference is logged in member cluster controller

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -65,11 +65,11 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	klog.V(2).InfoS("Reconcile", "memberCluster", req.NamespacedName)
 	var mc clusterv1beta1.MemberCluster
-	mcObjRef := klog.KObj(&mc)
 	if err := r.Client.Get(ctx, req.NamespacedName, &mc); err != nil {
 		klog.ErrorS(err, "failed to get member cluster", "memberCluster", req.Name)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	mcObjRef := klog.KObj(&mc)
 
 	// Handle deleting/leaving member cluster, garbage collect all the resources in the cluster namespace
 	if !mc.DeletionTimestamp.IsZero() {


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where empty key/value pair is logged in member cluster controller.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests
- [x] E2E tests (upstream)

### Special notes for your reviewer

Not a critical fix.
