### PR TITLE
fix: set up correct access control in v1beta1 hub agents

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -299,7 +299,7 @@ func (r *Reconciler) syncRole(ctx context.Context, mc *clusterv1beta1.MemberClus
 			Namespace:       namespaceName,
 			OwnerReferences: []metav1.OwnerReference{*toOwnerReference(mc)},
 		},
-		Rules: []rbacv1.PolicyRule{utils.FleetRule, utils.EventRule, utils.FleetNetworkRule, utils.WorkRule},
+		Rules: []rbacv1.PolicyRule{utils.FleetClusterRule, utils.FleetPlacementRule, utils.FleetNetworkRule, utils.EventRule},
 	}
 
 	// Creates role if not found.

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller_test.go
@@ -200,7 +200,7 @@ func TestSyncRole(t *testing.T) {
 								Name:      "fleet-role-mc1",
 								Namespace: namespace1,
 							},
-							Rules: []rbacv1.PolicyRule{utils.FleetRule, utils.EventRule, utils.FleetNetworkRule, utils.WorkRule},
+							Rules: []rbacv1.PolicyRule{utils.FleetClusterRule, utils.FleetPlacementRule, utils.FleetNetworkRule, utils.EventRule},
 						}
 						return nil
 					},

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/klog/v2"
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
+	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
+	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
 	"go.goms.io/fleet/pkg/utils/controller"
 	"go.goms.io/fleet/pkg/utils/informer"
@@ -66,6 +68,16 @@ var (
 	FleetRule = rbacv1.PolicyRule{
 		Verbs:     []string{"*"},
 		APIGroups: []string{fleetv1alpha1.GroupVersion.Group},
+		Resources: []string{"*"},
+	}
+	FleetClusterRule = rbacv1.PolicyRule{
+		Verbs:     []string{"*"},
+		APIGroups: []string{clusterv1beta1.GroupVersion.Group},
+		Resources: []string{"*"},
+	}
+	FleetPlacementRule = rbacv1.PolicyRule{
+		Verbs:     []string{"*"},
+		APIGroups: []string{placementv1beta1.GroupVersion.Group},
 		Resources: []string{"*"},
 	}
 	EventRule = rbacv1.PolicyRule{


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where the v1beta1 hub agent still applies permissions tailored for v1alpha1 APIs, which leads to member agents failing to join.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests
- [x] E2E tests (upstream)

### Special notes for your reviewer

