### PR TITLE
fix: set the resource change processing controller to handle v1beta1 CRPs correctly + ignore member cluster updates

### DIFF
--- a/apis/placement/v1beta1/commons.go
+++ b/apis/placement/v1beta1/commons.go
@@ -7,6 +7,7 @@ package v1beta1
 
 const (
 	ClusterResourcePlacementKind        = "ClusterResourcePlacement"
+	ClusterResourcePlacementResource    = "clusterresourceplacements"
 	ClusterResourceBindingKind          = "ClusterResourceBinding"
 	ClusterResourceSnapshotKind         = "ClusterResourceSnapshot"
 	ClusterSchedulingPolicySnapshotKind = "ClusterSchedulingPolicySnapshot"

--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
+
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
@@ -41,7 +43,6 @@ import (
 	"go.goms.io/fleet/pkg/utils/controller"
 	"go.goms.io/fleet/pkg/utils/informer"
 	"go.goms.io/fleet/pkg/utils/validator"
-	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 )
 
 const (

--- a/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
+++ b/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
@@ -246,7 +246,7 @@ func (r *Reconciler) persistSelectedResourceUnion(ctx context.Context, placement
 
 // getPlacement retrieves a ClusterResourcePlacement object by its name, this will hit the informer cache.
 func (r *Reconciler) getPlacement(name string) (*fleetv1alpha1.ClusterResourcePlacement, error) {
-	obj, err := r.InformerManager.Lister(utils.ClusterResourcePlacementGVR).Get(name)
+	obj, err := r.InformerManager.Lister(utils.ClusterResourcePlacementV1Alpha1GVR).Get(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/memberclusterplacement/membercluster_controller.go
+++ b/pkg/controllers/memberclusterplacement/membercluster_controller.go
@@ -57,7 +57,7 @@ func (r *Reconciler) Reconcile(_ context.Context, key controller.QueueKey) (ctrl
 		}
 		mObj = nil //guard against unexpected informer lib behavior
 	}
-	crpList, err := r.InformerManager.Lister(utils.ClusterResourcePlacementGVR).List(labels.Everything())
+	crpList, err := r.InformerManager.Lister(utils.ClusterResourcePlacementV1Alpha1GVR).List(labels.Everything())
 	if err != nil {
 		klog.ErrorS(err, "failed to list all the cluster resource placement", "memberCluster", memberClusterName)
 		return ctrl.Result{}, err

--- a/pkg/controllers/resourcechange/resourcechange_controller.go
+++ b/pkg/controllers/resourcechange/resourcechange_controller.go
@@ -136,6 +136,7 @@ func (r *Reconciler) findPlacementsSelectedDeletedResV1Alpha1(res keys.ClusterWi
 
 	if len(matchedCrps) == 0 {
 		klog.V(2).InfoS("change in deleted object does not affect any v1alpha1 placement", "obj", res)
+		return
 	}
 
 	for _, crp := range matchedCrps {
@@ -171,6 +172,7 @@ func (r *Reconciler) findPlacementsSelectedDeletedResV1Beta1(res keys.ClusterWid
 
 	if len(matchedCrps) == 0 {
 		klog.V(2).InfoS("change in deleted object does not affect any v1beta1 placement", "obj", res)
+		return
 	}
 
 	for _, crp := range matchedCrps {

--- a/pkg/controllers/resourcechange/resourcechange_controller_test.go
+++ b/pkg/controllers/resourcechange/resourcechange_controller_test.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
-	ctrl "sigs.k8s.io/controller-runtime"
 
-	. "go.goms.io/fleet/apis/v1alpha1"
+	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
 	"go.goms.io/fleet/pkg/utils/controller"
 	"go.goms.io/fleet/pkg/utils/keys"
 	"go.goms.io/fleet/pkg/utils/validator"
@@ -40,26 +40,26 @@ func (w *fakeController) Enqueue(obj interface{}) {
 	w.QueueObj = append(w.QueueObj, obj.(string))
 }
 
-func TestFindPlacementsSelectedDeletedRes(t *testing.T) {
-	deletedRes := ResourceIdentifier{
+func TestFindPlacementsSelectedDeletedResV1Alpha1(t *testing.T) {
+	deletedRes := fleetv1alpha1.ResourceIdentifier{
 		Group:     "abc",
 		Name:      "foo",
 		Namespace: "bar",
 	}
 	tests := map[string]struct {
 		clusterWideKey keys.ClusterWideKey
-		crpList        []*ClusterResourcePlacement
+		crpList        []*fleetv1alpha1.ClusterResourcePlacement
 		wantCrp        []string
 	}{
 		"match a placement that selected the deleted resource": {
 			clusterWideKey: keys.ClusterWideKey{ResourceIdentifier: deletedRes},
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Status: ClusterResourcePlacementStatus{
-						SelectedResources: []ResourceIdentifier{
+					Status: fleetv1alpha1.ClusterResourcePlacementStatus{
+						SelectedResources: []fleetv1alpha1.ResourceIdentifier{
 							deletedRes,
 						},
 					},
@@ -69,13 +69,13 @@ func TestFindPlacementsSelectedDeletedRes(t *testing.T) {
 		},
 		"match all the placements that selected the deleted resource": {
 			clusterWideKey: keys.ClusterWideKey{ResourceIdentifier: deletedRes},
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Status: ClusterResourcePlacementStatus{
-						SelectedResources: []ResourceIdentifier{
+					Status: fleetv1alpha1.ClusterResourcePlacementStatus{
+						SelectedResources: []fleetv1alpha1.ResourceIdentifier{
 							deletedRes,
 						},
 					},
@@ -84,8 +84,8 @@ func TestFindPlacementsSelectedDeletedRes(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected-2",
 					},
-					Status: ClusterResourcePlacementStatus{
-						SelectedResources: []ResourceIdentifier{
+					Status: fleetv1alpha1.ClusterResourcePlacementStatus{
+						SelectedResources: []fleetv1alpha1.ResourceIdentifier{
 							deletedRes,
 							{
 								Group:     "abc",
@@ -100,13 +100,13 @@ func TestFindPlacementsSelectedDeletedRes(t *testing.T) {
 		},
 		"does not match placement that has selected some other resource": {
 			clusterWideKey: keys.ClusterWideKey{ResourceIdentifier: deletedRes},
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Status: ClusterResourcePlacementStatus{
-						SelectedResources: []ResourceIdentifier{
+					Status: fleetv1alpha1.ClusterResourcePlacementStatus{
+						SelectedResources: []fleetv1alpha1.ResourceIdentifier{
 							{
 								Group:     "abd",
 								Name:      "not-deleted",
@@ -120,13 +120,13 @@ func TestFindPlacementsSelectedDeletedRes(t *testing.T) {
 		},
 		"does not match placement that has not selected any resource": {
 			clusterWideKey: keys.ClusterWideKey{ResourceIdentifier: deletedRes},
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Status: ClusterResourcePlacementStatus{
-						SelectedResources: []ResourceIdentifier{},
+					Status: fleetv1alpha1.ClusterResourcePlacementStatus{
+						SelectedResources: []fleetv1alpha1.ResourceIdentifier{},
 					},
 				},
 			},
@@ -144,23 +144,136 @@ func TestFindPlacementsSelectedDeletedRes(t *testing.T) {
 				uMap, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(crp)
 				crpList = append(crpList, &unstructured.Unstructured{Object: uMap})
 			}
-			got, err := r.findPlacementsSelectedDeletedRes(tt.clusterWideKey, crpList)
+			r.findPlacementsSelectedDeletedResV1Alpha1(tt.clusterWideKey, crpList)
 			if !reflect.DeepEqual(placementController.QueueObj, tt.wantCrp) {
 				t.Errorf("test case `%s` got crp = %v, wantCrp %v", name, placementController.QueueObj, tt.wantCrp)
 				return
-			}
-			if err != nil {
-				t.Errorf("test case `%s` got error = %v, wantErr %v", name, err, nil)
-				return
-			}
-			if !reflect.DeepEqual(got, ctrl.Result{}) {
-				t.Errorf("test case `%s` got = %v, wantResult %v", name, got, ctrl.Result{})
 			}
 		})
 	}
 }
 
-func TestCollectAllAffectedPlacements(t *testing.T) {
+func TestFindPlacementsSelectedDeletedResV1Beta11(t *testing.T) {
+	// Perform some expedient duplication to accommodate the version differences.
+	deletedResV1Alpha1 := fleetv1alpha1.ResourceIdentifier{
+		Group:     "abc",
+		Name:      "foo",
+		Namespace: "bar",
+	}
+	deletedResV1Beta1 := placementv1beta1.ResourceIdentifier{
+		Group:     "abc",
+		Name:      "foo",
+		Namespace: "bar",
+	}
+
+	tests := map[string]struct {
+		clusterWideKey keys.ClusterWideKey
+		crpList        []*placementv1beta1.ClusterResourcePlacement
+		wantCrp        []string
+	}{
+		"match a placement that selected the deleted resource": {
+			clusterWideKey: keys.ClusterWideKey{ResourceIdentifier: deletedResV1Alpha1},
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Status: placementv1beta1.ClusterResourcePlacementStatus{
+						SelectedResources: []placementv1beta1.ResourceIdentifier{
+							deletedResV1Beta1,
+						},
+					},
+				},
+			},
+			wantCrp: []string{"resource-selected"},
+		},
+		"match all the placements that selected the deleted resource": {
+			clusterWideKey: keys.ClusterWideKey{ResourceIdentifier: deletedResV1Alpha1},
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Status: placementv1beta1.ClusterResourcePlacementStatus{
+						SelectedResources: []placementv1beta1.ResourceIdentifier{
+							deletedResV1Beta1,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected-2",
+					},
+					Status: placementv1beta1.ClusterResourcePlacementStatus{
+						SelectedResources: []placementv1beta1.ResourceIdentifier{
+							deletedResV1Beta1,
+							{
+								Group:     "abc",
+								Name:      "foo",
+								Namespace: "bar",
+							},
+						},
+					},
+				},
+			},
+			wantCrp: []string{"resource-selected", "resource-selected-2"},
+		},
+		"does not match placement that has selected some other resource": {
+			clusterWideKey: keys.ClusterWideKey{ResourceIdentifier: deletedResV1Alpha1},
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Status: placementv1beta1.ClusterResourcePlacementStatus{
+						SelectedResources: []placementv1beta1.ResourceIdentifier{
+							{
+								Group:     "abd",
+								Name:      "not-deleted",
+								Namespace: "bar",
+							},
+						},
+					},
+				},
+			},
+			wantCrp: nil,
+		},
+		"does not match placement that has not selected any resource": {
+			clusterWideKey: keys.ClusterWideKey{ResourceIdentifier: deletedResV1Alpha1},
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Status: placementv1beta1.ClusterResourcePlacementStatus{
+						SelectedResources: []placementv1beta1.ResourceIdentifier{},
+					},
+				},
+			},
+			wantCrp: nil,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			placementController := fakeController{}
+			r := &Reconciler{
+				PlacementControllerV1Alpha1: &placementController,
+			}
+			var crpList []runtime.Object
+			for _, crp := range tt.crpList {
+				uMap, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(crp)
+				crpList = append(crpList, &unstructured.Unstructured{Object: uMap})
+			}
+			r.findPlacementsSelectedDeletedResV1Alpha1(tt.clusterWideKey, crpList)
+			if !reflect.DeepEqual(placementController.QueueObj, tt.wantCrp) {
+				t.Errorf("test case `%s` got crp = %v, wantCrp %v", name, placementController.QueueObj, tt.wantCrp)
+				return
+			}
+		})
+	}
+}
+
+func TestCollectAllAffectedPlacementsV1Alpha1(t *testing.T) {
 	// the resource we use for all the tests
 	matchRes := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{
@@ -177,18 +290,18 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 	}
 	tests := map[string]struct {
 		res     *corev1.Namespace
-		crpList []*ClusterResourcePlacement
+		crpList []*fleetv1alpha1.ClusterResourcePlacement
 		wantCrp map[string]bool
 	}{
 		"match a place with the matching label": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -205,13 +318,13 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"does not match a place with no selector": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{},
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{},
 					},
 				},
 			},
@@ -219,13 +332,13 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"match a place with the name selector": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -240,13 +353,13 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"match a place with a match Expressions label": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -268,13 +381,13 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"match a place with a single matching label": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -291,13 +404,13 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"does not match a place with a miss matching label": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -318,13 +431,13 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"match a place with multiple matching resource selectors": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -354,13 +467,13 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"match a place with only one matching resource selectors": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -391,14 +504,14 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"match a place with a miss matching label but was selected": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
 						// the mis-matching resource selector
-						ResourceSelectors: []ClusterResourceSelector{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -411,8 +524,8 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 							},
 						},
 					},
-					Status: ClusterResourcePlacementStatus{
-						SelectedResources: []ResourceIdentifier{
+					Status: fleetv1alpha1.ClusterResourcePlacementStatus{
+						SelectedResources: []fleetv1alpha1.ResourceIdentifier{
 							{
 								Group:     corev1.GroupName,
 								Version:   "v1",
@@ -435,13 +548,13 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 		},
 		"does not match a place with a miss matching label and was not selected": {
 			res: matchRes,
-			crpList: []*ClusterResourcePlacement{
+			crpList: []*fleetv1alpha1.ClusterResourcePlacement{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "resource-selected",
 					},
-					Spec: ClusterResourcePlacementSpec{
-						ResourceSelectors: []ClusterResourceSelector{
+					Spec: fleetv1alpha1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []fleetv1alpha1.ClusterResourceSelector{
 							{
 								Group:   corev1.GroupName,
 								Version: "v1",
@@ -454,8 +567,8 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 							},
 						},
 					},
-					Status: ClusterResourcePlacementStatus{
-						SelectedResources: []ResourceIdentifier{
+					Status: fleetv1alpha1.ClusterResourcePlacementStatus{
+						SelectedResources: []fleetv1alpha1.ResourceIdentifier{
 							{
 								Group:     corev1.GroupName,
 								Version:   "v1beta2",
@@ -479,7 +592,334 @@ func TestCollectAllAffectedPlacements(t *testing.T) {
 			}
 			uRes, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.res)
 			validator.ResourceInformer = validator.MockResourceInformer{}
-			got := collectAllAffectedPlacements(&unstructured.Unstructured{Object: uRes}, crpList)
+			got := collectAllAffectedPlacementsV1Alpha1(&unstructured.Unstructured{Object: uRes}, crpList)
+			if !reflect.DeepEqual(got, tt.wantCrp) {
+				t.Errorf("test case `%s` got = %v, wantResult %v", name, got, tt.wantCrp)
+			}
+		})
+	}
+}
+
+func TestCollectAllAffectedPlacementsV1Beta1(t *testing.T) {
+	// the resource we use for all the tests
+	matchRes := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-nameSpace",
+			Labels: map[string]string{
+				"region":  utilrand.String(10),
+				"version": utilrand.String(4),
+			},
+		},
+	}
+	tests := map[string]struct {
+		res     *corev1.Namespace
+		crpList []*placementv1beta1.ClusterResourcePlacement
+		wantCrp map[string]bool
+	}{
+		"match a place with the matching label": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: matchRes.Labels,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCrp: map[string]bool{"resource-selected": true},
+		},
+		"does not match a place with no selector": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{},
+					},
+				},
+			},
+			wantCrp: make(map[string]bool),
+		},
+		"match a place with the name selector": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								Name:    matchRes.Name,
+							},
+						},
+					},
+				},
+			},
+			wantCrp: map[string]bool{"resource-selected": true},
+		},
+		"match a place with a match Expressions label": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "random",
+											Operator: metav1.LabelSelectorOpDoesNotExist,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCrp: map[string]bool{"resource-selected": true},
+		},
+		"match a place with a single matching label": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"region": matchRes.Labels["region"]},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCrp: map[string]bool{"resource-selected": true},
+		},
+		"does not match a place with a miss matching label": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"region": matchRes.Labels["region"],
+										// the mis-matching label
+										"random": "doesnotmatter",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCrp: make(map[string]bool),
+		},
+		"match a place with multiple matching resource selectors": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"region": matchRes.Labels["region"]},
+								},
+							},
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "version",
+											Operator: metav1.LabelSelectorOpExists,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCrp: map[string]bool{"resource-selected": true},
+		},
+		"match a place with only one matching resource selectors": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{"region": matchRes.Labels["region"]},
+								},
+							},
+							{
+								// the mis-matching label selector
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "version",
+											Operator: metav1.LabelSelectorOpDoesNotExist,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCrp: map[string]bool{"resource-selected": true},
+		},
+		"match a place with a miss matching label but was selected": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						// the mis-matching resource selector
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"random": "doesnotmatter",
+									},
+								},
+							},
+						},
+					},
+					Status: placementv1beta1.ClusterResourcePlacementStatus{
+						SelectedResources: []placementv1beta1.ResourceIdentifier{
+							{
+								Group:     corev1.GroupName,
+								Version:   "v1",
+								Kind:      matchRes.Kind,
+								Name:      matchRes.Name,
+								Namespace: "",
+							},
+							{
+								Group:     corev1.GroupName,
+								Version:   "v1beta2",
+								Kind:      "Pod",
+								Name:      matchRes.Name,
+								Namespace: "",
+							},
+						},
+					},
+				},
+			},
+			wantCrp: map[string]bool{"resource-selected": true},
+		},
+		"does not match a place with a miss matching label and was not selected": {
+			res: matchRes,
+			crpList: []*placementv1beta1.ClusterResourcePlacement{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "resource-selected",
+					},
+					Spec: placementv1beta1.ClusterResourcePlacementSpec{
+						ResourceSelectors: []placementv1beta1.ClusterResourceSelector{
+							{
+								Group:   corev1.GroupName,
+								Version: "v1",
+								Kind:    matchRes.Kind,
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"random": "doesnotmatter",
+									},
+								},
+							},
+						},
+					},
+					Status: placementv1beta1.ClusterResourcePlacementStatus{
+						SelectedResources: []placementv1beta1.ResourceIdentifier{
+							{
+								Group:     corev1.GroupName,
+								Version:   "v1beta2",
+								Kind:      "Pod",
+								Name:      matchRes.Name,
+								Namespace: "",
+							},
+						},
+					},
+				},
+			},
+			wantCrp: make(map[string]bool),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var crpList []runtime.Object
+			for _, crp := range tt.crpList {
+				uMap, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(crp)
+				crpList = append(crpList, &unstructured.Unstructured{Object: uMap})
+			}
+			uRes, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.res)
+			validator.ResourceInformer = validator.MockResourceInformer{}
+			got := collectAllAffectedPlacementsV1Alpha1(&unstructured.Unstructured{Object: uRes}, crpList)
 			if !reflect.DeepEqual(got, tt.wantCrp) {
 				t.Errorf("test case `%s` got = %v, wantResult %v", name, got, tt.wantCrp)
 			}

--- a/pkg/resourcewatcher/change_dector.go
+++ b/pkg/resourcewatcher/change_dector.go
@@ -92,8 +92,8 @@ func (d *ChangeDetector) Start(ctx context.Context) error {
 			d.onClusterResourcePlacementUpdated, d.onClusterResourcePlacementDeleted)
 		d.InformerManager.AddStaticResource(
 			informer.APIResourceMeta{
-				GroupVersionKind:     utils.ClusterResourcePlacementGVK,
-				GroupVersionResource: utils.ClusterResourcePlacementGVR,
+				GroupVersionKind:     utils.ClusterResourcePlacementV1Alpha1GVK,
+				GroupVersionResource: utils.ClusterResourcePlacementV1Alpha1GVR,
 				IsClusterScoped:      true,
 			}, clusterPlacementEventHandler)
 

--- a/pkg/utils/apiresources.go
+++ b/pkg/utils/apiresources.go
@@ -15,7 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	metricsV1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 
-	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
+	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
 )
 
@@ -62,7 +63,8 @@ func NewDisabledResourceConfig() *DisabledResourceConfig {
 	}
 	// disable fleet related resource by default
 	r.DisableGroup(fleetv1alpha1.GroupVersion.Group)
-	r.DisableGroup(fleetv1beta1.GroupVersion.Group)
+	r.DisableGroup(placementv1beta1.GroupVersion.Group)
+	r.DisableGroup(clusterv1beta1.GroupVersion.Group)
 	r.DisableGroupVersionKind(WorkGVK)
 
 	// disable the below built-in resources

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -99,13 +99,19 @@ var (
 
 // Those are the GVR/GVK of the fleet related resources.
 var (
-	ClusterResourcePlacementGVR = schema.GroupVersionResource{
+	ClusterResourcePlacementV1Alpha1GVR = schema.GroupVersionResource{
 		Group:    fleetv1alpha1.GroupVersion.Group,
 		Version:  fleetv1alpha1.GroupVersion.Version,
 		Resource: fleetv1alpha1.ClusterResourcePlacementResource,
 	}
 
-	ClusterResourcePlacementGVK = schema.GroupVersionKind{
+	ClusterResourcePlacementGVR = schema.GroupVersionResource{
+		Group:    placementv1beta1.GroupVersion.Group,
+		Version:  placementv1beta1.GroupVersion.Version,
+		Resource: placementv1beta1.ClusterResourcePlacementResource,
+	}
+
+	ClusterResourcePlacementV1Alpha1GVK = schema.GroupVersionKind{
 		Group:   fleetv1alpha1.GroupVersion.Group,
 		Version: fleetv1alpha1.GroupVersion.Version,
 		Kind:    "ClusterResourcePlacement",

--- a/test/e2e/actuals_test.go
+++ b/test/e2e/actuals_test.go
@@ -20,7 +20,7 @@ import (
 	"go.goms.io/fleet/test/e2e/framework"
 )
 
-func workNamespaceAndDeploymentPlacedOnClusterActual(cluster *framework.Cluster) func() error {
+func workNamespaceAndConfigMapPlacedOnClusterActual(cluster *framework.Cluster) func() error {
 	client := cluster.KubeClient
 
 	workNamespaceName := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
@@ -53,8 +53,7 @@ func workNamespaceAndDeploymentPlacedOnClusterActual(cluster *framework.Cluster)
 			return err
 		}
 
-		// Use the object created in the hub cluster as reference; this helps to avoid the trouble
-		// of having to ignore default fields in the spec.
+		// Use the object created in the hub cluster as reference.
 		wantConfigMap := &corev1.ConfigMap{}
 		if err := hubClient.Get(ctx, types.NamespacedName{Namespace: workNamespaceName, Name: appConfigMapName}, wantConfigMap); err != nil {
 			return err

--- a/test/e2e/placement_test.go
+++ b/test/e2e/placement_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -19,6 +20,8 @@ import (
 // Note that this container will run in parallel with other containers.
 var _ = Describe("placing resources using a CRP with no placement policy specified", Ordered, func() {
 	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+	workNamespaceName := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+	appConfigMapName := fmt.Sprintf(appConfigMapNameTemplate, GinkgoParallelProcess())
 
 	BeforeAll(func() {
 		// Create the resources.
@@ -41,7 +44,30 @@ var _ = Describe("placing resources using a CRP with no placement policy specifi
 
 	It("should place the resources on all member clusters", func() {
 		for idx := range allMemberClusters {
-			workResourcesPlacedActual := workNamespaceAndDeploymentPlacedOnClusterActual(allMemberClusters[idx])
+			workResourcesPlacedActual := workNamespaceAndConfigMapPlacedOnClusterActual(allMemberClusters[idx])
+			Eventually(workResourcesPlacedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to place work resources on member cluster")
+		}
+	})
+
+	It("should update CRP status as expected", func() {
+		crpStatusUpdatedActual := crpStatusUpdatedActual()
+		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+	})
+
+	It("can update the resource", func() {
+		// Get the config map.
+		configMap := &corev1.ConfigMap{}
+		Expect(hubClient.Get(ctx, types.NamespacedName{Namespace: workNamespaceName, Name: appConfigMapName}, configMap)).To(Succeed(), "Failed to get config map")
+
+		configMap.Data = map[string]string{
+			"data": "updated",
+		}
+		Expect(hubClient.Update(ctx, configMap)).To(Succeed(), "Failed to update config map")
+	})
+
+	It("should place the resources on all member clusters", func() {
+		for idx := range allMemberClusters {
+			workResourcesPlacedActual := workNamespaceAndConfigMapPlacedOnClusterActual(allMemberClusters[idx])
 			Eventually(workResourcesPlacedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to place work resources on member cluster")
 		}
 	})
@@ -79,6 +105,11 @@ var _ = Describe("placing resources using a CRP with no placement policy specifi
 		// Remove the custom deletion blocker finalizer from the CRP.
 		crp := &placementv1beta1.ClusterResourcePlacement{}
 		Expect(hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp)).To(Succeed(), "Failed to get CRP")
+
+		// Delete the CRP (again, if applicable).
+		//
+		// This helps the AfterAll node to run successfully even if the steps above fail early.
+		Expect(hubClient.Delete(ctx, crp)).To(Succeed(), "Failed to delete CRP")
 
 		crp.Finalizers = []string{}
 		Expect(hubClient.Update(ctx, crp)).To(Succeed(), "Failed to update CRP")

--- a/test/e2e/placement_test.go
+++ b/test/e2e/placement_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 )
@@ -37,6 +38,12 @@ var _ = Describe("placing resources using a CRP with no placement policy specifi
 			},
 			Spec: placementv1beta1.ClusterResourcePlacementSpec{
 				ResourceSelectors: workResourceSelector,
+				Strategy: placementv1beta1.RolloutStrategy{
+					Type: placementv1beta1.RollingUpdateRolloutStrategyType,
+					RollingUpdate: &placementv1beta1.RollingUpdateConfig{
+						UnavailablePeriodSeconds: pointer.Int(2),
+					},
+				},
 			},
 		}
 		Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP")

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -46,8 +46,8 @@ const (
 )
 
 const (
-	eventuallyDuration = time.Second * 10
-	eventuallyInterval = time.Millisecond * 500
+	eventuallyDuration = time.Minute * 10
+	eventuallyInterval = time.Second * 5
 )
 
 var (

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 )
@@ -96,10 +97,10 @@ func createWorkResources() {
 // deleteWorkResources deletes the resources created by createWorkResources.
 func deleteWorkResources() {
 	ns := workNamespace()
-	Expect(hubClient.Delete(ctx, &ns)).To(Succeed(), "Failed to delete namespace")
+	Expect(client.IgnoreNotFound(hubClient.Delete(ctx, &ns))).To(Succeed(), "Failed to delete namespace")
 
 	deploy := appConfigMap()
-	Expect(hubClient.Delete(ctx, &deploy)).To(Succeed(), "Failed to delete deployment")
+	Expect(client.IgnoreNotFound(hubClient.Delete(ctx, &deploy))).To(Succeed(), "Failed to delete deployment")
 }
 
 // setAllMemberClustersToLeave sets all member clusters to leave the fleet.
@@ -112,7 +113,7 @@ func setAllMemberClustersToLeave() {
 				Name: memberCluster.ClusterName,
 			},
 		}
-		Expect(hubClient.Delete(ctx, mcObj)).To(Succeed(), "Failed to set member cluster to leave state")
+		Expect(client.IgnoreNotFound(hubClient.Delete(ctx, mcObj))).To(Succeed(), "Failed to set member cluster to leave state")
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where the resource change processing controller only processes v1alpha1 CRPs, which leads to unreasonably long delays for fleets with v1beta1 API to apply resource changes.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] E2E tests (upstream)

### Special notes for your reviewer

Expedient fixes, which should get refactored in the future when v1alpha1 API becomes obsolete.

This also edits the E2E tests we have right now a little bit to verify the effectiveness.
