### PR TITLE
fix: watch for observed CRP annotation change in scheduler watcher

### DIFF
--- a/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/controller.go
+++ b/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/controller.go
@@ -124,7 +124,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 
 			// Policy snapshot spec is immutable; however, the scheduler will have to respond
-			// to changes in the annotations.
+			// to changes in the numberOfCluster & CRPGeneration annotations.
 			oldAnnotations := e.ObjectOld.GetAnnotations()
 			newAnnotations := e.ObjectNew.GetAnnotations()
 

--- a/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/controller.go
+++ b/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/controller.go
@@ -124,13 +124,19 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 
 			// Policy snapshot spec is immutable; however, the scheduler will have to respond
-			// to changes in the number of clusters annoation.
+			// to changes in the annoations.
 			oldAnnotations := e.ObjectOld.GetAnnotations()
 			newAnnotations := e.ObjectNew.GetAnnotations()
 
 			oldNumOfClusters := oldAnnotations[fleetv1beta1.NumberOfClustersAnnotation]
 			newNumOfClusters := newAnnotations[fleetv1beta1.NumberOfClustersAnnotation]
 			if oldNumOfClusters != newNumOfClusters {
+				return true
+			}
+
+			oldObservedCRPGeneration := oldAnnotations[fleetv1beta1.CRPGenerationAnnotation]
+			newObservedCRPGeneration := newAnnotations[fleetv1beta1.CRPGenerationAnnotation]
+			if oldObservedCRPGeneration != newObservedCRPGeneration {
 				return true
 			}
 

--- a/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/controller.go
+++ b/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/controller.go
@@ -124,7 +124,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 
 			// Policy snapshot spec is immutable; however, the scheduler will have to respond
-			// to changes in the annoations.
+			// to changes in the annotations.
 			oldAnnotations := e.ObjectOld.GetAnnotations()
 			newAnnotations := e.ObjectNew.GetAnnotations()
 
@@ -134,6 +134,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return true
 			}
 
+			// The scheduler needs to update the policy snapshot based on the latest CRP generation, when resource selector
+			// has changed and there are no policy changes.
 			oldObservedCRPGeneration := oldAnnotations[fleetv1beta1.CRPGenerationAnnotation]
 			newObservedCRPGeneration := newAnnotations[fleetv1beta1.CRPGenerationAnnotation]
 			if oldObservedCRPGeneration != newObservedCRPGeneration {

--- a/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/controller_integration_test.go
+++ b/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/controller_integration_test.go
@@ -144,7 +144,7 @@ var _ = Describe("cluster scheduling policy snapshot scheduler source controller
 			Expect(hubClient.Update(ctx, &policySnapshot)).Should(Succeed(), "Failed to update cluster scheduling policy snapshot")
 		})
 
-		It("should enqueue the CRP when number of clusters annotation updated", func() {
+		It("should enqueue the CRP when crp generation annotation updated", func() {
 			Eventually(expectedKeySetEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to enqueue expected key set")
 			Consistently(expectedKeySetEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to enqueue expected key set")
 		})


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where the scheduler watcher ignores observed CRP annotation changes.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Integration tests
- [x] E2E tests (upstream)

### Special notes for your reviewer
