### PR TITLE
fix: report cluster name as expected in CRP status when CRP controller reconciles unselected clusters

### DIFF
--- a/pkg/controllers/clusterresourceplacement/controller.go
+++ b/pkg/controllers/clusterresourceplacement/controller.go
@@ -915,6 +915,7 @@ func (r *Reconciler) setResourcePlacementStatusAndResourceConditions(ctx context
 		// TODO: we could improve the message by summarizing the failure reasons from all of the unselected clusters.
 		// For now, it starts from adding some sample failures of unselected clusters.
 		var rp fleetv1beta1.ResourcePlacementStatus
+		rp.ClusterName = unselected[i].ClusterName
 		scheduledCondition := metav1.Condition{
 			Status:             metav1.ConditionFalse,
 			Type:               string(fleetv1beta1.ResourceScheduledConditionType),

--- a/pkg/controllers/clusterresourceplacement/placement_status_test.go
+++ b/pkg/controllers/clusterresourceplacement/placement_status_test.go
@@ -780,6 +780,7 @@ func TestSetPlacementStatus(t *testing.T) {
 						FailedResourcePlacements: []fleetv1beta1.FailedResourcePlacement{},
 					},
 					{
+						ClusterName: "member-2",
 						Conditions: []metav1.Condition{
 							{
 								Status:             metav1.ConditionFalse,
@@ -790,6 +791,7 @@ func TestSetPlacementStatus(t *testing.T) {
 						},
 					},
 					{
+						ClusterName: "member-3",
 						Conditions: []metav1.Condition{
 							{
 								Status:             metav1.ConditionFalse,


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where cluster name is left empty in the status when clusters are unselected.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests
- [x] E2E tests


### Special notes for your reviewer

N/A
