### PR TITLE
fix: stop CRP controller from overwriting CRP annotations when reconciling CRPs of the PickN placement type

### DIFF
--- a/pkg/controllers/clusterresourceplacement/controller.go
+++ b/pkg/controllers/clusterresourceplacement/controller.go
@@ -298,9 +298,9 @@ func (r *Reconciler) getOrCreateClusterSchedulingPolicySnapshot(ctx context.Cont
 	if crp.Spec.Policy != nil &&
 		crp.Spec.Policy.PlacementType == fleetv1beta1.PickNPlacementType &&
 		crp.Spec.Policy.NumberOfClusters != nil {
-		latestPolicySnapshot.Annotations = map[string]string{
-			fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(int(*crp.Spec.Policy.NumberOfClusters)),
-		}
+		// Note that all policy snapshots should have the CRP generation annotation set already,
+		// so the Annotations field will not be nil.
+		latestPolicySnapshot.Annotations[fleetv1beta1.NumberOfClustersAnnotation] = strconv.Itoa(int(*crp.Spec.Policy.NumberOfClusters))
 	}
 
 	if err := r.Client.Create(ctx, latestPolicySnapshot); err != nil {

--- a/pkg/controllers/clusterresourceplacement/controller_test.go
+++ b/pkg/controllers/clusterresourceplacement/controller_test.go
@@ -169,6 +169,7 @@ func TestGetOrCreateClusterSchedulingPolicySnapshot(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
+							fleetv1beta1.CRPGenerationAnnotation:    strconv.Itoa(crpGeneration),
 							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
@@ -400,6 +401,7 @@ func TestGetOrCreateClusterSchedulingPolicySnapshot(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
+							fleetv1beta1.CRPGenerationAnnotation:    strconv.Itoa(crpGeneration),
 							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},
@@ -459,6 +461,7 @@ func TestGetOrCreateClusterSchedulingPolicySnapshot(t *testing.T) {
 							},
 						},
 						Annotations: map[string]string{
+							fleetv1beta1.CRPGenerationAnnotation:    strconv.Itoa(crpGeneration),
 							fleetv1beta1.NumberOfClustersAnnotation: strconv.Itoa(3),
 						},
 					},


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where the CRP controller would overwrite CRP object annotations when reconciling CRPs of the PickN placement; when this issues occurs, the CRP object would lose its CRP generation annotation, which would fail all future reconciliation loops.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests
- [x] E2E tests 

### Special notes for your reviewer


