### PR TITLE
fix: make the join event message clear.

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -48,7 +48,7 @@ const (
 	reasonMemberClusterNotReadyToJoin = "MemberClusterNotReadyToJoin"
 	reasonMemberClusterJoined         = "MemberClusterJoined"
 	reasonMemberClusterLeft           = "MemberClusterLeft"
-	reasonMemberClusterUnknown        = "MemberClusterUnknown"
+	reasonMemberClusterUnknown        = "MemberClusterJoinStateUnknown"
 )
 
 // Reconciler reconciles a MemberCluster object
@@ -581,8 +581,8 @@ func markMemberClusterUnknown(recorder record.EventRecorder, mc apis.Conditioned
 	// Joined status changed.
 	existingCondition := mc.GetCondition(newCondition.Type)
 	if existingCondition == nil || existingCondition.Status != newCondition.Status {
-		recorder.Event(mc, corev1.EventTypeWarning, reasonMemberClusterUnknown, "member cluster unknown")
-		klog.V(2).InfoS("memberCluster unknown", "memberCluster", klog.KObj(mc))
+		recorder.Event(mc, corev1.EventTypeWarning, reasonMemberClusterUnknown, "member cluster join state unknown")
+		klog.V(2).InfoS("memberCluster join state unknown", "memberCluster", klog.KObj(mc))
 	}
 
 	mc.SetConditions(newCondition)


### PR DESCRIPTION
### Description of your changes

Currently, we have an event shows as "clusterunknonw" which can be confusing.

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
