### PR TITLE
fix: explicitly set the selectedResources as an empty array

### DIFF
--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -337,8 +337,7 @@ type RollingUpdateConfig struct {
 // ClusterResourcePlacementStatus defines the observed state of the ClusterResourcePlacement object.
 type ClusterResourcePlacementStatus struct {
 	// SelectedResources contains a list of resources selected by ResourceSelectors.
-	// +optional
-	SelectedResources []ResourceIdentifier `json:"selectedResources,omitempty"`
+	SelectedResources []ResourceIdentifier `json:"selectedResources"`
 
 	// PlacementStatuses contains a list of placement status on the clusters that are selected by PlacementPolicy.
 	// Each selected cluster according to the latest resource placement is guaranteed to have a corresponding placementStatuses.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -816,6 +816,8 @@ spec:
                   - version
                   type: object
                 type: array
+            required:
+            - selectedResources
             type: object
         required:
         - spec

--- a/pkg/controllers/clusterresourceplacement/controller.go
+++ b/pkg/controllers/clusterresourceplacement/controller.go
@@ -166,6 +166,8 @@ func (r *Reconciler) handleUpdate(ctx context.Context, crp *fleetv1beta1.Cluster
 			Message:            fmt.Sprintf("The resource selectors are invalid: %v", err),
 			ObservedGeneration: crp.Generation,
 		}
+		// SelectedResources is a required field, so it should be set when updating the status.
+		crp.Status.SelectedResources = []fleetv1beta1.ResourceIdentifier{}
 		crp.SetConditions(scheduleCondition)
 		if updateErr := r.Client.Status().Update(ctx, crp); updateErr != nil {
 			klog.ErrorS(updateErr, "Failed to update the status", "clusterResourcePlacement", crpKObj)

--- a/pkg/controllers/clusterresourceplacement/controller_integration_test.go
+++ b/pkg/controllers/clusterresourceplacement/controller_integration_test.go
@@ -268,6 +268,7 @@ var _ = Describe("Test ClusterResourcePlacement Controller", func() {
 				},
 				Spec: crp.Spec,
 				Status: placementv1beta1.ClusterResourcePlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{},
 					Conditions: []metav1.Condition{
 						{
 							Status: metav1.ConditionUnknown,
@@ -316,6 +317,7 @@ var _ = Describe("Test ClusterResourcePlacement Controller", func() {
 				},
 				Spec: crp.Spec,
 				Status: placementv1beta1.ClusterResourcePlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{},
 					Conditions: []metav1.Condition{
 						{
 							Status: metav1.ConditionTrue,
@@ -373,6 +375,7 @@ var _ = Describe("Test ClusterResourcePlacement Controller", func() {
 				},
 				Spec: crp.Spec,
 				Status: placementv1beta1.ClusterResourcePlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{},
 					Conditions: []metav1.Condition{
 						{
 							Status: metav1.ConditionUnknown,
@@ -445,6 +448,7 @@ var _ = Describe("Test ClusterResourcePlacement Controller", func() {
 				},
 				Spec: crp.Spec,
 				Status: placementv1beta1.ClusterResourcePlacementStatus{
+					SelectedResources: []placementv1beta1.ResourceIdentifier{},
 					Conditions: []metav1.Condition{
 						{
 							Status: metav1.ConditionTrue,

--- a/pkg/controllers/clusterresourceplacementwatcher/watcher_integration_test.go
+++ b/pkg/controllers/clusterresourceplacementwatcher/watcher_integration_test.go
@@ -105,6 +105,7 @@ var _ = Describe("Test ClusterResourcePlacement Watcher", func() {
 				Reason:             "applied",
 				ObservedGeneration: createdCRP.GetGeneration(),
 			}
+			createdCRP.Status.SelectedResources = []fleetv1beta1.ResourceIdentifier{}
 			createdCRP.SetConditions(newCondition)
 			Expect(k8sClient.Status().Update(ctx, createdCRP)).Should(Succeed())
 

--- a/pkg/scheduler/watchers/membercluster/suite_test.go
+++ b/pkg/scheduler/watchers/membercluster/suite_test.go
@@ -100,6 +100,7 @@ func setupResources() {
 	})
 	Expect(hubClient.Create(ctx, crp)).Should(Succeed(), "Failed to create CRP")
 	// Update the status.
+	crp.Status.SelectedResources = []placementv1beta1.ResourceIdentifier{}
 	meta.SetStatusCondition(&crp.Status.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.ClusterResourcePlacementScheduledConditionType),
 		Status:             metav1.ConditionTrue,
@@ -115,6 +116,7 @@ func setupResources() {
 	})
 	Expect(hubClient.Create(ctx, crp)).Should(Succeed(), "Failed to create CRP")
 	// Update the status.
+	crp.Status.SelectedResources = []placementv1beta1.ResourceIdentifier{}
 	meta.SetStatusCondition(&crp.Status.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.ClusterResourcePlacementScheduledConditionType),
 		Status:             metav1.ConditionTrue,

--- a/test/e2e/placement_selecting_resources_test.go
+++ b/test/e2e/placement_selecting_resources_test.go
@@ -1103,7 +1103,7 @@ var _ = Describe("validating CRP revision history allowing single revision when 
 			// may hit 409
 			return hubClient.Update(ctx, crp)
 		}
-		Eventually(updateFunc(), eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update the crp %s", crpName)
+		Eventually(updateFunc, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update the crp %s", crpName)
 	})
 
 	It("should update CRP status as expected", checkIfPlacedWorkResourcesOnAllMemberClusters)
@@ -1196,7 +1196,7 @@ var _ = Describe("validating CRP revision history allowing multiple revisions wh
 			// may hit 409
 			return hubClient.Update(ctx, crp)
 		}
-		Eventually(updateFunc(), eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update the crp %s", crpName)
+		Eventually(updateFunc, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update the crp %s", crpName)
 	})
 
 	It("should update CRP status as expected", checkIfPlacedWorkResourcesOnAllMemberClusters)

--- a/test/e2e/placement_selecting_resources_test.go
+++ b/test/e2e/placement_selecting_resources_test.go
@@ -1106,7 +1106,12 @@ var _ = Describe("validating CRP revision history allowing single revision when 
 		Eventually(updateFunc, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update the crp %s", crpName)
 	})
 
-	It("should update CRP status as expected", checkIfPlacedWorkResourcesOnAllMemberClusters)
+	It("should update CRP status as expected", func() {
+		crpStatusUpdatedActual := crpStatusUpdatedActual()
+		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
+	})
+
+	It("should place the selected resources on member clusters", checkIfPlacedWorkResourcesOnAllMemberClusters)
 
 	It("should have one policy snapshot revision and one resource snapshot revision", func() {
 		Expect(validateCRPSnapshotRevisions(crpName, 1, 1)).Should(Succeed(), "Failed to validate the revision history")
@@ -1199,7 +1204,12 @@ var _ = Describe("validating CRP revision history allowing multiple revisions wh
 		Eventually(updateFunc, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update the crp %s", crpName)
 	})
 
-	It("should update CRP status as expected", checkIfPlacedWorkResourcesOnAllMemberClusters)
+	It("should update CRP status as expected", func() {
+		crpStatusUpdatedActual := crpStatusUpdatedActual()
+		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
+	})
+
+	It("should place the selected resources on member clusters", checkIfPlacedWorkResourcesOnAllMemberClusters)
 
 	It("should have one policy snapshot revision and two resource snapshot revisions", func() {
 		Expect(validateCRPSnapshotRevisions(crpName, 1, 2)).Should(Succeed(), "Failed to validate the revision history")

--- a/test/e2e/placement_selecting_resources_test.go
+++ b/test/e2e/placement_selecting_resources_test.go
@@ -197,7 +197,7 @@ var _ = Describe("validating CRP when cluster-scoped resources become selected a
 
 	It("should update CRP status as expected", func() {
 		crpStatusUpdatedActual := func() error {
-			return validateCRPStatus(types.NamespacedName{Name: crpName}, nil)
+			return validateCRPStatus(types.NamespacedName{Name: crpName}, []placementv1beta1.ResourceIdentifier{})
 		}
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -305,7 +305,7 @@ var _ = Describe("validating CRP when cluster-scoped resources become unselected
 
 	It("should update CRP status as expected", func() {
 		crpStatusUpdatedActual := func() error {
-			return validateCRPStatus(types.NamespacedName{Name: crpName}, nil)
+			return validateCRPStatus(types.NamespacedName{Name: crpName}, []placementv1beta1.ResourceIdentifier{})
 		}
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -639,6 +639,7 @@ var _ = Describe("validating CRP when resource selector is not valid", Ordered, 
 			}
 
 			wantStatus := placementv1beta1.ClusterResourcePlacementStatus{
+				SelectedResources: []placementv1beta1.ResourceIdentifier{},
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(placementv1beta1.ClusterResourcePlacementScheduledConditionType),
@@ -718,6 +719,7 @@ var _ = Describe("validating CRP when selecting a reserved resource", Ordered, f
 			}
 
 			wantStatus := placementv1beta1.ClusterResourcePlacementStatus{
+				SelectedResources: []placementv1beta1.ResourceIdentifier{},
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(placementv1beta1.ClusterResourcePlacementScheduledConditionType),
@@ -1080,7 +1082,7 @@ var _ = Describe("validating CRP revision history allowing single revision when 
 
 	It("should update CRP status as expected", func() {
 		crpStatusUpdatedActual := func() error {
-			return validateCRPStatus(types.NamespacedName{Name: crpName}, nil)
+			return validateCRPStatus(types.NamespacedName{Name: crpName}, []placementv1beta1.ResourceIdentifier{})
 		}
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})
@@ -1173,7 +1175,7 @@ var _ = Describe("validating CRP revision history allowing multiple revisions wh
 
 	It("should update CRP status as expected", func() {
 		crpStatusUpdatedActual := func() error {
-			return validateCRPStatus(types.NamespacedName{Name: crpName}, nil)
+			return validateCRPStatus(types.NamespacedName{Name: crpName}, []placementv1beta1.ResourceIdentifier{})
 		}
 		Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP %s status as expected", crpName)
 	})


### PR DESCRIPTION
### Description of your changes

According to the json mashal documentation, ```The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.```
https://pkg.go.dev/encoding/json#Marshal

To explicitly set the selectedResources as an empty array, the field should be required. Otherwise, it will be omitted.

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

It's covered by e2e tests


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
