### PR TITLE
fix: fix the case that rollout stuck when there are failed to apply binding

### DIFF
--- a/pkg/controllers/rollout/controller.go
+++ b/pkg/controllers/rollout/controller.go
@@ -354,7 +354,7 @@ func pickBindingsToRoll(allBindings []*fleetv1beta1.ClusterResourceBinding, late
 		"lowerBoundAvailableBindings", lowerBoundAvailableNumber, "maxNumberOfBindingsToRemove", maxNumberToRemove)
 
 	// we can still update the bindings that are failed to apply already regardless of the maxNumberToRemove
-	for i := 0; i < maxUnavailableNumber && i < len(applyFailedUpdateCandidates); i++ {
+	for i := 0; i < len(applyFailedUpdateCandidates); i++ {
 		toBeUpdatedBinding = append(toBeUpdatedBinding, applyFailedUpdateCandidates[i])
 	}
 	if maxNumberToRemove > 0 {

--- a/pkg/controllers/rollout/controller.go
+++ b/pkg/controllers/rollout/controller.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
@@ -245,6 +246,11 @@ func pickBindingsToRoll(allBindings []*fleetv1beta1.ClusterResourceBinding, late
 	// Those are the bindings that are candidates to be updated to latest resources during the rolling phase.
 	updateCandidates := make([]*fleetv1beta1.ClusterResourceBinding, 0)
 
+	// Those are the bindings that are a sub-set of the candidates to be updated to latest resources but also are failed to apply.
+	// We can safely update those bindings to latest resources even if we can't update the rest of the bindings when we don't meet the
+	// minimum AvailableNumber of copies as we won't reduce the total unavailable number of bindings.
+	applyFailedUpdateCandidates := make([]*fleetv1beta1.ClusterResourceBinding, 0)
+
 	// calculate the cutoff time for a binding to be applied before so that it can be considered ready
 	readyTimeCutOff := time.Now().Add(-time.Duration(*crp.Spec.Strategy.RollingUpdate.UnavailablePeriodSeconds) * time.Second)
 
@@ -254,14 +260,20 @@ func pickBindingsToRoll(allBindings []*fleetv1beta1.ClusterResourceBinding, late
 		binding := allBindings[idx]
 		switch binding.Spec.State {
 		case fleetv1beta1.BindingStateUnscheduled:
-			canBeReadyBindings = append(canBeReadyBindings, binding)
+			appliedCondition := binding.GetCondition(string(fleetv1beta1.ResourceBindingApplied))
+			if appliedCondition != nil && appliedCondition.Status == metav1.ConditionFalse && appliedCondition.ObservedGeneration == binding.Generation {
+				klog.V(3).InfoS("Found an failed to apply unscheduled binding", "clusterResourcePlacement", klog.KObj(crp), "binding", klog.KObj(binding))
+			} else {
+				canBeReadyBindings = append(canBeReadyBindings, binding)
+			}
 			_, bindingReady := isBindingReady(binding, readyTimeCutOff)
 			if bindingReady {
-				klog.V(8).InfoS("Found a ready unscheduled binding", "clusterResourcePlacement", klog.KObj(crp), "binding", klog.KObj(binding))
+				klog.V(3).InfoS("Found a ready unscheduled binding", "clusterResourcePlacement", klog.KObj(crp), "binding", klog.KObj(binding))
 				readyBindings = append(readyBindings, binding)
 			}
 			if binding.DeletionTimestamp.IsZero() {
 				// it's not been deleted yet, so it is a removal candidate
+				klog.V(3).InfoS("Found a not yet deleted unscheduled binding", "clusterResourcePlacement", klog.KObj(crp), "binding", klog.KObj(binding))
 				removeCandidates = append(removeCandidates, binding)
 			} else if bindingReady {
 				// it is being deleted, it can be removed from the cluster at any time, so it can be unavailable at any time
@@ -275,15 +287,26 @@ func pickBindingsToRoll(allBindings []*fleetv1beta1.ClusterResourceBinding, late
 			boundingCandidates = append(boundingCandidates, binding)
 
 		case fleetv1beta1.BindingStateBound:
+			bindingFailed := false
 			schedulerTargetedBinds = append(schedulerTargetedBinds, binding)
-			canBeReadyBindings = append(canBeReadyBindings, binding)
 			if _, bindingReady := isBindingReady(binding, readyTimeCutOff); bindingReady {
-				klog.V(8).InfoS("Found a ready bound binding", "clusterResourcePlacement", klog.KObj(crp), "binding", klog.KObj(binding))
+				klog.V(3).InfoS("Found a ready bound binding", "clusterResourcePlacement", klog.KObj(crp), "binding", klog.KObj(binding))
 				readyBindings = append(readyBindings, binding)
+			}
+			appliedCondition := binding.GetCondition(string(fleetv1beta1.ResourceBindingApplied))
+			if appliedCondition != nil && appliedCondition.Status == metav1.ConditionFalse && appliedCondition.ObservedGeneration == binding.Generation {
+				klog.V(3).InfoS("Found a failed to apply bound binding", "clusterResourcePlacement", klog.KObj(crp), "binding", klog.KObj(binding))
+				bindingFailed = true
+			} else {
+				canBeReadyBindings = append(canBeReadyBindings, binding)
 			}
 			// The binding needs update if it's not pointing to the latest resource resourceBinding
 			if binding.Spec.ResourceSnapshotName != latestResourceSnapshotName {
 				updateCandidates = append(updateCandidates, binding)
+				if bindingFailed {
+					// the binding has been applied but failed to apply, we can safely update it to latest resources without affecting max unavailable count
+					applyFailedUpdateCandidates = append(applyFailedUpdateCandidates, binding)
+				}
 			}
 		}
 	}
@@ -311,7 +334,7 @@ func pickBindingsToRoll(allBindings []*fleetv1beta1.ClusterResourceBinding, late
 	klog.V(2).InfoS("Calculated the targetNumber", "clusterResourcePlacement", klog.KObj(crp),
 		"targetNumber", targetNumber, "readyBindingNumber", len(readyBindings), "canBeUnavailableBindingNumber", len(canBeUnavailableBindings),
 		"canBeReadyBindingNumber", len(canBeReadyBindings), "boundingCandidateNumber", len(boundingCandidates),
-		"removeCandidateNumber", len(removeCandidates), "updateCandidateNumber", len(updateCandidates))
+		"removeCandidateNumber", len(removeCandidates), "updateCandidateNumber", len(updateCandidates), "applyFailedUpdateCandidateNumber", len(applyFailedUpdateCandidates))
 
 	// the list of bindings that are to be updated by this rolling phase
 	toBeUpdatedBinding := make([]*fleetv1beta1.ClusterResourceBinding, 0)
@@ -329,6 +352,11 @@ func pickBindingsToRoll(allBindings []*fleetv1beta1.ClusterResourceBinding, late
 	klog.V(2).InfoS("Calculated the max number of bindings to remove", "clusterResourcePlacement", klog.KObj(crp),
 		"maxUnavailableNumber", maxUnavailableNumber, "minAvailableNumber", minAvailableNumber,
 		"lowerBoundAvailableBindings", lowerBoundAvailableNumber, "maxNumberOfBindingsToRemove", maxNumberToRemove)
+
+	// we can still update the bindings that are failed to apply already regardless of the maxNumberToRemove
+	for i := 0; i < maxUnavailableNumber && i < len(applyFailedUpdateCandidates); i++ {
+		toBeUpdatedBinding = append(toBeUpdatedBinding, applyFailedUpdateCandidates[i])
+	}
 	if maxNumberToRemove > 0 {
 		i := 0
 		// we first remove the bindings that are not selected by the scheduler anymore

--- a/pkg/controllers/rollout/controller_integration_test.go
+++ b/pkg/controllers/rollout/controller_integration_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		// simulate that some of the bindings are applied
 		firstApplied := 3
 		for i := 0; i < firstApplied; i++ {
-			markBindingApplied(bindings[i].GetName())
+			markBindingApplied(bindings[i], true)
 		}
 		// simulate another scheduling decision, pick some cluster to unselect from the bottom of the list
 		var newTarget int32 = 9
@@ -182,7 +182,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		}
 		// simulate that some of the bindings are applied
 		for i := firstApplied; i < int(newTarget); i++ {
-			markBindingApplied(bindings[i].GetName())
+			markBindingApplied(bindings[i], true)
 		}
 		newScheduled := int(newTarget) - stillScheduled
 		for i := 0; i < newScheduled; i++ {
@@ -194,7 +194,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		}
 		// simulate that some of the bindings are applied
 		for i := int(newTarget); i < int(targetCluster); i++ {
-			markBindingApplied(bindings[i].GetName())
+			markBindingApplied(bindings[i], true)
 		}
 		// check that the second round of bindings are scheduled
 		Eventually(func() bool {
@@ -211,7 +211,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		}, timeout, interval).Should(BeTrue(), "rollout controller should roll all the bindings to Bound state")
 		// simulate that the new bindings are applied
 		for i := 0; i < len(secondRoundBindings); i++ {
-			markBindingApplied(secondRoundBindings[i].GetName())
+			markBindingApplied(secondRoundBindings[i], true)
 		}
 		// check that the unselected bindings are deleted
 		Eventually(func() bool {
@@ -258,7 +258,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		// simulate that some of the bindings are applied
 		firstApplied := 3
 		for i := 0; i < firstApplied; i++ {
-			markBindingApplied(bindings[i].GetName())
+			markBindingApplied(bindings[i], true)
 		}
 		// simulate another scheduling decision, pick some cluster to unselect from the bottom of the list
 		var newTarget int32 = 9
@@ -280,7 +280,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		}
 		// simulate that some of the bindings are applied
 		for i := firstApplied; i < int(newTarget); i++ {
-			markBindingApplied(bindings[i].GetName())
+			markBindingApplied(bindings[i], true)
 		}
 		// create the newly scheduled bindings
 		newScheduled := int(newTarget) - stillScheduled
@@ -293,7 +293,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		}
 		// simulate that some of the bindings are applied
 		for i := int(newTarget); i < int(targetCluster); i++ {
-			markBindingApplied(bindings[i].GetName())
+			markBindingApplied(bindings[i], true)
 		}
 		// mark the master snapshot as not latest
 		masterSnapshot.SetLabels(map[string]string{
@@ -319,7 +319,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		}, timeout, interval).Should(BeTrue(), "rollout controller should roll all the bindings to Bound state")
 		// simulate that the new bindings are applied
 		for i := 0; i < len(secondRoundBindings); i++ {
-			markBindingApplied(secondRoundBindings[i].GetName())
+			markBindingApplied(secondRoundBindings[i], true)
 		}
 		// check that the unselected bindings are deleted
 		Eventually(func() bool {
@@ -342,7 +342,7 @@ var _ = Describe("Test the rollout Controller", func() {
 				}
 				if binding.Spec.ResourceSnapshotName == newMasterSnapshot.Name {
 					// simulate the work generator to make the newly updated bindings to be applied
-					markBindingApplied(binding.GetName())
+					markBindingApplied(binding, true)
 				} else {
 					misMatch = true
 				}
@@ -452,24 +452,103 @@ var _ = Describe("Test the rollout Controller", func() {
 		By("Verified that the rollout is finally unblocked")
 	})
 
+	It("Should rollout both the old applied and failed to apply bond the new resources", func() {
+		// create CRP
+		var targetCluster int32 = 5
+		rolloutCRP = clusterResourcePlacementForTest(testCRPName, createPlacementPolicyForTest(fleetv1beta1.PickNPlacementType, targetCluster))
+		Expect(k8sClient.Create(ctx, rolloutCRP)).Should(Succeed())
+		// create master resource snapshot that is latest
+		masterSnapshot := generateResourceSnapshot(rolloutCRP.Name, 0, true)
+		Expect(k8sClient.Create(ctx, masterSnapshot)).Should(Succeed())
+		By(fmt.Sprintf("master resource snapshot  %s created", masterSnapshot.Name))
+		// create scheduled bindings for master snapshot on target clusters
+		clusters := make([]string, targetCluster)
+		for i := 0; i < int(targetCluster); i++ {
+			clusters[i] = "cluster-" + strconv.Itoa(i)
+			binding := generateClusterResourceBinding(fleetv1beta1.BindingStateScheduled, masterSnapshot.Name, clusters[i])
+			Expect(k8sClient.Create(ctx, binding)).Should(Succeed())
+			By(fmt.Sprintf("resource binding  %s created", binding.Name))
+			bindings = append(bindings, binding)
+		}
+		// check that all bindings are scheduled
+		Eventually(func() bool {
+			for _, binding := range bindings {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: binding.GetName()}, binding)
+				if err != nil {
+					return false
+				}
+				if binding.Spec.State != fleetv1beta1.BindingStateBound {
+					return false
+				}
+			}
+			return true
+		}, timeout, interval).Should(BeTrue(), "rollout controller should roll all the bindings to Bound state")
+		// simulate that some of the bindings are applied successfully
+		applySuccessfully := 3
+		for i := 0; i < applySuccessfully; i++ {
+			markBindingApplied(bindings[i], true)
+		}
+		// simulate that some of the bindings fail to apply
+		for i := applySuccessfully; i < int(targetCluster); i++ {
+			markBindingApplied(bindings[i], false)
+		}
+		// mark the master snapshot as not latest
+		masterSnapshot.SetLabels(map[string]string{
+			fleetv1beta1.CRPTrackingLabel:      testCRPName,
+			fleetv1beta1.IsLatestSnapshotLabel: "false"},
+		)
+		Expect(k8sClient.Update(ctx, masterSnapshot)).Should(Succeed())
+		// create a new master resource snapshot
+		newMasterSnapshot := generateResourceSnapshot(rolloutCRP.Name, 1, true)
+		Expect(k8sClient.Create(ctx, newMasterSnapshot)).Should(Succeed())
+		Eventually(func() bool {
+			allMatch := true
+			for _, binding := range bindings {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: binding.GetName()}, binding)
+				if err != nil {
+					allMatch = false
+				}
+				if binding.Spec.ResourceSnapshotName == newMasterSnapshot.Name {
+					// simulate the work generator to make the newly updated bindings to be applied successfully
+					markBindingApplied(binding, true)
+				} else {
+					allMatch = false
+				}
+			}
+			return allMatch
+		}, timeout, interval).Should(BeTrue(), "rollout controller should roll all the bindings to use the latest resource snapshot")
+	})
+
 	// TODO: should update scheduled bindings to the latest snapshot when it is updated to bound state.
 
 	// TODO: should count the deleting bindings as can be Unavailable.
 
 })
 
-func markBindingApplied(bindingName string) {
-	binding := fleetv1beta1.ClusterResourceBinding{}
-	// get the binding again to avoid conflict
-	Expect(k8sClient.Get(ctx, types.NamespacedName{Name: bindingName}, &binding)).Should(Succeed())
-	binding.SetConditions(metav1.Condition{
-		Status:             metav1.ConditionTrue,
-		Type:               string(fleetv1beta1.ResourceBindingApplied),
-		Reason:             "applied",
-		ObservedGeneration: binding.Generation,
-	})
-	Expect(k8sClient.Status().Update(ctx, &binding)).Should(Succeed())
-	By(fmt.Sprintf("resource binding `%s` is marked as applied", binding.Name))
+func markBindingApplied(binding *fleetv1beta1.ClusterResourceBinding, success bool) {
+	applyCondition := metav1.Condition{
+		Type: string(fleetv1beta1.ResourceBindingApplied),
+	}
+	if success {
+		applyCondition.Status = metav1.ConditionTrue
+		applyCondition.Reason = "applySucceeded"
+	} else {
+		applyCondition.Status = metav1.ConditionFalse
+		applyCondition.Reason = "applyFailed"
+	}
+	Eventually(func() error {
+		applyCondition.ObservedGeneration = binding.Generation
+		binding.SetConditions(applyCondition)
+		if err := k8sClient.Status().Update(ctx, binding); err != nil {
+			if apierrors.IsConflict(err) {
+				// get the binding again to avoid conflict
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: binding.Name}, binding)).Should(Succeed())
+			}
+			return err
+		}
+		return nil
+	}, timeout, interval).Should(Succeed(), "should update the binding status successfully")
+	By(fmt.Sprintf("resource binding `%s` is marked as applied with status %t", binding.Name, success))
 }
 
 func generateClusterResourceBinding(state fleetv1beta1.BindingState, resourceSnapshotName, targetCluster string) *fleetv1beta1.ClusterResourceBinding {

--- a/pkg/controllers/rollout/controller_test.go
+++ b/pkg/controllers/rollout/controller_test.go
@@ -30,9 +30,11 @@ var (
 	cluster1 = "cluster-1"
 	cluster2 = "cluster-2"
 	cluster3 = "cluster-3"
+	cluster4 = "cluster-4"
+	cluster5 = "cluster-5"
 )
 
-func TestReconciler_handleResourceSnapshot(t *testing.T) {
+func TestReconcilerHandleResourceSnapshot(t *testing.T) {
 	tests := map[string]struct {
 		snapshot      client.Object
 		shouldEnqueue bool
@@ -113,7 +115,7 @@ func TestReconciler_handleResourceSnapshot(t *testing.T) {
 	}
 }
 
-func TestReconciler_handleResourceBinding(t *testing.T) {
+func TestReconcilerHandleResourceBinding(t *testing.T) {
 	tests := map[string]struct {
 		resourceBinding client.Object
 		shouldEnqueue   bool
@@ -149,7 +151,7 @@ func TestReconciler_handleResourceBinding(t *testing.T) {
 	}
 }
 
-func Test_waitForResourcesToCleanUp(t *testing.T) {
+func TestWaitForResourcesToCleanUp(t *testing.T) {
 	tests := map[string]struct {
 		allBindings []*fleetv1beta1.ClusterResourceBinding
 		wantWait    bool
@@ -215,44 +217,7 @@ func Test_waitForResourcesToCleanUp(t *testing.T) {
 	}
 }
 
-func Test_pickBindingsToRoll(t *testing.T) {
-	tests := map[string]struct {
-		allBindings                []*fleetv1beta1.ClusterResourceBinding
-		latestResourceSnapshotName string
-		crp                        *fleetv1beta1.ClusterResourcePlacement
-		tobeUpdatedBindings        []int
-		needRoll                   bool
-	}{
-		// TODO: add more tests
-		"test bound with out dated bindings": {
-			allBindings: []*fleetv1beta1.ClusterResourceBinding{
-				generateClusterResourceBinding(fleetv1beta1.BindingStateScheduled, "snapshot-1", cluster1),
-			},
-			latestResourceSnapshotName: "snapshot-2",
-			crp: clusterResourcePlacementForTest("test",
-				createPlacementPolicyForTest(fleetv1beta1.PickAllPlacementType, 0)),
-			tobeUpdatedBindings: []int{0},
-			needRoll:            true,
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			gotUpdatedBindings, gotNeedRoll := pickBindingsToRoll(tt.allBindings, tt.latestResourceSnapshotName, tt.crp)
-			tobeUpdatedBindings := make([]*fleetv1beta1.ClusterResourceBinding, 0)
-			for _, index := range tt.tobeUpdatedBindings {
-				tobeUpdatedBindings = append(tobeUpdatedBindings, tt.allBindings[index])
-			}
-			if !reflect.DeepEqual(gotUpdatedBindings, tobeUpdatedBindings) {
-				t.Errorf("pickBindingsToRoll test `%s` gotUpdatedBindings = %v, wantReady %v", name, gotUpdatedBindings, tt.tobeUpdatedBindings)
-			}
-			if gotNeedRoll != tt.needRoll {
-				t.Errorf("pickBindingsToRoll test `%s` gotNeedRoll = %v, wantReady %v", name, gotNeedRoll, tt.needRoll)
-			}
-		})
-	}
-}
-
-func TestReconciler_updateBindings(t *testing.T) {
+func TestReconcilerUpdateBindings(t *testing.T) {
 	tests := map[string]struct {
 		name                       string
 		Client                     client.Client
@@ -274,64 +239,7 @@ func TestReconciler_updateBindings(t *testing.T) {
 	}
 }
 
-func createPlacementPolicyForTest(placementType fleetv1beta1.PlacementType, numberOfClusters int32) *fleetv1beta1.PlacementPolicy {
-	return &fleetv1beta1.PlacementPolicy{
-		PlacementType:    placementType,
-		NumberOfClusters: pointer.Int32(numberOfClusters),
-		Affinity: &fleetv1beta1.Affinity{
-			ClusterAffinity: &fleetv1beta1.ClusterAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &fleetv1beta1.ClusterSelector{
-					ClusterSelectorTerms: []fleetv1beta1.ClusterSelectorTerm{
-						{
-							LabelSelector: metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"key1": "value1",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func clusterResourcePlacementForTest(crpName string, policy *fleetv1beta1.PlacementPolicy) *fleetv1beta1.ClusterResourcePlacement {
-	return &fleetv1beta1.ClusterResourcePlacement{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: crpName,
-		},
-		Spec: fleetv1beta1.ClusterResourcePlacementSpec{
-			ResourceSelectors: []fleetv1beta1.ClusterResourceSelector{
-				{
-					Group:   corev1.GroupName,
-					Version: "v1",
-					Kind:    "Service",
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"region": "east"},
-					},
-				},
-			},
-			Policy: policy,
-			Strategy: fleetv1beta1.RolloutStrategy{
-				Type: fleetv1beta1.RollingUpdateRolloutStrategyType,
-				RollingUpdate: &fleetv1beta1.RollingUpdateConfig{
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.String,
-						StrVal: "20%",
-					},
-					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 3,
-					},
-					UnavailablePeriodSeconds: pointer.Int(1),
-				},
-			},
-		},
-	}
-}
-
-func Test_isBindingReady(t *testing.T) {
+func TestIsBindingReady(t *testing.T) {
 	tests := map[string]struct {
 		binding         *fleetv1beta1.ClusterResourceBinding
 		readyTimeCutOff time.Time
@@ -426,4 +334,121 @@ func Test_isBindingReady(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPickBindingsToRoll(t *testing.T) {
+	tests := map[string]struct {
+		allBindings                []*fleetv1beta1.ClusterResourceBinding
+		latestResourceSnapshotName string
+		crp                        *fleetv1beta1.ClusterResourcePlacement
+		tobeUpdatedBindings        []int
+		needRoll                   bool
+	}{
+		// TODO: add more tests
+		"test bound with out dated bindings": {
+			allBindings: []*fleetv1beta1.ClusterResourceBinding{
+				generateClusterResourceBinding(fleetv1beta1.BindingStateScheduled, "snapshot-1", cluster1),
+			},
+			latestResourceSnapshotName: "snapshot-2",
+			crp: clusterResourcePlacementForTest("test",
+				createPlacementPolicyForTest(fleetv1beta1.PickAllPlacementType, 0)),
+			tobeUpdatedBindings: []int{0},
+			needRoll:            true,
+		},
+		"test bound with failed to apply bindings": {
+			allBindings: []*fleetv1beta1.ClusterResourceBinding{
+				generateFailedToApplyClusterResourceBinding(fleetv1beta1.BindingStateBound, "snapshot-1", cluster1),
+				generateClusterResourceBinding(fleetv1beta1.BindingStateBound, "snapshot-1", cluster2),
+				generateClusterResourceBinding(fleetv1beta1.BindingStateBound, "snapshot-1", cluster3),
+				generateClusterResourceBinding(fleetv1beta1.BindingStateBound, "snapshot-1", cluster4),
+				generateClusterResourceBinding(fleetv1beta1.BindingStateBound, "snapshot-1", cluster5),
+			},
+			latestResourceSnapshotName: "snapshot-2",
+			crp: clusterResourcePlacementForTest("test",
+				createPlacementPolicyForTest(fleetv1beta1.PickNPlacementType, 5)),
+			tobeUpdatedBindings: []int{0},
+			needRoll:            true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotUpdatedBindings, gotNeedRoll := pickBindingsToRoll(tt.allBindings, tt.latestResourceSnapshotName, tt.crp)
+			tobeUpdatedBindings := make([]*fleetv1beta1.ClusterResourceBinding, 0)
+			for _, index := range tt.tobeUpdatedBindings {
+				tobeUpdatedBindings = append(tobeUpdatedBindings, tt.allBindings[index])
+			}
+			if !reflect.DeepEqual(gotUpdatedBindings, tobeUpdatedBindings) {
+				t.Errorf("pickBindingsToRoll test `%s` gotUpdatedBindings = %v, wantReady %v", name, gotUpdatedBindings, tt.tobeUpdatedBindings)
+			}
+			if gotNeedRoll != tt.needRoll {
+				t.Errorf("pickBindingsToRoll test `%s` gotNeedRoll = %v, wantReady %v", name, gotNeedRoll, tt.needRoll)
+			}
+		})
+	}
+}
+
+func createPlacementPolicyForTest(placementType fleetv1beta1.PlacementType, numberOfClusters int32) *fleetv1beta1.PlacementPolicy {
+	return &fleetv1beta1.PlacementPolicy{
+		PlacementType:    placementType,
+		NumberOfClusters: pointer.Int32(numberOfClusters),
+		Affinity: &fleetv1beta1.Affinity{
+			ClusterAffinity: &fleetv1beta1.ClusterAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &fleetv1beta1.ClusterSelector{
+					ClusterSelectorTerms: []fleetv1beta1.ClusterSelectorTerm{
+						{
+							LabelSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"key1": "value1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func clusterResourcePlacementForTest(crpName string, policy *fleetv1beta1.PlacementPolicy) *fleetv1beta1.ClusterResourcePlacement {
+	return &fleetv1beta1.ClusterResourcePlacement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crpName,
+		},
+		Spec: fleetv1beta1.ClusterResourcePlacementSpec{
+			ResourceSelectors: []fleetv1beta1.ClusterResourceSelector{
+				{
+					Group:   corev1.GroupName,
+					Version: "v1",
+					Kind:    "Service",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"region": "east"},
+					},
+				},
+			},
+			Policy: policy,
+			Strategy: fleetv1beta1.RolloutStrategy{
+				Type: fleetv1beta1.RollingUpdateRolloutStrategyType,
+				RollingUpdate: &fleetv1beta1.RollingUpdateConfig{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "20%",
+					},
+					MaxSurge: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 3,
+					},
+					UnavailablePeriodSeconds: pointer.Int(1),
+				},
+			},
+		},
+	}
+}
+
+func generateFailedToApplyClusterResourceBinding(state fleetv1beta1.BindingState, resourceSnapshotName, targetCluster string) *fleetv1beta1.ClusterResourceBinding {
+	binding := generateClusterResourceBinding(state, resourceSnapshotName, targetCluster)
+	binding.Status.Conditions = append(binding.Status.Conditions, metav1.Condition{
+		Type:   string(fleetv1beta1.ResourceBindingApplied),
+		Status: metav1.ConditionFalse,
+	})
+	return binding
 }


### PR DESCRIPTION
### Description of your changes

Rollout can get stuck when there are failed to apply bindings since there are already max unavailable bindings. The fix is to update the failed bindings first since it won't make more bindings unavailable since they are already unavailable anyway.

Fixes #

I have:

- [x ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

UT/IT/E2E


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
