### PR TITLE
feat: add resource snapshot info in the crp status

### DIFF
--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -340,6 +340,11 @@ type ClusterResourcePlacementStatus struct {
 	// +optional
 	SelectedResources []ResourceIdentifier `json:"selectedResources,omitempty"`
 
+	// ClusterResourceSnapshots is a list of clusterResourceSnapshot names.
+	// ClusterResourceSnapshot is used to store a snapshot of selected resources by a resource placement policy.
+	// A placement could produce multiple clusterResourceSnapshots to select large amount of resources.
+	ClusterResourceSnapshots []string `json:"clusterResourceSnapshots,omitempty"`
+
 	// PlacementStatuses contains a list of placement status on the clusters that are selected by PlacementPolicy.
 	// Each selected cluster according to the latest resource placement is guaranteed to have a corresponding placementStatuses.
 	// In the pickN case, there are N placement statuses where N = NumberOfClusters; Or in the pickFixed case, there are

--- a/apis/placement/v1beta1/zz_generated.deepcopy.go
+++ b/apis/placement/v1beta1/zz_generated.deepcopy.go
@@ -11,7 +11,7 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -353,6 +353,11 @@ func (in *ClusterResourcePlacementStatus) DeepCopyInto(out *ClusterResourcePlace
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.ClusterResourceSnapshots != nil {
+		in, out := &in.ClusterResourceSnapshots, &out.ClusterResourceSnapshots
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.PlacementStatuses != nil {
 		in, out := &in.PlacementStatuses, &out.PlacementStatuses

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -479,6 +479,14 @@ spec:
           status:
             description: The observed status of ClusterResourcePlacement.
             properties:
+              clusterResourceSnapshots:
+                description: ClusterResourceSnapshots is a list of clusterResourceSnapshot
+                  names. ClusterResourceSnapshot is used to store a snapshot of selected
+                  resources by a resource placement policy. A placement could produce
+                  multiple clusterResourceSnapshots to select large amount of resources.
+                items:
+                  type: string
+                type: array
               conditions:
                 description: Conditions is an array of current observed conditions
                   for ClusterResourcePlacement.


### PR DESCRIPTION
### Description of your changes

Provide a way to show the resource content applied by CRP.
Note, the clusterResourceSnapshot objects will be a customer visible object and customer can check the resource content by the CRP.

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

API change

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
