### PR TITLE
fix: use hyphen case for all labels and annotation names

### DIFF
--- a/apis/placement/v1beta1/policysnapshot_types.go
+++ b/apis/placement/v1beta1/policysnapshot_types.go
@@ -12,13 +12,13 @@ import (
 
 const (
 	// PolicyIndexLabel is the label that indicate the policy snapshot index of a cluster policy.
-	PolicyIndexLabel = fleetPrefix + "policyIndex"
+	PolicyIndexLabel = fleetPrefix + "policy-index"
 
 	// PolicySnapshotNameFmt is clusterPolicySnapshot name format: {CRPName}-{PolicySnapshotIndex}.
 	PolicySnapshotNameFmt = "%s-%d"
 
 	// NumberOfClustersAnnotation is the annotation that indicates how many clusters should be selected for selectN placement type.
-	NumberOfClustersAnnotation = fleetPrefix + "numberOfClusters"
+	NumberOfClustersAnnotation = fleetPrefix + "number-of-clusters"
 )
 
 // +genclient

--- a/apis/placement/v1beta1/resourcesnapshot_types.go
+++ b/apis/placement/v1beta1/resourcesnapshot_types.go
@@ -13,20 +13,20 @@ import (
 
 const (
 	// ResourceIndexLabel is the label that indicate the resource snapshot index of a cluster resource snapshot.
-	ResourceIndexLabel = fleetPrefix + "resourceIndex"
+	ResourceIndexLabel = fleetPrefix + "resource-index"
 
 	// ResourceGroupHashAnnotation is the annotation that contains the value of the sha-256 hash
 	// value of all the snapshots belong to the same snapshot index.
-	ResourceGroupHashAnnotation = fleetPrefix + "resourceHash"
+	ResourceGroupHashAnnotation = fleetPrefix + "resource-hash"
 
 	// NumberOfEnvelopedObjectsAnnotation is the annotation that contains the number of the enveloped objects in the resource snapshot group.
-	NumberOfEnvelopedObjectsAnnotation = fleetPrefix + "numberOfEnvelopedObject"
+	NumberOfEnvelopedObjectsAnnotation = fleetPrefix + "number-of-enveloped-object"
 
 	// NumberOfResourceSnapshotsAnnotation is the annotation that contains the total number of resource snapshots.
-	NumberOfResourceSnapshotsAnnotation = fleetPrefix + "numberOfResourceSnapshots"
+	NumberOfResourceSnapshotsAnnotation = fleetPrefix + "number-of-resource-snapshots"
 
 	// SubindexOfResourceSnapshotAnnotation is the annotation to store the subindex of resource snapshot in the group.
-	SubindexOfResourceSnapshotAnnotation = fleetPrefix + "subindexOfResourceSnapshot"
+	SubindexOfResourceSnapshotAnnotation = fleetPrefix + "subindex-of-resource-snapshot"
 
 	// ResourceSnapshotNameFmt is resourcePolicySnapshot name format: {CRPName}-{resourceIndex}-snapshot.
 	ResourceSnapshotNameFmt = "%s-%d-snapshot"


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where we use both camel case and hyphen case for our labels and annotations.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A
