### PR TITLE
feat: add allowedPropagatingAPIs option for resource selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,11 @@ $(GOIMPORTS):
 $(ENVTEST):
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) sigs.k8s.io/controller-runtime/tools/setup-envtest $(ENVTEST_BIN) $(ENVTEST_VER)
 
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
 ## --------------------------------------
 ## Linting
 ## --------------------------------------

--- a/apis/placement/v1beta1/zz_generated.deepcopy.go
+++ b/apis/placement/v1beta1/zz_generated.deepcopy.go
@@ -11,7 +11,7 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/cmd/hubagent/options/options.go
+++ b/cmd/hubagent/options/options.go
@@ -48,6 +48,8 @@ type Options struct {
 	// WorkPendingGracePeriod represents the grace period after a work is created/updated.
 	// We consider a work failed if a work's last applied condition doesn't change after period.
 	WorkPendingGracePeriod metav1.Duration
+	// SkippedPropagatingAPIs and AllowedPropagatingAPIs options are used to control the propagation of resources.
+	// If none of them are set, the default skippedPropagatingAPIs list will be used.
 	// SkippedPropagatingAPIs indicates semicolon separated resources that should be skipped for propagating.
 	SkippedPropagatingAPIs string
 	// AllowedPropagatingAPIs indicates semicolon separated resources that should be allowed for propagating.

--- a/cmd/hubagent/options/options.go
+++ b/cmd/hubagent/options/options.go
@@ -48,8 +48,11 @@ type Options struct {
 	// WorkPendingGracePeriod represents the grace period after a work is created/updated.
 	// We consider a work failed if a work's last applied condition doesn't change after period.
 	WorkPendingGracePeriod metav1.Duration
-	// SkippedPropagatingAPIs indicates comma separated resources that should be skipped for propagating.
+	// SkippedPropagatingAPIs indicates semicolon separated resources that should be skipped for propagating.
 	SkippedPropagatingAPIs string
+	// AllowedPropagatingAPIs indicates semicolon separated resources that should be allowed for propagating.
+	// This is mutually exclusive with SkippedPropagatingAPIs.
+	AllowedPropagatingAPIs string
 	// SkippedPropagatingNamespaces is a list of namespaces that will be skipped for propagating.
 	SkippedPropagatingNamespaces string
 	// HubQPS is the QPS to use while talking with hub-apiserver. Default is 20.0.
@@ -107,6 +110,10 @@ func (o *Options) AddFlags(flags *flag.FlagSet) {
 	flags.DurationVar(&o.ClusterUnhealthyThreshold.Duration, "cluster-unhealthy-threshold", 60*time.Second, "The duration for a member cluster to be in a degraded state before considered unhealthy.")
 	flags.DurationVar(&o.WorkPendingGracePeriod.Duration, "work-pending-grace-period", 15*time.Second,
 		"Specifies the grace period of allowing a manifest to be pending before marking it as failed.")
+	flags.StringVar(&o.AllowedPropagatingAPIs, "allowed-propagating-apis", "", "Semicolon separated resources that should be allowed for propagation. Supported formats are:\n"+
+		"<group> for allowing resources with a specific API group(e.g. networking.k8s.io),\n"+
+		"<group>/<version> for allowing resources with a specific API version(e.g. networking.k8s.io/v1beta1),\n"+
+		"<group>/<version>/<kind>,<kind> for allowing one or more specific resources (e.g. networking.k8s.io/v1beta1/Ingress,IngressClass) where the Kinds are case-insensitive.")
 	flags.StringVar(&o.SkippedPropagatingAPIs, "skipped-propagating-apis", "", "Semicolon separated resources that should be skipped from propagating in addition to the default skip list(cluster.fleet.io;policy.fleet.io;work.fleet.io). Supported formats are:\n"+
 		"<group> for skip resources with a specific API group(e.g. networking.k8s.io),\n"+
 		"<group>/<version> for skip resources with a specific API version(e.g. networking.k8s.io/v1beta1),\n"+

--- a/cmd/hubagent/options/validation.go
+++ b/cmd/hubagent/options/validation.go
@@ -22,7 +22,7 @@ func (o *Options) Validate() field.ErrorList {
 		errs = append(errs, field.Invalid(newPath.Child("AllowedPropagatingAPIs"), o.AllowedPropagatingAPIs, "AllowedPropagatingAPIs and SkippedPropagatingAPIs are mutually exclusive"))
 	}
 
-	resourceConfig := utils.NewResourceConfig(false)
+	resourceConfig := utils.NewResourceConfig(o.AllowedPropagatingAPIs != "")
 	if err := resourceConfig.Parse(o.SkippedPropagatingAPIs); err != nil {
 		errs = append(errs, field.Invalid(newPath.Child("SkippedPropagatingAPIs"), o.SkippedPropagatingAPIs, "Invalid API string"))
 	}

--- a/cmd/hubagent/options/validation.go
+++ b/cmd/hubagent/options/validation.go
@@ -18,10 +18,20 @@ func (o *Options) Validate() field.ErrorList {
 	errs := field.ErrorList{}
 	newPath := field.NewPath("Options")
 
-	disabledResourceConfig := utils.NewDisabledResourceConfig()
+	if o.AllowedPropagatingAPIs != "" && o.SkippedPropagatingAPIs != "" {
+		errs = append(errs, field.Invalid(newPath.Child("AllowedPropagatingAPIs"), o.AllowedPropagatingAPIs, "AllowedPropagatingAPIs and SkippedPropagatingAPIs are mutually exclusive"))
+	}
+
+	disabledResourceConfig := utils.NewResourceConfig(true)
 	if err := disabledResourceConfig.Parse(o.SkippedPropagatingAPIs); err != nil {
 		errs = append(errs, field.Invalid(newPath.Child("SkippedPropagatingAPIs"), o.SkippedPropagatingAPIs, "Invalid API string"))
 	}
+
+	allowedResourceConfig := utils.NewResourceConfig(false)
+	if err := allowedResourceConfig.Parse(o.AllowedPropagatingAPIs); err != nil {
+		errs = append(errs, field.Invalid(newPath.Child("AllowedPropagatingAPIs"), o.AllowedPropagatingAPIs, "Invalid API string"))
+	}
+
 	if o.ClusterUnhealthyThreshold.Duration <= 0 {
 		errs = append(errs, field.Invalid(newPath.Child("ClusterUnhealthyThreshold"), o.ClusterUnhealthyThreshold, "Must be greater than 0"))
 	}

--- a/cmd/hubagent/options/validation.go
+++ b/cmd/hubagent/options/validation.go
@@ -22,13 +22,11 @@ func (o *Options) Validate() field.ErrorList {
 		errs = append(errs, field.Invalid(newPath.Child("AllowedPropagatingAPIs"), o.AllowedPropagatingAPIs, "AllowedPropagatingAPIs and SkippedPropagatingAPIs are mutually exclusive"))
 	}
 
-	disabledResourceConfig := utils.NewResourceConfig(true)
-	if err := disabledResourceConfig.Parse(o.SkippedPropagatingAPIs); err != nil {
+	resourceConfig := utils.NewResourceConfig(false)
+	if err := resourceConfig.Parse(o.SkippedPropagatingAPIs); err != nil {
 		errs = append(errs, field.Invalid(newPath.Child("SkippedPropagatingAPIs"), o.SkippedPropagatingAPIs, "Invalid API string"))
 	}
-
-	allowedResourceConfig := utils.NewResourceConfig(false)
-	if err := allowedResourceConfig.Parse(o.AllowedPropagatingAPIs); err != nil {
+	if err := resourceConfig.Parse(o.AllowedPropagatingAPIs); err != nil {
 		errs = append(errs, field.Invalid(newPath.Child("AllowedPropagatingAPIs"), o.AllowedPropagatingAPIs, "Invalid API string"))
 	}
 

--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -105,8 +105,11 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		}
 	}
 
+	// AllowedPropagatingAPIs and SkippedPropagatingAPIs are mutually exclusive.
+    // If none of them are set, the resourceConfig by default stores a list of skipped propagation APIs.
 	resourceConfig := utils.NewResourceConfig(opts.AllowedPropagatingAPIs != "")
 	if err := resourceConfig.Parse(opts.AllowedPropagatingAPIs); err != nil {
+		// The program will never go here because the parameters have been checked.
 		return err
 	}
 	if err := resourceConfig.Parse(opts.SkippedPropagatingAPIs); err != nil {

--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -105,14 +105,12 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		}
 	}
 
-	disabledResourceConfig := utils.NewResourceConfig(true)
-	if err := disabledResourceConfig.Parse(opts.SkippedPropagatingAPIs); err != nil {
-		// The program will never go here because the parameters have been checked
+	disabledResourceConfig := utils.NewResourceConfig(opts.AllowedPropagatingAPIs != "")
+	if err := disabledResourceConfig.Parse(opts.AllowedPropagatingAPIs); err != nil {
 		return err
 	}
-
-	allowedResourceConfig := utils.NewResourceConfig(false)
-	if err := allowedResourceConfig.Parse(opts.AllowedPropagatingAPIs); err != nil {
+	if err := disabledResourceConfig.Parse(opts.SkippedPropagatingAPIs); err != nil {
+		// The program will never go here because the parameters have been checked
 		return err
 	}
 
@@ -138,7 +136,6 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		RestMapper:             mgr.GetRESTMapper(),
 		InformerManager:        dynamicInformerManager,
 		DisabledResourceConfig: disabledResourceConfig,
-		AllowedResourceConfig:  allowedResourceConfig,
 		SkippedNamespaces:      skippedNamespaces,
 		Scheme:                 mgr.GetScheme(),
 		UncachedReader:         mgr.GetAPIReader(),
@@ -276,7 +273,6 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		MemberClusterPlacementController:           memberClusterPlacementController,
 		InformerManager:                            dynamicInformerManager,
 		DisabledResourceConfig:                     disabledResourceConfig,
-		AllowedResourceConfig:                      allowedResourceConfig,
 		SkippedNamespaces:                          skippedNamespaces,
 		ConcurrentClusterPlacementWorker:           opts.ConcurrentClusterPlacementSyncs,
 		ConcurrentResourceChangeWorker:             opts.ConcurrentResourceChangeSyncs,

--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -105,9 +105,14 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		}
 	}
 
-	disabledResourceConfig := utils.NewDisabledResourceConfig()
+	disabledResourceConfig := utils.NewResourceConfig(true)
 	if err := disabledResourceConfig.Parse(opts.SkippedPropagatingAPIs); err != nil {
 		// The program will never go here because the parameters have been checked
+		return err
+	}
+
+	allowedResourceConfig := utils.NewResourceConfig(false)
+	if err := allowedResourceConfig.Parse(opts.AllowedPropagatingAPIs); err != nil {
 		return err
 	}
 
@@ -133,6 +138,7 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		RestMapper:             mgr.GetRESTMapper(),
 		InformerManager:        dynamicInformerManager,
 		DisabledResourceConfig: disabledResourceConfig,
+		AllowedResourceConfig:  allowedResourceConfig,
 		SkippedNamespaces:      skippedNamespaces,
 		Scheme:                 mgr.GetScheme(),
 		UncachedReader:         mgr.GetAPIReader(),
@@ -270,6 +276,7 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		MemberClusterPlacementController:           memberClusterPlacementController,
 		InformerManager:                            dynamicInformerManager,
 		DisabledResourceConfig:                     disabledResourceConfig,
+		AllowedResourceConfig:                      allowedResourceConfig,
 		SkippedNamespaces:                          skippedNamespaces,
 		ConcurrentClusterPlacementWorker:           opts.ConcurrentClusterPlacementSyncs,
 		ConcurrentResourceChangeWorker:             opts.ConcurrentResourceChangeSyncs,

--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -105,11 +105,11 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		}
 	}
 
-	disabledResourceConfig := utils.NewResourceConfig(opts.AllowedPropagatingAPIs != "")
-	if err := disabledResourceConfig.Parse(opts.AllowedPropagatingAPIs); err != nil {
+	resourceConfig := utils.NewResourceConfig(opts.AllowedPropagatingAPIs != "")
+	if err := resourceConfig.Parse(opts.AllowedPropagatingAPIs); err != nil {
 		return err
 	}
-	if err := disabledResourceConfig.Parse(opts.SkippedPropagatingAPIs); err != nil {
+	if err := resourceConfig.Parse(opts.SkippedPropagatingAPIs); err != nil {
 		// The program will never go here because the parameters have been checked
 		return err
 	}
@@ -131,14 +131,14 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 
 	// Set up  a custom controller to reconcile cluster resource placement
 	crpc := &clusterresourceplacement.Reconciler{
-		Client:                 mgr.GetClient(),
-		Recorder:               mgr.GetEventRecorderFor(crpControllerName),
-		RestMapper:             mgr.GetRESTMapper(),
-		InformerManager:        dynamicInformerManager,
-		DisabledResourceConfig: disabledResourceConfig,
-		SkippedNamespaces:      skippedNamespaces,
-		Scheme:                 mgr.GetScheme(),
-		UncachedReader:         mgr.GetAPIReader(),
+		Client:            mgr.GetClient(),
+		Recorder:          mgr.GetEventRecorderFor(crpControllerName),
+		RestMapper:        mgr.GetRESTMapper(),
+		InformerManager:   dynamicInformerManager,
+		ResourceConfig:    resourceConfig,
+		SkippedNamespaces: skippedNamespaces,
+		Scheme:            mgr.GetScheme(),
+		UncachedReader:    mgr.GetAPIReader(),
 	}
 
 	rateLimiter := options.DefaultControllerRateLimiter(opts.RateLimiterOpts)
@@ -272,7 +272,7 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 		ResourceChangeController:                   resourceChangeController,
 		MemberClusterPlacementController:           memberClusterPlacementController,
 		InformerManager:                            dynamicInformerManager,
-		DisabledResourceConfig:                     disabledResourceConfig,
+		ResourceConfig:                             resourceConfig,
 		SkippedNamespaces:                          skippedNamespaces,
 		ConcurrentClusterPlacementWorker:           opts.ConcurrentClusterPlacementSyncs,
 		ConcurrentResourceChangeWorker:             opts.ConcurrentResourceChangeSyncs,

--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -106,7 +106,7 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 	}
 
 	// AllowedPropagatingAPIs and SkippedPropagatingAPIs are mutually exclusive.
-    // If none of them are set, the resourceConfig by default stores a list of skipped propagation APIs.
+	// If none of them are set, the resourceConfig by default stores a list of skipped propagation APIs.
 	resourceConfig := utils.NewResourceConfig(opts.AllowedPropagatingAPIs != "")
 	if err := resourceConfig.Parse(opts.AllowedPropagatingAPIs); err != nil {
 		// The program will never go here because the parameters have been checked.

--- a/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
+++ b/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
@@ -50,7 +50,11 @@ type Reconciler struct {
 	UncachedReader client.Reader
 
 	// DisabledResourceConfig contains all the api resources that we won't select.
-	DisabledResourceConfig *utils.DisabledResourceConfig
+	DisabledResourceConfig *utils.ResourceConfig
+
+	// AllowedResourceConfig contains all the api resources that are selected for
+	// propagation. This is mutually exclusive with DisabledResourceConfig
+	AllowedResourceConfig *utils.ResourceConfig
 
 	// SkippedNamespaces contains the namespaces that we should not propagate.
 	SkippedNamespaces map[string]bool

--- a/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
+++ b/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
@@ -49,7 +49,7 @@ type Reconciler struct {
 	// It's only needed by v1beta1 APIs.
 	UncachedReader client.Reader
 
-	// ResourceConfig contains all the API resources that we won't select based on allowed or skipped propagating APIs ption.
+	// ResourceConfig contains all the API resources that we won't select based on allowed or skipped propagating APIs option.
 	ResourceConfig *utils.ResourceConfig
 
 	// SkippedNamespaces contains the namespaces that we should not propagate.

--- a/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
+++ b/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
@@ -52,10 +52,6 @@ type Reconciler struct {
 	// DisabledResourceConfig contains all the api resources that we won't select.
 	DisabledResourceConfig *utils.ResourceConfig
 
-	// AllowedResourceConfig contains all the api resources that are selected for
-	// propagation. This is mutually exclusive with DisabledResourceConfig
-	AllowedResourceConfig *utils.ResourceConfig
-
 	// SkippedNamespaces contains the namespaces that we should not propagate.
 	SkippedNamespaces map[string]bool
 

--- a/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
+++ b/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
@@ -49,8 +49,8 @@ type Reconciler struct {
 	// It's only needed by v1beta1 APIs.
 	UncachedReader client.Reader
 
-	// DisabledResourceConfig contains all the api resources that we won't select.
-	DisabledResourceConfig *utils.ResourceConfig
+	// ResourceConfig contains all the api resources that we won't select based on allowed or skipped propagating apis option.
+	ResourceConfig *utils.ResourceConfig
 
 	// SkippedNamespaces contains the namespaces that we should not propagate.
 	SkippedNamespaces map[string]bool

--- a/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
+++ b/pkg/controllers/clusterresourceplacement/placement_controllerv1alpha1.go
@@ -49,7 +49,7 @@ type Reconciler struct {
 	// It's only needed by v1beta1 APIs.
 	UncachedReader client.Reader
 
-	// ResourceConfig contains all the api resources that we won't select based on allowed or skipped propagating apis option.
+	// ResourceConfig contains all the API resources that we won't select based on allowed or skipped propagating APIs ption.
 	ResourceConfig *utils.ResourceConfig
 
 	// SkippedNamespaces contains the namespaces that we should not propagate.

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -79,7 +79,7 @@ func (r *Reconciler) gatherSelectedResource(placement string, selectors []fleetv
 			Kind:    selector.Kind,
 		}
 
-		if r.DisabledResourceConfig.IsResourceConfigured(gvk) {
+		if r.DisabledResourceConfig.IsResourceDisabled(gvk) {
 			klog.V(2).InfoS("Skip select resource", "group version kind", gvk.String())
 			continue
 		}
@@ -287,29 +287,18 @@ func (r *Reconciler) fetchAllResourcesInOneNamespace(namespaceName string, place
 	return resources, nil
 }
 
-// shouldSelectResource returns whether a resource should be selected for propagation
+// shouldSelectResource returns whether a resource should be selected for propagation.
 func (r *Reconciler) shouldSelectResource(gvr schema.GroupVersionResource) bool {
+	if r.DisabledResourceConfig.IsEmpty() {
+		return true
+	}
 	gvks, err := r.RestMapper.KindsFor(gvr)
 	if err != nil {
 		klog.ErrorS(err, "gvr(%s) transform failed: %v", gvr.String(), err)
 		return false
 	}
-
-	if !r.AllowedResourceConfig.IsEmpty() {
-		for _, gvk := range gvks {
-			if !r.AllowedResourceConfig.IsResourceConfigured(gvk) {
-				return false
-			}
-			klog.V(2).InfoS("Selecting Allowed Resource", "GVK", gvk.String())
-		}
-	}
-
-	if r.DisabledResourceConfig.IsEmpty() {
-		return true
-	}
-
 	for _, gvk := range gvks {
-		if r.DisabledResourceConfig.IsResourceConfigured(gvk) {
+		if r.DisabledResourceConfig.IsResourceDisabled(gvk) {
 			klog.V(2).InfoS("Skip watch resource", "group version kind", gvk.String())
 			return false
 		}

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -79,7 +79,7 @@ func (r *Reconciler) gatherSelectedResource(placement string, selectors []fleetv
 			Kind:    selector.Kind,
 		}
 
-		if r.DisabledResourceConfig.IsResourceDisabled(gvk) {
+		if r.ResourceConfig.IsResourceDisabled(gvk) {
 			klog.V(2).InfoS("Skip select resource", "group version kind", gvk.String())
 			continue
 		}
@@ -289,7 +289,7 @@ func (r *Reconciler) fetchAllResourcesInOneNamespace(namespaceName string, place
 
 // shouldSelectResource returns whether a resource should be selected for propagation.
 func (r *Reconciler) shouldSelectResource(gvr schema.GroupVersionResource) bool {
-	if r.DisabledResourceConfig.IsEmpty() {
+	if r.ResourceConfig.IsEmpty() {
 		return true
 	}
 	gvks, err := r.RestMapper.KindsFor(gvr)
@@ -298,7 +298,7 @@ func (r *Reconciler) shouldSelectResource(gvr schema.GroupVersionResource) bool 
 		return false
 	}
 	for _, gvk := range gvks {
-		if r.DisabledResourceConfig.IsResourceDisabled(gvk) {
+		if r.ResourceConfig.IsResourceDisabled(gvk) {
 			klog.V(2).InfoS("Skip watch resource", "group version kind", gvk.String())
 			return false
 		}

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -289,6 +289,7 @@ func (r *Reconciler) fetchAllResourcesInOneNamespace(namespaceName string, place
 
 // shouldSelectResource returns whether a resource should be selected for propagation.
 func (r *Reconciler) shouldSelectResource(gvr schema.GroupVersionResource) bool {
+	// By default, all of the APIs are allowed.
 	if r.ResourceConfig == nil {
 		return true
 	}

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -289,7 +289,7 @@ func (r *Reconciler) fetchAllResourcesInOneNamespace(namespaceName string, place
 
 // shouldSelectResource returns whether a resource should be selected for propagation.
 func (r *Reconciler) shouldSelectResource(gvr schema.GroupVersionResource) bool {
-	if r.ResourceConfig.IsEmpty() {
+	if r.ResourceConfig == nil {
 		return true
 	}
 	gvks, err := r.RestMapper.KindsFor(gvr)

--- a/pkg/controllers/clusterresourceplacement/suite_test.go
+++ b/pkg/controllers/clusterresourceplacement/suite_test.go
@@ -102,8 +102,7 @@ var _ = BeforeSuite(func() {
 		Recorder:               mgr.GetEventRecorderFor(controllerName),
 		RestMapper:             mgr.GetRESTMapper(),
 		InformerManager:        informer.NewInformerManager(dynamicClient, 5*time.Minute, ctx.Done()),
-		DisabledResourceConfig: utils.NewResourceConfig(true),
-		AllowedResourceConfig:  utils.NewResourceConfig(false),
+		DisabledResourceConfig: utils.NewResourceConfig(false),
 		SkippedNamespaces: map[string]bool{
 			"default": true,
 		},

--- a/pkg/controllers/clusterresourceplacement/suite_test.go
+++ b/pkg/controllers/clusterresourceplacement/suite_test.go
@@ -102,7 +102,8 @@ var _ = BeforeSuite(func() {
 		Recorder:               mgr.GetEventRecorderFor(controllerName),
 		RestMapper:             mgr.GetRESTMapper(),
 		InformerManager:        informer.NewInformerManager(dynamicClient, 5*time.Minute, ctx.Done()),
-		DisabledResourceConfig: utils.NewDisabledResourceConfig(),
+		DisabledResourceConfig: utils.NewResourceConfig(true),
+		AllowedResourceConfig:  utils.NewResourceConfig(false),
 		SkippedNamespaces: map[string]bool{
 			"default": true,
 		},

--- a/pkg/controllers/clusterresourceplacement/suite_test.go
+++ b/pkg/controllers/clusterresourceplacement/suite_test.go
@@ -96,13 +96,13 @@ var _ = BeforeSuite(func() {
 	Expect(err).Should(Succeed(), "failed to create manager")
 
 	reconciler := &Reconciler{
-		Client:                 mgr.GetClient(),
-		Scheme:                 mgr.GetScheme(),
-		UncachedReader:         mgr.GetAPIReader(),
-		Recorder:               mgr.GetEventRecorderFor(controllerName),
-		RestMapper:             mgr.GetRESTMapper(),
-		InformerManager:        informer.NewInformerManager(dynamicClient, 5*time.Minute, ctx.Done()),
-		DisabledResourceConfig: utils.NewResourceConfig(false),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		UncachedReader:  mgr.GetAPIReader(),
+		Recorder:        mgr.GetEventRecorderFor(controllerName),
+		RestMapper:      mgr.GetRESTMapper(),
+		InformerManager: informer.NewInformerManager(dynamicClient, 5*time.Minute, ctx.Done()),
+		ResourceConfig:  utils.NewResourceConfig(false),
 		SkippedNamespaces: map[string]bool{
 			"default": true,
 		},

--- a/pkg/resourcewatcher/change_dector.go
+++ b/pkg/resourcewatcher/change_dector.go
@@ -64,7 +64,7 @@ type ChangeDetector struct {
 	// InformerManager manages all the dynamic informers created by the discovery client
 	InformerManager informer.Manager
 
-	// ResourceConfig contains all the api resources that we won't select based on the allowed or skipped propagating apis option.
+	// ResourceConfig contains all the API resources that we won't select based on the allowed or skipped propagating APIs option.
 	ResourceConfig *utils.ResourceConfig
 
 	// SkippedNamespaces contains all the namespaces that we won't select

--- a/pkg/resourcewatcher/change_dector.go
+++ b/pkg/resourcewatcher/change_dector.go
@@ -186,6 +186,7 @@ func (d *ChangeDetector) discoverResources(dynamicResourceEventHandler cache.Res
 
 // gvrDisabled returns whether GroupVersionResource is disabled.
 func (d *ChangeDetector) shouldWatchResource(gvr schema.GroupVersionResource) bool {
+	// By default, all of the APIs are allowed.
 	if d.ResourceConfig == nil {
 		return true
 	}

--- a/pkg/resourcewatcher/change_dector.go
+++ b/pkg/resourcewatcher/change_dector.go
@@ -64,8 +64,8 @@ type ChangeDetector struct {
 	// InformerManager manages all the dynamic informers created by the discovery client
 	InformerManager informer.Manager
 
-	// DisabledResourceConfig contains all the api resources that we won't select
-	DisabledResourceConfig *utils.ResourceConfig
+	// ResourceConfig contains all the api resources that we won't select based on the allowed or skipped propagating apis option.
+	ResourceConfig *utils.ResourceConfig
 
 	// SkippedNamespaces contains all the namespaces that we won't select
 	SkippedNamespaces map[string]bool
@@ -186,7 +186,7 @@ func (d *ChangeDetector) discoverResources(dynamicResourceEventHandler cache.Res
 
 // gvrDisabled returns whether GroupVersionResource is disabled.
 func (d *ChangeDetector) shouldWatchResource(gvr schema.GroupVersionResource) bool {
-	if d.DisabledResourceConfig.IsEmpty() {
+	if d.ResourceConfig.IsEmpty() {
 		return true
 	}
 
@@ -196,7 +196,7 @@ func (d *ChangeDetector) shouldWatchResource(gvr schema.GroupVersionResource) bo
 		return false
 	}
 	for _, gvk := range gvks {
-		if d.DisabledResourceConfig.IsResourceDisabled(gvk) {
+		if d.ResourceConfig.IsResourceDisabled(gvk) {
 			klog.V(4).InfoS("Skip watch resource", "group version kind", gvk.String())
 			return false
 		}

--- a/pkg/resourcewatcher/change_dector.go
+++ b/pkg/resourcewatcher/change_dector.go
@@ -186,7 +186,7 @@ func (d *ChangeDetector) discoverResources(dynamicResourceEventHandler cache.Res
 
 // gvrDisabled returns whether GroupVersionResource is disabled.
 func (d *ChangeDetector) shouldWatchResource(gvr schema.GroupVersionResource) bool {
-	if d.ResourceConfig.IsEmpty() {
+	if d.ResourceConfig == nil {
 		return true
 	}
 

--- a/pkg/utils/apiresources.go
+++ b/pkg/utils/apiresources.go
@@ -58,7 +58,7 @@ type ResourceConfig struct {
 }
 
 // NewResourceConfig creates an empty ResourceConfig with an allow list flag.
-// If the resourceConfig is not an allowlist, it creates a default skipped propagation APIs list.
+// If the resourceConfig is not an allowlist, it creates a default skipped propagating APIs list.
 func NewResourceConfig(isAllowList bool) *ResourceConfig {
 	r := &ResourceConfig{
 		groups:            map[string]struct{}{},
@@ -171,7 +171,7 @@ func (r *ResourceConfig) parseSingle(token string) error {
 }
 
 // IsResourceDisabled returns whether a given GroupVersionKind is disabled.
-// A gkv is disabled if its group or group version is disabled.
+// A gvk is disabled if its group or group version is disabled.
 func (r *ResourceConfig) IsResourceDisabled(gvk schema.GroupVersionKind) bool {
 	isConfigured := r.isResourceConfigured(gvk)
 	if r.isAllowList {
@@ -198,17 +198,17 @@ func (r *ResourceConfig) isResourceConfigured(gvk schema.GroupVersionKind) bool 
 	return false
 }
 
-// AddGroup stores group in the resource config.
+// AddGroup stores a group in the resource config.
 func (r *ResourceConfig) AddGroup(g string) {
 	r.groups[g] = struct{}{}
 }
 
-// AddGroupVersion stores group version in the resource config.
+// AddGroupVersion stores a group version in the resource config.
 func (r *ResourceConfig) AddGroupVersion(gv schema.GroupVersion) {
 	r.groupVersions[gv] = struct{}{}
 }
 
-// AddGroupVersionKind stores GroupVersionKind in the resource config.
+// AddGroupVersionKind stores a GroupVersionKind in the resource config.
 func (r *ResourceConfig) AddGroupVersionKind(gvk schema.GroupVersionKind) {
 	r.groupVersionKinds[gvk] = struct{}{}
 }

--- a/pkg/utils/apiresources.go
+++ b/pkg/utils/apiresources.go
@@ -58,8 +58,7 @@ type ResourceConfig struct {
 }
 
 // NewResourceConfig creates an empty ResourceConfig with an allow list flag.
-// if the resourceConfig is not an allowlist, we add fleet related resources
-// and default built-in resources to the config.
+// If the resourceConfig is not an allowlist, it creates a default skipped propagation APIs list.
 func NewResourceConfig(isAllowList bool) *ResourceConfig {
 	r := &ResourceConfig{
 		groups:            map[string]struct{}{},
@@ -71,18 +70,18 @@ func NewResourceConfig(isAllowList bool) *ResourceConfig {
 		return r
 	}
 	// disable fleet related resource by default
-	r.DisableGroup(fleetv1alpha1.GroupVersion.Group)
-	r.DisableGroup(placementv1beta1.GroupVersion.Group)
-	r.DisableGroup(clusterv1beta1.GroupVersion.Group)
-	r.DisableGroupVersionKind(WorkGVK)
+	r.AddGroup(fleetv1alpha1.GroupVersion.Group)
+	r.AddGroup(placementv1beta1.GroupVersion.Group)
+	r.AddGroup(clusterv1beta1.GroupVersion.Group)
+	r.AddGroupVersionKind(WorkGVK)
 
 	// disable the below built-in resources
-	r.DisableGroup(eventsv1.GroupName)
-	r.DisableGroup(coordv1.GroupName)
-	r.DisableGroup(metricsV1beta1.GroupName)
-	r.DisableGroupVersionKind(corev1PodGVK)
-	r.DisableGroupVersionKind(corev1NodeGVK)
-	r.DisableGroupVersionKind(serviceImportGVK)
+	r.AddGroup(eventsv1.GroupName)
+	r.AddGroup(coordv1.GroupName)
+	r.AddGroup(metricsV1beta1.GroupName)
+	r.AddGroupVersionKind(corev1PodGVK)
+	r.AddGroupVersionKind(corev1NodeGVK)
+	r.AddGroupVersionKind(serviceImportGVK)
 	return r
 }
 
@@ -172,7 +171,7 @@ func (r *ResourceConfig) parseSingle(token string) error {
 }
 
 // IsResourceDisabled returns whether a given GroupVersionKind is disabled.
-// a gkv is disabled if its group or group version is disabled
+// A gkv is disabled if its group or group version is disabled.
 func (r *ResourceConfig) IsResourceDisabled(gvk schema.GroupVersionKind) bool {
 	isConfigured := r.isResourceConfigured(gvk)
 	if r.isAllowList {
@@ -182,7 +181,7 @@ func (r *ResourceConfig) IsResourceDisabled(gvk schema.GroupVersionKind) bool {
 }
 
 // isResourceConfigured returns whether a given GroupVersionKind is found in the ResourceConfig.
-// a gvk is configured if its group or group version is configured
+// A gvk is configured if its group or group version is configured.
 func (r *ResourceConfig) isResourceConfigured(gvk schema.GroupVersionKind) bool {
 	if _, ok := r.groups[gvk.Group]; ok {
 		return true
@@ -199,18 +198,18 @@ func (r *ResourceConfig) isResourceConfigured(gvk schema.GroupVersionKind) bool 
 	return false
 }
 
-// DisableGroup to disable group.
-func (r *ResourceConfig) DisableGroup(g string) {
+// AddGroup to store group in the resource config.
+func (r *ResourceConfig) AddGroup(g string) {
 	r.groups[g] = struct{}{}
 }
 
-// DisableGroupVersion to disable group version.
-func (r *ResourceConfig) DisableGroupVersion(gv schema.GroupVersion) {
+// AddGroupVersion to store group version in the resource config.
+func (r *ResourceConfig) AddGroupVersion(gv schema.GroupVersion) {
 	r.groupVersions[gv] = struct{}{}
 }
 
-// DisableGroupVersionKind to disable GroupVersionKind.
-func (r *ResourceConfig) DisableGroupVersionKind(gvk schema.GroupVersionKind) {
+// AddGroupVersionKind to store GroupVersionKind in the resource config.
+func (r *ResourceConfig) AddGroupVersionKind(gvk schema.GroupVersionKind) {
 	r.groupVersionKinds[gvk] = struct{}{}
 }
 

--- a/pkg/utils/apiresources.go
+++ b/pkg/utils/apiresources.go
@@ -198,22 +198,17 @@ func (r *ResourceConfig) isResourceConfigured(gvk schema.GroupVersionKind) bool 
 	return false
 }
 
-// AddGroup to store group in the resource config.
+// AddGroup stores group in the resource config.
 func (r *ResourceConfig) AddGroup(g string) {
 	r.groups[g] = struct{}{}
 }
 
-// AddGroupVersion to store group version in the resource config.
+// AddGroupVersion stores group version in the resource config.
 func (r *ResourceConfig) AddGroupVersion(gv schema.GroupVersion) {
 	r.groupVersions[gv] = struct{}{}
 }
 
-// AddGroupVersionKind to store GroupVersionKind in the resource config.
+// AddGroupVersionKind stores GroupVersionKind in the resource config.
 func (r *ResourceConfig) AddGroupVersionKind(gvk schema.GroupVersionKind) {
 	r.groupVersionKinds[gvk] = struct{}{}
-}
-
-// IsEmpty returns whether the ResourceConfig is empty.
-func (r *ResourceConfig) IsEmpty() bool {
-	return len(r.groups) == 0 && len(r.groupVersions) == 0 && len(r.groupVersionKinds) == 0
 }

--- a/pkg/utils/apiresources_test.go
+++ b/pkg/utils/apiresources_test.go
@@ -228,7 +228,7 @@ func TestResourceConfigGroupParse(t *testing.T) {
 	}
 }
 
-func TestDisabledResourceConfigMixedParse(t *testing.T) {
+func TestResourceConfigMixedParse(t *testing.T) {
 	tests := []struct {
 		input    string
 		disabled []schema.GroupVersionKind
@@ -309,7 +309,7 @@ func TestDisabledResourceConfigMixedParse(t *testing.T) {
 		// test allow list
 		r := NewResourceConfig(true)
 		if err := r.Parse(test.input); err != nil {
-			t.Fatalf("Unexpected error: %v", err)
+			t.Fatalf("Parse() returned error: %v", err)
 		}
 		// Since we are testing allow list, the result is reversed
 		for i, o := range test.disabled {

--- a/pkg/utils/apiresources_test.go
+++ b/pkg/utils/apiresources_test.go
@@ -76,13 +76,13 @@ func TestResourceConfigGVKParse(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -145,13 +145,13 @@ func TestResourceConfigGVParse(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -214,13 +214,13 @@ func TestResourceConfigGroupParse(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -228,7 +228,7 @@ func TestResourceConfigGroupParse(t *testing.T) {
 	}
 }
 
-func TestResourceConfigMixedParse(t *testing.T) {
+func TestDisabledResourceConfigMixedParse(t *testing.T) {
 	tests := []struct {
 		input    string
 		disabled []schema.GroupVersionKind
@@ -293,13 +293,13 @@ func TestResourceConfigMixedParse(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -351,18 +351,18 @@ func TestDefaultDisabledResourceConfigGroupVersionKindParse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r := NewResourceConfig(true)
+		r := NewResourceConfig(false)
 		if err := r.Parse(""); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceConfigured(o)
+			ok := r.IsResourceDisabled(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -385,7 +385,7 @@ func TestResourceConfigIsEmpty(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r := NewResourceConfig(false)
+		r := NewResourceConfig(true)
 		if err := r.Parse(test.input); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/pkg/utils/apiresources_test.go
+++ b/pkg/utils/apiresources_test.go
@@ -305,6 +305,24 @@ func TestDisabledResourceConfigMixedParse(t *testing.T) {
 			}
 		}
 	}
+	for _, test := range tests {
+		// test allow list
+		r := NewResourceConfig(true)
+		if err := r.Parse(test.input); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		// Since we are testing allow list, the result is reversed
+		for i, o := range test.disabled {
+			if ok := r.IsResourceDisabled(o); ok {
+				t.Errorf("%d: expected resource to be enabled : %v", i, o)
+			}
+		}
+		for i, o := range test.enabled {
+			if ok := r.IsResourceDisabled(o); !ok {
+				t.Errorf("%d: expected resource to be disabled : %v", i, o)
+			}
+		}
+	}
 }
 
 func TestDefaultDisabledResourceConfigGroupVersionKindParse(t *testing.T) {

--- a/pkg/utils/apiresources_test.go
+++ b/pkg/utils/apiresources_test.go
@@ -323,7 +323,6 @@ func TestResourceConfigMixedParse(t *testing.T) {
 }
 
 func TestDefaultResourceConfigGroupVersionKindParse(t *testing.T) {
-
 	resourcesInDefaultDisabledList := []schema.GroupVersionKind{
 		corev1PodGVK, corev1NodeGVK,
 		{

--- a/pkg/utils/apiresources_test.go
+++ b/pkg/utils/apiresources_test.go
@@ -351,7 +351,7 @@ func TestDefaultDisabledResourceConfigGroupVersionKindParse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r := NewResourceConfig(false)
+		r := NewResourceConfig(true)
 		if err := r.Parse(""); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}

--- a/pkg/utils/apiresources_test.go
+++ b/pkg/utils/apiresources_test.go
@@ -229,162 +229,172 @@ func TestResourceConfigGroupParse(t *testing.T) {
 }
 
 func TestResourceConfigMixedParse(t *testing.T) {
-	tests := []struct {
-		input    string
-		disabled []schema.GroupVersionKind
-		enabled  []schema.GroupVersionKind
-	}{
+	input := "v1/Node,Pod;networking.k8s.io;apps/v1;authorization.k8s.io/v1/SelfSubjectRulesReview"
+
+	// these are the resources that are in the scope of the user specified input
+	resourcesInUserInput := []schema.GroupVersionKind{
 		{
-			input: "v1/Node,Pod;networking.k8s.io;apps/v1;authorization.k8s.io/v1/SelfSubjectRulesReview",
-			disabled: []schema.GroupVersionKind{
-				{
-					Group:   "networking.k8s.io",
-					Version: "v1beta1",
-					Kind:    "Ingress",
-				},
-				{
-					Group:   "networking.k8s.io",
-					Version: "v1",
-					Kind:    "IngressClass",
-				},
-				{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Node",
-				},
-				{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Pod",
-				},
-				{
-					Group:   "authorization.k8s.io",
-					Version: "v1",
-					Kind:    "SelfSubjectRulesReview",
-				},
-				{
-					Group:   "apps",
-					Version: "v1",
-					Kind:    "HealthState",
-				},
-			},
-			enabled: []schema.GroupVersionKind{
-				{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Ingress",
-				},
-				{
-					Group:   "apps",
-					Version: "v1beta1",
-					Kind:    "IngressClass",
-				},
-				{
-					Group:   "authorization.k8s.io",
-					Version: "v1",
-					Kind:    "LocalSubjectAccessReview",
-				},
-			},
+			Group:   "networking.k8s.io",
+			Version: "v1beta1",
+			Kind:    "Ingress",
+		},
+		{
+			Group:   "networking.k8s.io",
+			Version: "v1",
+			Kind:    "IngressClass",
+		},
+		{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Node",
+		},
+		{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Pod",
+		},
+		{
+			Group:   "authorization.k8s.io",
+			Version: "v1",
+			Kind:    "SelfSubjectRulesReview",
+		},
+		{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "HealthState",
 		},
 	}
-	for _, test := range tests {
-		r := NewResourceConfig(false)
-		if err := r.Parse(test.input); err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		for i, o := range test.disabled {
-			ok := r.IsResourceDisabled(o)
-			if !ok {
-				t.Errorf("%d: unexpected error: %v", i, o)
-			}
-		}
-		for i, o := range test.enabled {
-			ok := r.IsResourceDisabled(o)
-			if ok {
-				t.Errorf("%d: unexpected error: %v", i, o)
-			}
-		}
+
+	// these are the resources that are not in the scope of the user specified input
+	resourcesNotInUserInput := []schema.GroupVersionKind{
+		{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Ingress",
+		},
+		{
+			Group:   "apps",
+			Version: "v1beta1",
+			Kind:    "IngressClass",
+		},
+		{
+			Group:   "authorization.k8s.io",
+			Version: "v1",
+			Kind:    "LocalSubjectAccessReview",
+		},
 	}
-	for _, test := range tests {
-		// test allow list
-		r := NewResourceConfig(true)
-		if err := r.Parse(test.input); err != nil {
-			t.Fatalf("Parse() returned error: %v", err)
-		}
-		// Since we are testing allow list, the result is reversed
-		for i, o := range test.disabled {
-			if ok := r.IsResourceDisabled(o); ok {
-				t.Errorf("%d: expected resource to be enabled : %v", i, o)
+
+	tests := map[string]struct {
+		isAllowList bool
+		disabled    []schema.GroupVersionKind
+		enabled     []schema.GroupVersionKind
+	}{
+		"disabled list": {
+			isAllowList: false,
+			disabled:    resourcesInUserInput,
+			enabled:     resourcesNotInUserInput,
+		},
+		"enabled list": {
+			isAllowList: true,
+			disabled:    resourcesNotInUserInput,
+			enabled:     resourcesInUserInput,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := NewResourceConfig(test.isAllowList)
+			if err := r.Parse(input); err != nil {
+				t.Fatalf("Parse() returned error: %v", err)
 			}
-		}
-		for i, o := range test.enabled {
-			if ok := r.IsResourceDisabled(o); !ok {
-				t.Errorf("%d: expected resource to be disabled : %v", i, o)
+
+			for i, o := range test.disabled {
+				if ok := r.IsResourceDisabled(o); !ok {
+					t.Errorf("%d: expected resource to be disabled : %v", i, o)
+				}
 			}
-		}
+
+			for i, o := range test.enabled {
+				if ok := r.IsResourceDisabled(o); ok {
+					t.Errorf("%d: expected resource to be enabled : %v", i, o)
+				}
+			}
+		})
 	}
 }
 
-func TestDefaultDisabledResourceConfigGroupVersionKindParse(t *testing.T) {
-	tests := []struct {
-		disabled []schema.GroupVersionKind
-		enabled  []schema.GroupVersionKind
-	}{
+func TestDefaultResourceConfigGroupVersionKindParse(t *testing.T) {
+
+	resourcesInDefaultDisabledList := []schema.GroupVersionKind{
+		corev1PodGVK, corev1NodeGVK,
 		{
-			disabled: []schema.GroupVersionKind{
-				corev1PodGVK, corev1NodeGVK,
-				{
-					Group:   "fleet.azure.com",
-					Version: "v1beta1",
-					Kind:    "MemberCluster",
-				},
-				{
-					Group:   "fleet.azure.com",
-					Version: "v1alpha1",
-					Kind:    "MemberCluster",
-				},
-				{
-					Group:   "events.k8s.io",
-					Version: "v1beta1",
-					Kind:    "Event",
-				},
-			},
-			enabled: []schema.GroupVersionKind{
-				{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Namespace",
-				},
-				{
-					Group:   "apps",
-					Version: "v1",
-					Kind:    "Deployment",
-				},
-				{
-					Group:   "",
-					Version: "v1",
-					Kind:    "Event",
-				},
-			},
+			Group:   "fleet.azure.com",
+			Version: "v1beta1",
+			Kind:    "MemberCluster",
+		},
+		{
+			Group:   "fleet.azure.com",
+			Version: "v1alpha1",
+			Kind:    "MemberCluster",
+		},
+		{
+			Group:   "events.k8s.io",
+			Version: "v1beta1",
+			Kind:    "Event",
 		},
 	}
-	for _, test := range tests {
-		r := NewResourceConfig(false)
-		if err := r.Parse(""); err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-		for i, o := range test.disabled {
-			ok := r.IsResourceDisabled(o)
-			if !ok {
-				t.Errorf("%d: unexpected error: %v", i, o)
+
+	resourcesNotInDefaultResourcesList := []schema.GroupVersionKind{
+		{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Namespace",
+		},
+		{
+			Group:   "apps",
+			Version: "v1",
+			Kind:    "Deployment",
+		},
+		{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Event",
+		},
+	}
+
+	tests := map[string]struct {
+		isAllowList bool
+		disabled    []schema.GroupVersionKind
+		enabled     []schema.GroupVersionKind
+	}{
+		"default disabled list": {
+			isAllowList: false,
+			disabled:    resourcesInDefaultDisabledList,
+			enabled:     resourcesNotInDefaultResourcesList,
+		},
+		"default enabled list": {
+			isAllowList: true,
+			disabled:    append(resourcesNotInDefaultResourcesList, resourcesInDefaultDisabledList...),
+			enabled:     []schema.GroupVersionKind{},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := NewResourceConfig(test.isAllowList)
+			if err := r.Parse(""); err != nil {
+				t.Fatalf("Parse() returned error: %v", err)
 			}
-		}
-		for i, o := range test.enabled {
-			ok := r.IsResourceDisabled(o)
-			if ok {
-				t.Errorf("%d: unexpected error: %v", i, o)
+			for i, o := range test.disabled {
+				if ok := r.IsResourceDisabled(o); !ok {
+					t.Errorf("%d: expected resource to be disabled : %v", i, o)
+				}
 			}
-		}
+
+			for i, o := range test.enabled {
+				if ok := r.IsResourceDisabled(o); ok {
+					t.Errorf("%d: expected resource to be enabled : %v", i, o)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/utils/apiresources_test.go
+++ b/pkg/utils/apiresources_test.go
@@ -71,18 +71,18 @@ func TestResourceConfigGVKParse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r := NewDisabledResourceConfig()
+		r := NewResourceConfig(false)
 		if err := r.Parse(test.input); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -140,18 +140,18 @@ func TestResourceConfigGVParse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r := NewDisabledResourceConfig()
+		r := NewResourceConfig(false)
 		if err := r.Parse(test.input); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -209,18 +209,18 @@ func TestResourceConfigGroupParse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r := NewDisabledResourceConfig()
+		r := NewResourceConfig(false)
 		if err := r.Parse(test.input); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -228,7 +228,7 @@ func TestResourceConfigGroupParse(t *testing.T) {
 	}
 }
 
-func TestDisabledResourceConfigMixedParse(t *testing.T) {
+func TestResourceConfigMixedParse(t *testing.T) {
 	tests := []struct {
 		input    string
 		disabled []schema.GroupVersionKind
@@ -288,18 +288,18 @@ func TestDisabledResourceConfigMixedParse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r := NewDisabledResourceConfig()
+		r := NewResourceConfig(false)
 		if err := r.Parse(test.input); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
@@ -351,21 +351,46 @@ func TestDefaultDisabledResourceConfigGroupVersionKindParse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		r := NewDisabledResourceConfig()
+		r := NewResourceConfig(false)
 		if err := r.Parse(""); err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		for i, o := range test.disabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if !ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
 		}
 		for i, o := range test.enabled {
-			ok := r.IsResourceDisabled(o)
+			ok := r.IsResourceConfigured(o)
 			if ok {
 				t.Errorf("%d: unexpected error: %v", i, o)
 			}
+		}
+	}
+}
+
+func TestResourceConfigIsEmpty(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{
+			input: "",
+			want:  true,
+		},
+		{
+			input: "v1/Node,Pod;networking.k8s.io;apps/v1;authorization.k8s.io/v1/SelfSubjectRulesReview",
+			want:  false,
+		},
+	}
+	for _, test := range tests {
+		r := NewResourceConfig(false)
+		if err := r.Parse(test.input); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if got := r.IsEmpty(); got != test.want {
+			t.Errorf("Unexpected result: %v", got)
 		}
 	}
 }


### PR DESCRIPTION
### Changes

- Add `--allowed-propagating-apis` option to hub-agent command.
- Validate that `--allowed-propagating-apis` and `--skipped-propagating-apis` are mutually exclusive and cannot be specified together.
- Refactor `DisabledResourceConfig` type into a generic `ResourceConfig` so that we can reuse it for both `Allowed` and `Disabled` resource configs. During initializing `DisabledResourceConfig`, fleet and built-in resources are configured.
- Update `change_detector` to watch only the allowed resources if specified.
- Update `resource_selector` to only select allowed resources if specified.
- Add a util function with unit test to determine if a ResourceConfig is empty

#### Other changes
- Add make `help` recipe for developers to list the available commands in the Makefile.

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #633":

-->

Fixes #633 

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

Verify that the options are mutually exclusive.
```
E1213 17:04:40.247238   91214 main.go:79] "invalid parameter" err="Options.AllowedPropagatingAPIs: Invalid value: \"policy/v1\": AllowedPropagatingAPIs and SkippedPropagatingAPIs are mutually exclusive"
exit status 1
```

Run hub-agent locally, its able to start with the right option value for `--allowed-propagating-apis`
```
❯ export POD_NAMESPACE=fleet-system
❯ go run ./cmd/hubagent/main.go --enable-v1alpha1-apis=false --enable-v1beta1-apis=true --allowed-propagating-apis=rbac.authorization.k8s.io/v1 --v=1
I1214 09:19:00.292904   85484 main.go:76] "flag:" name="add_dir_header" value="false"
I1214 09:19:00.293211   85484 main.go:76] "flag:" name="allowed-propagating-apis" value="rbac.authorization.k8s.io/v1"
```

<details>
<summary>Verify that the Allowed resources are being watched and informer is created</summary>

```
I1214 09:19:11.823118   85484 change_dector.go:205] "Watching Allowed Resource" GVK="rbac.authorization.k8s.io/v1, Kind=ClusterRole"
I1214 09:19:11.823254   85484 change_dector.go:205] "Watching Allowed Resource" GVK="rbac.authorization.k8s.io/v1, Kind=Role"
I1214 09:19:11.823345   85484 change_dector.go:205] "Watching Allowed Resource" GVK="rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding"
I1214 09:19:11.823394   85484 change_dector.go:205] "Watching Allowed Resource" GVK="rbac.authorization.k8s.io/v1, Kind=RoleBinding"
I1214 09:19:11.826453   85484 informermanager.go:123] "Added an informer for a new resource" res={"GroupVersionKind":{"Group":"rbac.authorization.k8s.io","Version":"v1","Kind":"ClusterRole"},"GroupVersionResource":{"Group":"rbac.authorization.k8s.io","Version":"v1","Resource":"clusterroles"},"IsClusterScoped":true}
I1214 09:19:11.826502   85484 informermanager.go:123] "Added an informer for a new resource" res={"GroupVersionKind":{"Group":"rbac.authorization.k8s.io","Version":"v1","Kind":"Role"},"GroupVersionResource":{"Group":"rbac.authorization.k8s.io","Version":"v1","Resource":"roles"},"IsClusterScoped":false}
I1214 09:19:11.826519   85484 informermanager.go:123] "Added an informer for a new resource" res={"GroupVersionKind":{"Group":"rbac.authorization.k8s.io","Version":"v1","Kind":"ClusterRoleBinding"},"GroupVersionResource":{"Group":"rbac.authorization.k8s.io","Version":"v1","Resource":"clusterrolebindings"},"IsClusterScoped":true}
I1214 09:19:11.826536   85484 informermanager.go:123] "Added an informer for a new resource" res={"GroupVersionKind":{"Group":"rbac.authorization.k8s.io","Version":"v1","Kind":"RoleBinding"},"GroupVersionResource":{"Group":"rbac.authorization.k8s.io","Version":"v1","Resource":"rolebindings"},"IsClusterScoped":false}
```

</details>

<details>
<summary>It selects the correct resources</summary>

```
    - lastTransitionTime: "2023-12-14T03:54:43Z"
      message: Successfully applied resources
      observedGeneration: 1
      reason: ApplySucceeded
      status: "True"
      type: ResourceApplied
  selectedResources:
  - group: rbac.authorization.k8s.io
    kind: Role
    name: vbongale-test-lease-role
    namespace: vbongale-test-ns
    version: v1
  - kind: Namespace
    name: vbongale-test-ns
    version: v1
```

</details>

```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestResourceConfigIsEmpty$ go.goms.io/fleet/pkg/utils
ok  	go.goms.io/fleet/pkg/utils
```

<details>
<summary>$ make help</summary>

```

❯ make help

Usage:
  make <target>
  help             Display this help.
  lint-full        Run slower linters to detect possible issues
  fmt              Run go fmt against code.
  vet              Run go vet against code.
  test             Run tests.
  local-unit-test  Run tests.
  integration-test  Run tests.
  build            Build agent binaries.
  run-hubagent     Run a controllers from your host.
  run-memberagent  Run a controllers from your host.
  clean-bin        Remove all generated binaries
```

</details>

