### PR TITLE
fix: fleet guard rail allows member agent to CREATE/UPDATE/DELETE

### DIFF
--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -68,8 +68,8 @@ func (v *fleetResourceValidator) Handle(ctx context.Context, req admission.Reque
 		case req.Kind == validation.NamespaceGVK:
 			klog.V(2).InfoS("handling namespace resource", "name", req.Name, "operation", req.Operation, "subResource", req.SubResource)
 			response = v.handleNamespace(req)
-		case req.Kind == validation.V1Alpha1IMCGVK || req.Kind == validation.V1Alpha1WorkGVK || req.Kind == validation.IMCGVK || req.Kind == validation.WorkGVK || req.Kind == validation.EndpointSliceExportGVK || req.Kind == validation.EndpointSliceImportGVK || req.Kind == validation.InternalServiceExportGVK || req.Kind == validation.InternalServiceImportGVK:
-			klog.V(2).InfoS("handling internal fleet owned/created namespaced resource in fleet reserved namespaces", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
+		case req.Kind == validation.V1Alpha1IMCGVK || req.Kind == validation.V1Alpha1WorkGVK || req.Kind == validation.IMCGVK || req.Kind == validation.WorkGVK || req.Kind == validation.EndpointSliceExportGVK || req.Kind == validation.EndpointSliceImportGVK || req.Kind == validation.InternalServiceExportGVK || req.Kind == validation.InternalServiceImportGVK || req.Kind == validation.EndpointSliceGVK:
+			klog.V(2).InfoS("handling fleet owned namespaced resource in fleet reserved namespaces", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
 			response = v.handleFleetReservedNamespacedResource(ctx, req)
 		case req.Kind == validation.EventGVK:
 			klog.V(3).InfoS("handling event resource", "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -46,6 +46,7 @@ type fleetResourceValidator struct {
 }
 
 // Handle receives the request then allows/denies the request to modify fleet resources.
+// TODO: enpointSlice in discovery/v1 is being created in fleet-system namespace.
 func (v *fleetResourceValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	// special case for Kind:Namespace resources req.Name and req.Namespace has the same value the ObjectMeta.Name of Namespace.
 	if req.Kind.Kind == "Namespace" {

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -141,7 +141,7 @@ func (v *fleetResourceValidator) handleFleetReservedNamespacedResource(ctx conte
 			return validation.ValidateMCIdentity(ctx, v.client, req, mcName, v.isFleetV1Beta1API)
 		}
 		return response
-	} else if strings.HasPrefix(req.Name, fleetNamespacePrefix) || strings.HasPrefix(req.Name, kubeNamespacePrefix) {
+	} else if strings.HasPrefix(req.Namespace, fleetNamespacePrefix) || strings.HasPrefix(req.Namespace, kubeNamespacePrefix) {
 		return validation.ValidateUserForResource(req, v.whiteListedUsers)
 	}
 	klog.V(3).InfoS("namespace name doesn't begin with fleet/kube prefix so we allow all operations on these namespaces",

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -46,7 +46,6 @@ type fleetResourceValidator struct {
 }
 
 // Handle receives the request then allows/denies the request to modify fleet resources.
-// TODO: enpointSlice in discovery/v1 is being created in fleet-system namespace.
 func (v *fleetResourceValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	// special case for Kind:Namespace resources req.Name and req.Namespace has the same value the ObjectMeta.Name of Namespace.
 	if req.Kind.Kind == "Namespace" {

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -134,7 +134,7 @@ func (v *fleetResourceValidator) handleFleetMemberNamespacedResource(ctx context
 		// check to see if valid users other than member agent is making the request.
 		response = validation.ValidateUserForResource(req, v.whiteListedUsers)
 		// check to see if member agent is making the request only on Update.
-		if !response.Allowed && req.Operation == admissionv1.Update {
+		if !response.Allowed {
 			// if namespace name is just "fleet-member", mcName variable becomes empty and the request is allowed since that namespaces is not watched by member agents.
 			mcName := parseMemberClusterNameFromNamespace(req.Namespace)
 			return validation.ValidateMCIdentity(ctx, v.client, req, mcName, v.isFleetV1Beta1API)

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -75,7 +75,7 @@ func (v *fleetResourceValidator) Handle(ctx context.Context, req admission.Reque
 			klog.V(3).InfoS("handling event resource", "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
 			response = v.handleEvent(ctx, req)
 		case req.Namespace != "":
-			klog.V(2).InfoS("handling namespaced resource created in fleet reserved namespaces", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
+			klog.V(2).InfoS("handling namespaced resource in fleet reserved namespaces", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
 			response = validation.ValidateUserForResource(req, v.whiteListedUsers)
 		default:
 			klog.V(3).InfoS("resource is not monitored by fleet resource validator webhook", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -75,7 +75,7 @@ func (v *fleetResourceValidator) Handle(ctx context.Context, req admission.Reque
 			klog.V(3).InfoS("handling event resource", "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
 			response = v.handleEvent(ctx, req)
 		case req.Namespace != "":
-			klog.V(2).InfoS("handling namespaced resource created in user namespaces", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
+			klog.V(2).InfoS("handling namespaced resource created in fleet/kube pre-fixed namespaces", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
 			response = validation.ValidateUserForResource(req, v.whiteListedUsers)
 		default:
 			klog.V(3).InfoS("resource is not monitored by fleet resource validator webhook", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -67,7 +67,7 @@ func (v *fleetResourceValidator) Handle(ctx context.Context, req admission.Reque
 		case req.Kind == validation.NamespaceGVK:
 			klog.V(2).InfoS("handling namespace resource", "name", req.Name, "operation", req.Operation, "subResource", req.SubResource)
 			response = v.handleNamespace(req)
-		case req.Kind == validation.V1Alpha1IMCGVK || req.Kind == validation.V1Alpha1WorkGVK || req.Kind == validation.IMCGVK || req.Kind == validation.WorkGVK || req.Kind == validation.EndpointSliceExportGVK || req.Kind == validation.EndpointSliceImportGVK || req.Kind == validation.InternalServiceExportGVK || req.Kind == validation.InternalServiceImportGVK || req.Kind == validation.EndpointSliceGVK:
+		case req.Kind == validation.V1Alpha1IMCGVK || req.Kind == validation.V1Alpha1WorkGVK || req.Kind == validation.IMCGVK || req.Kind == validation.WorkGVK || req.Kind == validation.EndpointSliceExportGVK || req.Kind == validation.EndpointSliceImportGVK || req.Kind == validation.InternalServiceExportGVK || req.Kind == validation.InternalServiceImportGVK:
 			klog.V(2).InfoS("handling fleet owned namespaced resource in fleet reserved namespaces", "GVK", req.RequestKind, "namespacedName", namespacedName, "operation", req.Operation, "subResource", req.SubResource)
 			response = v.handleFleetReservedNamespacedResource(ctx, req)
 		case req.Kind == validation.EventGVK:

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
@@ -972,25 +972,6 @@ func TestHandleFleetReservedNamespacedResource(t *testing.T) {
 			},
 			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "testUser", utils.GenerateGroupString([]string{"testGroup"}), admissionv1.Create, &validation.EndpointSliceExportGVK, "", types.NamespacedName{Name: "test-net-eps", Namespace: "fleet-system"})),
 		},
-		"allow request to delete in kube-system if user is validated user with discovery/v1 endPointSlice": {
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Name:        "test-eps",
-					Namespace:   "kube-system",
-					RequestKind: &validation.EndpointSliceGVK,
-					UserInfo: authenticationv1.UserInfo{
-						Username: "testUser",
-						Groups:   []string{"system:masters"},
-					},
-					Operation: admissionv1.Delete,
-				},
-			},
-			resourceValidator: fleetResourceValidator{
-				client:            mockClient,
-				isFleetV1Beta1API: true,
-			},
-			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "testUser", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Delete, &validation.EndpointSliceGVK, "", types.NamespacedName{Name: "test-eps", Namespace: "kube-system"})),
-		},
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
@@ -679,7 +679,7 @@ func TestHandleMemberCluster(t *testing.T) {
 	}
 }
 
-func TestHandleFleetMemberNamespacedResource(t *testing.T) {
+func TestHandleFleetReservedNamespacedResource(t *testing.T) {
 	v1Alpha1MockClient := &test.MockClient{
 		MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 			if key.Name == mcName {
@@ -736,7 +736,7 @@ func TestHandleFleetMemberNamespacedResource(t *testing.T) {
 					Operation: admissionv1.Create,
 				},
 			},
-			wantResponse: admission.Allowed("namespace name doesn't begin with fleet-member prefix so we allow all operations on these namespaces for the request object"),
+			wantResponse: admission.Allowed("namespace name doesn't begin with fleet/kube prefix so we allow all operations on these namespaces for the request object"),
 		},
 		"allow user in system:masters group with update in fleet member cluster namespace with v1alpha1 Work": {
 			req: admission.Request{
@@ -956,7 +956,7 @@ func TestHandleFleetMemberNamespacedResource(t *testing.T) {
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			gotResult := testCase.resourceValidator.handleFleetMemberNamespacedResource(context.Background(), testCase.req)
+			gotResult := testCase.resourceValidator.handleFleetReservedNamespacedResource(context.Background(), testCase.req)
 			assert.Equal(t, testCase.wantResponse, gotResult, utils.TestCaseMsg, testName)
 		})
 	}

--- a/pkg/webhook/validation/uservalidation.go
+++ b/pkg/webhook/validation/uservalidation.go
@@ -9,7 +9,6 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -57,7 +56,6 @@ var (
 	EndpointSliceImportGVK   = metav1.GroupVersionKind{Group: fleetnetworkingv1alpha1.GroupVersion.Group, Version: fleetnetworkingv1alpha1.GroupVersion.Version, Kind: "EndpointSliceImport"}
 	InternalServiceExportGVK = metav1.GroupVersionKind{Group: fleetnetworkingv1alpha1.GroupVersion.Group, Version: fleetnetworkingv1alpha1.GroupVersion.Version, Kind: "InternalServiceExport"}
 	InternalServiceImportGVK = metav1.GroupVersionKind{Group: fleetnetworkingv1alpha1.GroupVersion.Group, Version: fleetnetworkingv1alpha1.GroupVersion.Version, Kind: "InternalServiceImport"}
-	EndpointSliceGVK         = metav1.GroupVersionKind{Group: discoveryv1.SchemeGroupVersion.Group, Version: discoveryv1.SchemeGroupVersion.Version, Kind: "EndpointSlice"}
 )
 
 // ValidateUserForFleetCRD checks to see if user is not allowed to modify fleet CRDs.

--- a/pkg/webhook/validation/uservalidation.go
+++ b/pkg/webhook/validation/uservalidation.go
@@ -9,6 +9,7 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,6 +57,7 @@ var (
 	EndpointSliceImportGVK   = metav1.GroupVersionKind{Group: fleetnetworkingv1alpha1.GroupVersion.Group, Version: fleetnetworkingv1alpha1.GroupVersion.Version, Kind: "EndpointSliceImport"}
 	InternalServiceExportGVK = metav1.GroupVersionKind{Group: fleetnetworkingv1alpha1.GroupVersion.Group, Version: fleetnetworkingv1alpha1.GroupVersion.Version, Kind: "InternalServiceExport"}
 	InternalServiceImportGVK = metav1.GroupVersionKind{Group: fleetnetworkingv1alpha1.GroupVersion.Group, Version: fleetnetworkingv1alpha1.GroupVersion.Version, Kind: "InternalServiceImport"}
+	EndpointSliceGVK         = metav1.GroupVersionKind{Group: discoveryv1.SchemeGroupVersion.Group, Version: discoveryv1.SchemeGroupVersion.Version, Kind: "EndpointSlice"}
 )
 
 // ValidateUserForFleetCRD checks to see if user is not allowed to modify fleet CRDs.

--- a/pkg/webhook/validation/uservalidation.go
+++ b/pkg/webhook/validation/uservalidation.go
@@ -36,10 +36,9 @@ const (
 	allowedModifyResource = "user in groups is allowed to modify resource"
 	deniedModifyResource  = "user in groups is not allowed to modify resource"
 
-	ResourceAllowedFormat            = "user: '%s' in '%s' is allowed to %s resource %+v/%s: %+v"
-	ResourceDeniedFormat             = "user: '%s' in '%s' is not allowed to %s resource %+v/%s: %+v"
-	ResourceAllowedGetMCFailed       = "user: '%s' in '%s' is allowed to %s resource %+v/%s: %+v because we failed to get MC"
-	ResourceAllowedGetFleetAPIFailed = "user: '%s' in groups: '%s' is allowed to %s resource %+v/%s: %+v because we failed to get current Fleet API version"
+	ResourceAllowedFormat      = "user: '%s' in '%s' is allowed to %s resource %+v/%s: %+v"
+	ResourceDeniedFormat       = "user: '%s' in '%s' is not allowed to %s resource %+v/%s: %+v"
+	ResourceAllowedGetMCFailed = "user: '%s' in '%s' is allowed to %s resource %+v/%s: %+v because we failed to get MC"
 )
 
 var (

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -332,7 +332,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 	}
 	// we don't monitor lease to prevent the deadlock issue, we also don't monitor events.
 	namespacedResourcesRules := []admv1.RuleWithOperations{
-		// we want to monitor delete operations on all namespaced resources.
+		// we want to monitor delete operations on all fleet/kube pre-fixed namespaced resources.
 		{
 			Operations: []admv1.OperationType{admv1.Delete},
 			Rule:       createRule([]string{"*"}, []string{"*"}, []string{"*/*"}, &namespacedScope),

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -15,7 +15,6 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -42,7 +41,6 @@ var (
 	imcGVK     = metav1.GroupVersionKind{Group: clusterv1beta1.GroupVersion.Group, Version: clusterv1beta1.GroupVersion.Version, Kind: "InternalMemberCluster"}
 	workGVK    = metav1.GroupVersionKind{Group: placementv1beta1.GroupVersion.Group, Version: placementv1beta1.GroupVersion.Version, Kind: "Work"}
 	iseGVK     = metav1.GroupVersionKind{Group: fleetnetworkingv1alpha1.GroupVersion.Group, Version: fleetnetworkingv1alpha1.GroupVersion.Version, Kind: "InternalServiceExport"}
-	esGVK      = metav1.GroupVersionKind{Group: discoveryv1.SchemeGroupVersion.Group, Version: discoveryv1.SchemeGroupVersion.Version, Kind: "EndpointSlice"}
 	testGroups = []string{"system:authenticated"}
 )
 
@@ -503,7 +501,6 @@ var _ = Describe("fleet guard rail networking E2Es", Serial, Ordered, func() {
 		iseName := fmt.Sprintf(internalServiceExportNameTemplate, GinkgoParallelProcess())
 		isiName := fmt.Sprintf(internalServiceImportNameTemplate, GinkgoParallelProcess())
 		epName := fmt.Sprintf(endpointSliceExportNameTemplate, GinkgoParallelProcess())
-		esName := fmt.Sprintf(endpointSliceNameTemplate, GinkgoParallelProcess())
 		imcNamespace := fmt.Sprintf(utils.NamespaceNameFormat, mcName)
 		BeforeEach(func() {
 			createMemberCluster(mcName, "test-user", nil)
@@ -530,12 +527,6 @@ var _ = Describe("fleet guard rail networking E2Es", Serial, Ordered, func() {
 			ise := endpointSliceExport(epName, imcNamespace)
 			By("expecting successful CREATE of Endpoint slice export")
 			Expect(impersonateHubClient.Create(ctx, &ise)).Should(Succeed())
-		})
-
-		It("should allow CREATE operation in Endpoint slice resource in fleet-member namespace for user in member cluster identity", func() {
-			es := endpointSlice(esName, imcNamespace)
-			By("expecting successful CREATE of Endpoint slice")
-			Expect(impersonateHubClient.Create(ctx, &es)).Should(Succeed())
 		})
 	})
 
@@ -597,13 +588,5 @@ var _ = Describe("fleet guard rail restrict internal fleet resources from being 
 		var statusErr *k8sErrors.StatusError
 		Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create internal service export call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
 		Expect(string(statusErr.Status().Reason)).Should(Equal(fmt.Sprintf(validation.ResourceDeniedFormat, testUser, utils.GenerateGroupString(testGroups), admissionv1.Create, &iseGVK, "", types.NamespacedName{Name: ise.Name, Namespace: ise.Namespace})))
-	})
-
-	It("should deny CREATE operation on endpoint slice in fleet-system namespace for invalid user", func() {
-		es := endpointSlice("test-es", "fleet-system")
-		err := impersonateHubClient.Create(ctx, &es)
-		var statusErr *k8sErrors.StatusError
-		Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create endpoint slice call produced error %s. Error type wanted is %s.", reflect.TypeOf(err), reflect.TypeOf(&k8sErrors.StatusError{})))
-		Expect(string(statusErr.Status().Reason)).Should(Equal(fmt.Sprintf(validation.ResourceDeniedFormat, testUser, utils.GenerateGroupString(testGroups), admissionv1.Create, &esGVK, "", types.NamespacedName{Name: es.Name, Namespace: es.Namespace})))
 	})
 })

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -7,14 +7,14 @@ package e2e
 
 import (
 	"fmt"
-	discoveryv1 "k8s.io/api/discovery/v1"
-	"k8s.io/utils/pointer"
 	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	fleetnetworkingv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -28,6 +28,7 @@ const (
 	internalServiceExportNameTemplate = "ise-%d"
 	internalServiceImportNameTemplate = "isi-%d"
 	endpointSliceExportNameTemplate   = "ep-%d"
+	endpointSliceNameTemplate         = "es-%d"
 
 	customDeletionBlockerFinalizer = "custom-deletion-blocker-finalizer"
 	workNamespaceLabelName         = "process"
@@ -160,6 +161,29 @@ func endpointSliceExport(name, namespace string) fleetnetworkingv1alpha1.Endpoin
 				Namespace:      "test-ns",
 				Name:           "test-name",
 				NamespacedName: "test-ns/test-name",
+			},
+		},
+	}
+}
+
+func endpointSlice(name, namespace string) discoveryv1.EndpointSlice {
+	protocol := corev1.ProtocolTCP
+	return discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		AddressType: "IPv4",
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"192.168.0.0"},
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Name:     pointer.String("http"),
+				Protocol: &protocol,
+				Port:     pointer.Int32(80),
 			},
 		},
 	}

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -165,26 +165,3 @@ func endpointSliceExport(name, namespace string) fleetnetworkingv1alpha1.Endpoin
 		},
 	}
 }
-
-func endpointSlice(name, namespace string) discoveryv1.EndpointSlice {
-	protocol := corev1.ProtocolTCP
-	return discoveryv1.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		AddressType: "IPv4",
-		Endpoints: []discoveryv1.Endpoint{
-			{
-				Addresses: []string{"192.168.0.0"},
-			},
-		},
-		Ports: []discoveryv1.EndpointPort{
-			{
-				Name:     pointer.String("http"),
-				Protocol: &protocol,
-				Port:     pointer.Int32(80),
-			},
-		},
-	}
-}

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -7,6 +7,8 @@ package e2e
 
 import (
 	"fmt"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/utils/pointer"
 	"strconv"
 	"time"
 
@@ -19,11 +21,13 @@ import (
 )
 
 const (
-	workNamespaceNameTemplate = "application-%d"
-	appConfigMapNameTemplate  = "app-config-%d"
-	crpNameTemplate           = "crp-%d"
-	mcNameTemplate            = "mc-%d"
-	iseNameTemplate           = "ise-%d"
+	workNamespaceNameTemplate         = "application-%d"
+	appConfigMapNameTemplate          = "app-config-%d"
+	crpNameTemplate                   = "crp-%d"
+	mcNameTemplate                    = "mc-%d"
+	internalServiceExportNameTemplate = "ise-%d"
+	internalServiceImportNameTemplate = "isi-%d"
+	endpointSliceExportNameTemplate   = "ep-%d"
 
 	customDeletionBlockerFinalizer = "custom-deletion-blocker-finalizer"
 	workNamespaceLabelName         = "process"
@@ -95,6 +99,67 @@ func internalServiceExport(name, namespace string) fleetnetworkingv1alpha1.Inter
 				ResourceVersion: "test-resource-version",
 				ClusterID:       "member-1",
 				ExportedSince:   metav1.NewTime(time.Now().Round(time.Second)),
+			},
+		},
+	}
+}
+
+func internalServiceImport(name, namespace string) fleetnetworkingv1alpha1.InternalServiceImport {
+	return fleetnetworkingv1alpha1.InternalServiceImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: fleetnetworkingv1alpha1.InternalServiceImportSpec{
+			ServiceImportReference: fleetnetworkingv1alpha1.ExportedObjectReference{
+				ClusterID:       "test-cluster-id",
+				Kind:            "test-kind",
+				Namespace:       "test-ns",
+				Name:            "test-name",
+				ResourceVersion: "1",
+				Generation:      1,
+				UID:             "test-id",
+				NamespacedName:  "test-ns/test-name",
+			},
+		},
+	}
+}
+
+func endpointSliceExport(name, namespace string) fleetnetworkingv1alpha1.EndpointSliceExport {
+	protocol := corev1.ProtocolTCP
+	return fleetnetworkingv1alpha1.EndpointSliceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: fleetnetworkingv1alpha1.EndpointSliceExportSpec{
+			AddressType: "IPv4",
+			Endpoints: []fleetnetworkingv1alpha1.Endpoint{
+				{
+					Addresses: []string{"test-address-1"},
+				},
+			},
+			Ports: []discoveryv1.EndpointPort{
+				{
+					Name:     pointer.String("http"),
+					Protocol: &protocol,
+					Port:     pointer.Int32(80),
+				},
+			},
+			EndpointSliceReference: fleetnetworkingv1alpha1.ExportedObjectReference{
+				ClusterID:       "test-cluster-id",
+				Kind:            "test-kind",
+				Namespace:       "test-ns",
+				Name:            "test-name",
+				ResourceVersion: "1",
+				Generation:      1,
+				UID:             "test-id",
+				NamespacedName:  "test-ns/test-name",
+			},
+			OwnerServiceReference: fleetnetworkingv1alpha1.OwnerServiceReference{
+				Namespace:      "test-ns",
+				Name:           "test-name",
+				NamespacedName: "test-ns/test-name",
 			},
 		},
 	}

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -71,9 +71,13 @@ helm install hub-agent ../../charts/hub-agent/ \
     --set enableV1Alpha1APIs=false \
     --set enableV1Beta1APIs=true
 
-# Download CRD from Fleet networking repo
-export NETWORKING_CRD_URL=https://raw.githubusercontent.com/Azure/fleet-networking/v0.2.7/config/crd/bases/networking.fleet.azure.com_internalserviceexports.yaml
-curl $NETWORKING_CRD_URL | kubectl apply -f -
+# Download CRDs from Fleet networking repo
+export ENDPOINT_SLICE_EXPORT_CRD_URL=https://raw.githubusercontent.com/Azure/fleet-networking/v0.2.7/config/crd/bases/networking.fleet.azure.com_endpointsliceexports.yaml
+export INTERNAL_SERVICE_EXPORT_CRD_URL=https://raw.githubusercontent.com/Azure/fleet-networking/v0.2.7/config/crd/bases/networking.fleet.azure.com_internalserviceexports.yaml
+export INTERNAL_SERVICE_IMPORT_CRD_URL=https://raw.githubusercontent.com/Azure/fleet-networking/v0.2.7/config/crd/bases/networking.fleet.azure.com_internalserviceimports.yaml
+curl $ENDPOINT_SLICE_EXPORT_CRD_URL | kubectl apply -f -
+curl $INTERNAL_SERVICE_EXPORT_CRD_URL | kubectl apply -f -
+curl $INTERNAL_SERVICE_IMPORT_CRD_URL | kubectl apply -f -
 
 # Install the member agent and related components to the member clusters
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -445,24 +445,6 @@ func createWorkResource(name, namespace string) {
 	Expect(hubClient.Create(ctx, &w)).Should(Succeed())
 }
 
-func deleteWorkResource(name, namespace string) {
-	w := placementv1beta1.Work{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-	Expect(hubClient.Delete(ctx, &w)).Should(Succeed())
-
-	Eventually(func(g Gomega) error {
-		var w placementv1beta1.Work
-		if err := hubClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &w); !apierrors.IsNotFound(err) {
-			return fmt.Errorf("work still exists or an unexpected error occurred: %w", err)
-		}
-		return nil
-	}, eventuallyDuration, eventuallyInterval).Should(Succeed())
-}
-
 // createWorkResources creates some resources on the hub cluster for testing purposes.
 func createWorkResources() {
 	ns := workNamespace()

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -405,16 +405,6 @@ func checkInternalMemberClusterExists(name, namespace string) {
 	}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 }
 
-func checkMemberClusterNamespaceIsDeleted(name string) {
-	Eventually(func(g Gomega) error {
-		var ns corev1.Namespace
-		if err := hubClient.Get(ctx, types.NamespacedName{Name: name}, &ns); !apierrors.IsNotFound(err) {
-			return fmt.Errorf("member cluster namespace %s still exists or an unexpected error occurred: %w", name, err)
-		}
-		return nil
-	}, eventuallyDuration, eventuallyInterval).Should(Succeed())
-}
-
 func createWorkResource(name, namespace string) {
 	testDeployment := appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/test/e2e/v1alpha1/webhook_test.go
+++ b/test/e2e/v1alpha1/webhook_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"reflect"
 	"regexp"
 
@@ -31,6 +30,7 @@ import (
 	workv1alpha1 "sigs.k8s.io/work-api/pkg/apis/v1alpha1"
 
 	fleetnetworkingv1alpha1 "go.goms.io/fleet-networking/api/v1alpha1"
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	fleetv1alpha1 "go.goms.io/fleet/apis/v1alpha1"
 	"go.goms.io/fleet/pkg/utils"
 	"go.goms.io/fleet/pkg/webhook/validation"


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

- Allow member agent to create/update/delete internal fleet namespaced resources.
- Deny users from creating internal fleet namespaced resources in fleet/kube prefixed namesapces

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
