### PR TITLE
fix: Changes in correlation with new GH Action Permission Changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ env:
 jobs:
   detect-noop:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       noop: ${{ steps.noop.outputs.should_skip }}
     steps:
@@ -32,6 +35,9 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     needs: detect-noop
+    permissions:
+      contents: read
+      pull-requests: read
     if: needs.detect-noop.outputs.noop != 'true'
     steps:
       - name: Set up Go
@@ -59,6 +65,9 @@ jobs:
   
   e2e-tests-v1alpha1:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     needs: [
       detect-noop,
     ]
@@ -87,6 +96,9 @@ jobs:
   
   e2e-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     needs: [
       detect-noop,
     ]

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -20,6 +20,8 @@ jobs:
 
   detect-noop:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       noop: ${{ steps.noop.outputs.should_skip }}
     steps:
@@ -33,6 +35,8 @@ jobs:
 
   staticcheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: detect-noop
     if: needs.detect-noop.outputs.noop != 'true'
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: thehanimo/pr-title-checker@v1.4.1
         with:


### PR DESCRIPTION
These changes are made in correlation with the following changes coming soon in the GH actions permissions. Please take a kind look. ❤️🙏☕️

https://docs.opensource.microsoft.com/github/apps/permission-changes/

Key aspects from this change referential is:

> Changes are coming that will break your GitHub Actions workflows unless you add a [permissions block](https://docs.opensource.microsoft.com/github/apps/permission-changes/#what-steps-must-i-take-to-avoid-a-bad-time). You can add this today to minimize impact to your group or your GitHub Actions may fail starting on 2024-02-01.

Followed by:

> In your GHA workflow, you must add a [permissions block](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions) to your workflow file that will require you to specify the scope and permission you are granting it to your repo. The options for access are read, write and none.

If this helps please feel free to check and this might help in being prepared for the changes coming soon from 1st Feb.