### PR TITLE
docs: update docs for allowed propagating apis flag

### DIFF
--- a/docs/api-references.md
+++ b/docs/api-references.md
@@ -228,7 +228,7 @@ _Appears in:_
 
 
 ClusterResourcePlacement is used to select cluster scoped resources, including built-in resources and custom resources, and placement them onto selected member clusters in a fleet. 
- If a namespace is selected, ALL the resources under the namespace are placed to the target clusters. Note that you can't select the following resources: - reserved namespaces including: default, kube-* (reserved for Kubernetes system namespaces), fleet-* (reserved for fleet system namespaces). - reserved fleet resource types including: MemberCluster, InternalMemberCluster, ClusterResourcePlacement, ClusterSchedulingPolicySnapshot, ClusterResourceSnapshot, ClusterResourceBinding, etc. 
+ If a namespace is selected, ALL the resources under the namespace are placed to the target clusters unless `allowed-propagating-apis` flag is configured on hub-agent. Note that you can't select the following resources: - reserved namespaces including: default, kube-* (reserved for Kubernetes system namespaces), fleet-* (reserved for fleet system namespaces). - reserved fleet resource types including: MemberCluster, InternalMemberCluster, ClusterResourcePlacement, ClusterSchedulingPolicySnapshot, ClusterResourceSnapshot, ClusterResourceBinding, etc.
  `ClusterSchedulingPolicySnapshot` and `ClusterResourceSnapshot` objects are created when there are changes in the system to keep the history of the changes affecting a `ClusterResourcePlacement`.
 
 _Appears in:_

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,6 +36,8 @@ The fleet reserved namespace are `fleet-system` and `fleet-member-{clusterName}`
 
 ## What kind of the resources are allowed to be propagated from the hub cluster to the member clusters? How can I control the list?
 
+The resources to be propagated from the hub cluster to the member clusters can be controlled by either an exclude/skip list or an include/allow list which are mutually exclusive.
+
 `ClusterResourcePlacement` excludes certain groups/resources when propagating the resources by default. They are defined [here](https://github.com/Azure/fleet/blob/main/pkg/utils/apiresources.go).
 - `k8s.io/api/events/v1` (group)
 - `k8s.io/api/coordination/v1` (group)
@@ -45,6 +47,8 @@ The fleet reserved namespace are `fleet-system` and `fleet-member-{clusterName}`
 - any resources in the "default" namespace
 
 You can use `skipped-propagating-apis` and `skipped-propagating-namespaces` flag when installing the hub-agent to skip resources from being propagated by specifying their group/group-version/group-version-kind and namespaces.
+
+You can use `allowed-propagating-apis` flag on the hub-agent to only allow propagation of desired set of resources specified in the form of group/group-version/group-version-kind. This flag is mutually exclusive with `skipped-propagating-apis`.
 
 ## What happens to existing resources in member clusters when their definitions conflict with the desired resources in the hub cluster?
 


### PR DESCRIPTION
### Summary

A new flag `--allowed-propagating-apis` was introduced in #633. I am updating the reference docs to describe how the user can use this flag.

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #649

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### Testing
Rendered the markdown locally and ran `make test`

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer
- api-resources doc has been updated to suggest that if a namespace is selected, the default behavior of ALL resource propagation can be controlled with this flag.

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
