### PR TITLE
interface: Taints & Tolerations API

### DIFF
--- a/apis/cluster/v1beta1/membercluster_types.go
+++ b/apis/cluster/v1beta1/membercluster_types.go
@@ -6,7 +6,6 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +50,7 @@ type MemberClusterSpec struct {
 
 	// If specified, the MemberCluster's taints.
 	// +optional
-	Taints []corev1.Taint `json:"taints,omitempty"`
+	Taints []Taint `json:"taints,omitempty"`
 }
 
 // MemberClusterStatus defines the observed status of MemberCluster.
@@ -72,6 +71,33 @@ type MemberClusterStatus struct {
 	// AgentStatus is an array of current observed status, each corresponding to one member agent running in the member cluster.
 	// +optional
 	AgentStatus []AgentStatus `json:"agentStatus,omitempty"`
+}
+
+// TaintEffect defines the effect of the taint.
+// +enum
+type TaintEffect string
+
+const (
+	// TaintEffectNoSchedule does not allow new pods to schedule onto the node unless they
+	// tolerate the taint, but allow all pods submitted to Kubelet without going through
+	// the scheduler to start, and allow all already-running pods to continue running.
+	// Enforced by the scheduler.
+	TaintEffectNoSchedule TaintEffect = "NoSchedule"
+)
+
+// Taint attached to MemberCluster has the "effect" on
+// any ClusterResourcePlacement that does not tolerate the Taint.
+type Taint struct {
+	// The taint key to be applied to a node.
+	// +required
+	Key string `json:"key"`
+	// The taint value corresponding to the taint key.
+	// +optional
+	Value string `json:"value,omitempty"`
+	// The effect of the taint on pods that do not tolerate the taint.
+	// Valid effect is NoSchedule.
+	// +required
+	Effect TaintEffect `json:"effect"`
 }
 
 // MemberClusterConditionType defines a specific condition of a member cluster.

--- a/apis/cluster/v1beta1/membercluster_types.go
+++ b/apis/cluster/v1beta1/membercluster_types.go
@@ -6,6 +6,7 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +48,10 @@ type MemberClusterSpec struct {
 	// How often (in seconds) for the member cluster to send a heartbeat to the hub cluster. Default: 60 seconds. Min: 1 second. Max: 10 minutes.
 	// +optional
 	HeartbeatPeriodSeconds int32 `json:"heartbeatPeriodSeconds,omitempty"`
+
+	// If specified, the MemberCluster's taints.
+	// +optional
+	Taints []corev1.Taint `json:"taints,omitempty"`
 }
 
 // MemberClusterStatus defines the observed status of MemberCluster.

--- a/apis/cluster/v1beta1/membercluster_types.go
+++ b/apis/cluster/v1beta1/membercluster_types.go
@@ -50,6 +50,7 @@ type MemberClusterSpec struct {
 	HeartbeatPeriodSeconds int32 `json:"heartbeatPeriodSeconds,omitempty"`
 
 	// If specified, the MemberCluster's taints.
+	// +kubebuilder:validation:MaxItems=100
 	// +optional
 	Taints []Taint `json:"taints,omitempty"`
 }
@@ -84,7 +85,8 @@ type Taint struct {
 	// +optional
 	Value string `json:"value,omitempty"`
 	// The effect of the taint on ClusterResourcePlacements that do not tolerate the taint.
-	// Valid effect is NoSchedule.
+	// Only NoSchedule is supported.
+	// +kubebuilder:validation:Enum=NoSchedule
 	// +required
 	Effect corev1.TaintEffect `json:"effect"`
 }

--- a/apis/cluster/v1beta1/membercluster_types.go
+++ b/apis/cluster/v1beta1/membercluster_types.go
@@ -6,6 +6,7 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,18 +74,6 @@ type MemberClusterStatus struct {
 	AgentStatus []AgentStatus `json:"agentStatus,omitempty"`
 }
 
-// TaintEffect defines the effect of the taint.
-// +enum
-type TaintEffect string
-
-const (
-	// TaintEffectNoSchedule does not allow new pods to schedule onto the node unless they
-	// tolerate the taint, but allow all pods submitted to Kubelet without going through
-	// the scheduler to start, and allow all already-running pods to continue running.
-	// Enforced by the scheduler.
-	TaintEffectNoSchedule TaintEffect = "NoSchedule"
-)
-
 // Taint attached to MemberCluster has the "effect" on
 // any ClusterResourcePlacement that does not tolerate the Taint.
 type Taint struct {
@@ -97,7 +86,7 @@ type Taint struct {
 	// The effect of the taint on ClusterResourcePlacements that do not tolerate the taint.
 	// Valid effect is NoSchedule.
 	// +required
-	Effect TaintEffect `json:"effect"`
+	Effect corev1.TaintEffect `json:"effect"`
 }
 
 // MemberClusterConditionType defines a specific condition of a member cluster.

--- a/apis/cluster/v1beta1/membercluster_types.go
+++ b/apis/cluster/v1beta1/membercluster_types.go
@@ -81,9 +81,11 @@ type Taint struct {
 	// The taint key to be applied to a MemberCluster.
 	// +required
 	Key string `json:"key"`
+
 	// The taint value corresponding to the taint key.
 	// +optional
 	Value string `json:"value,omitempty"`
+
 	// The effect of the taint on ClusterResourcePlacements that do not tolerate the taint.
 	// Only NoSchedule is supported.
 	// +kubebuilder:validation:Enum=NoSchedule

--- a/apis/cluster/v1beta1/membercluster_types.go
+++ b/apis/cluster/v1beta1/membercluster_types.go
@@ -88,13 +88,13 @@ const (
 // Taint attached to MemberCluster has the "effect" on
 // any ClusterResourcePlacement that does not tolerate the Taint.
 type Taint struct {
-	// The taint key to be applied to a node.
+	// The taint key to be applied to a MemberCluster.
 	// +required
 	Key string `json:"key"`
 	// The taint value corresponding to the taint key.
 	// +optional
 	Value string `json:"value,omitempty"`
-	// The effect of the taint on pods that do not tolerate the taint.
+	// The effect of the taint on ClusterResourcePlacements that do not tolerate the taint.
 	// Valid effect is NoSchedule.
 	// +required
 	Effect TaintEffect `json:"effect"`

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -171,6 +171,7 @@ type PlacementPolicy struct {
 	TopologySpreadConstraints []TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty" patchStrategy:"merge" patchMergeKey:"topologyKey"`
 
 	// If specified, the ClusterResourcePlacement's tolerations.
+	// +kubebuilder:validation:MaxItems=100
 	// +optional
 	Tolerations []Toleration `json:"tolerations,omitempty"`
 }
@@ -478,7 +479,8 @@ type Toleration struct {
 	// +optional
 	Value string `json:"value,omitempty"`
 	// Effect indicates the taint effect to match. Empty means match all taint effects.
-	// When specified, allowed value is NoSchedule.
+	// When specified, only allowed value is NoSchedule.
+	//+kubebuilder:validation:Enum=NoSchedule
 	// +optional
 	Effect corev1.TaintEffect `json:"effect,omitempty"`
 }

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -471,8 +471,8 @@ type Toleration struct {
 	Key string `json:"key,omitempty"`
 	// Operator represents a key's relationship to the value.
 	// Valid operators are Exists and Equal. Defaults to Equal.
-	// Exists is equivalent to wildcard for value, so that a pod can
-	// tolerate all taints of a particular category.
+	// Exists is equivalent to wildcard for value, so that a
+	// ClusterResourcePlacement can tolerate all taints of a particular category.
 	// +kubebuilder:default=Equal
 	// +kubebuilder:validation:Enum=Equal;Exists
 	// +optional

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -6,11 +6,10 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 )
 
 const (
@@ -461,15 +460,6 @@ type FailedResourcePlacement struct {
 	Condition metav1.Condition `json:"condition"`
 }
 
-// TolerationOperator is the set of operators that can be used in a toleration.
-// +enum
-type TolerationOperator string
-
-const (
-	TolerationOpExists TolerationOperator = "Exists"
-	TolerationOpEqual  TolerationOperator = "Equal"
-)
-
 // Toleration allows ClusterResourcePlacement to tolerate any taint that matches
 // the triple <key,value,effect> using the matching operator <operator>.
 type Toleration struct {
@@ -482,7 +472,7 @@ type Toleration struct {
 	// Exists is equivalent to wildcard for value, so that a pod can
 	// tolerate all taints of a particular category.
 	// +optional
-	Operator TolerationOperator `json:"operator,omitempty"`
+	Operator corev1.TolerationOperator `json:"operator,omitempty"`
 	// Value is the taint value the toleration matches to.
 	// If the operator is Exists, the value should be empty, otherwise just a regular string.
 	// +optional
@@ -490,7 +480,7 @@ type Toleration struct {
 	// Effect indicates the taint effect to match. Empty means match all taint effects.
 	// When specified, allowed value is NoSchedule.
 	// +optional
-	Effect clusterv1beta1.TaintEffect `json:"effect,omitempty"`
+	Effect corev1.TaintEffect `json:"effect,omitempty"`
 }
 
 // ClusterResourcePlacementConditionType defines a specific condition of a cluster resource placement.

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -473,7 +473,7 @@ type Toleration struct {
 	// Exists is equivalent to wildcard for value, so that a pod can
 	// tolerate all taints of a particular category.
 	// +kubebuilder:default=Equal
-	// +kubebuilder:validation:Enum=Equal,Exists
+	// +kubebuilder:validation:Enum=Equal;Exists
 	// +optional
 	Operator corev1.TolerationOperator `json:"operator,omitempty"`
 	// Value is the taint value the toleration matches to.

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -469,6 +469,7 @@ type Toleration struct {
 	// If the key is empty, operator must be Exists; this combination means to match all values and all keys.
 	// +optional
 	Key string `json:"key,omitempty"`
+
 	// Operator represents a key's relationship to the value.
 	// Valid operators are Exists and Equal. Defaults to Equal.
 	// Exists is equivalent to wildcard for value, so that a
@@ -477,10 +478,12 @@ type Toleration struct {
 	// +kubebuilder:validation:Enum=Equal;Exists
 	// +optional
 	Operator corev1.TolerationOperator `json:"operator,omitempty"`
+
 	// Value is the taint value the toleration matches to.
 	// If the operator is Exists, the value should be empty, otherwise just a regular string.
 	// +optional
 	Value string `json:"value,omitempty"`
+
 	// Effect indicates the taint effect to match. Empty means match all taint effects.
 	// When specified, only allowed value is NoSchedule.
 	// +kubebuilder:validation:Enum=NoSchedule

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -472,6 +472,8 @@ type Toleration struct {
 	// Valid operators are Exists and Equal. Defaults to Equal.
 	// Exists is equivalent to wildcard for value, so that a pod can
 	// tolerate all taints of a particular category.
+	// +kubebuilder:default=Equal
+	// +kubebuilder:validation:Enum=Equal,Exists
 	// +optional
 	Operator corev1.TolerationOperator `json:"operator,omitempty"`
 	// Value is the taint value the toleration matches to.
@@ -480,7 +482,7 @@ type Toleration struct {
 	Value string `json:"value,omitempty"`
 	// Effect indicates the taint effect to match. Empty means match all taint effects.
 	// When specified, only allowed value is NoSchedule.
-	//+kubebuilder:validation:Enum=NoSchedule
+	// +kubebuilder:validation:Enum=NoSchedule
 	// +optional
 	Effect corev1.TaintEffect `json:"effect,omitempty"`
 }

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 )
 
 const (
@@ -172,7 +174,7 @@ type PlacementPolicy struct {
 
 	// If specified, the ClusterResourcePlacement's tolerations.
 	// +optional
-	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	Tolerations []Toleration `json:"tolerations,omitempty"`
 }
 
 // Affinity is a group of cluster affinity scheduling rules. More to be added.
@@ -458,6 +460,29 @@ type FailedResourcePlacement struct {
 	// The failed condition status.
 	// +required
 	Condition metav1.Condition `json:"condition"`
+}
+
+// Toleration allows ClusterResourcePlacement to tolerate any taint that matches
+// the triple <key,value,effect> using the matching operator <operator>.
+type Toleration struct {
+	// Key is the taint key that the toleration applies to. Empty means match all taint keys.
+	// If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+	// +optional
+	Key string `json:"key,omitempty"`
+	// Operator represents a key's relationship to the value.
+	// Valid operators are Exists and Equal. Defaults to Equal.
+	// Exists is equivalent to wildcard for value, so that a pod can
+	// tolerate all taints of a particular category.
+	// +optional
+	Operator corev1.TolerationOperator `json:"operator,omitempty"`
+	// Value is the taint value the toleration matches to.
+	// If the operator is Exists, the value should be empty, otherwise just a regular string.
+	// +optional
+	Value string `json:"value,omitempty"`
+	// Effect indicates the taint effect to match. Empty means match all taint effects.
+	// When specified, allowed value is NoSchedule.
+	// +optional
+	Effect clusterv1beta1.TaintEffect `json:"effect,omitempty"`
 }
 
 // ClusterResourcePlacementConditionType defines a specific condition of a cluster resource placement.

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -6,6 +6,7 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -168,6 +169,10 @@ type PlacementPolicy struct {
 	// +patchMergeKey=topologyKey
 	// +patchStrategy=merge
 	TopologySpreadConstraints []TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty" patchStrategy:"merge" patchMergeKey:"topologyKey"`
+
+	// If specified, the ClusterResourcePlacement's tolerations.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // Affinity is a group of cluster affinity scheduling rules. More to be added.

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -170,7 +170,8 @@ type PlacementPolicy struct {
 	// +patchStrategy=merge
 	TopologySpreadConstraints []TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty" patchStrategy:"merge" patchMergeKey:"topologyKey"`
 
-	// If specified, the ClusterResourcePlacement's tolerations.
+	// If specified, the ClusterResourcePlacement's Tolerations.
+	// Tolerations cannot be updated or deleted.
 	// +kubebuilder:validation:MaxItems=100
 	// +optional
 	Tolerations []Toleration `json:"tolerations,omitempty"`

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -6,7 +6,6 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -462,6 +461,15 @@ type FailedResourcePlacement struct {
 	Condition metav1.Condition `json:"condition"`
 }
 
+// TolerationOperator is the set of operators that can be used in a toleration.
+// +enum
+type TolerationOperator string
+
+const (
+	TolerationOpExists TolerationOperator = "Exists"
+	TolerationOpEqual  TolerationOperator = "Equal"
+)
+
 // Toleration allows ClusterResourcePlacement to tolerate any taint that matches
 // the triple <key,value,effect> using the matching operator <operator>.
 type Toleration struct {
@@ -474,7 +482,7 @@ type Toleration struct {
 	// Exists is equivalent to wildcard for value, so that a pod can
 	// tolerate all taints of a particular category.
 	// +optional
-	Operator corev1.TolerationOperator `json:"operator,omitempty"`
+	Operator TolerationOperator `json:"operator,omitempty"`
 	// Value is the taint value the toleration matches to.
 	// If the operator is Exists, the value should be empty, otherwise just a regular string.
 	// +optional

--- a/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
+++ b/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
@@ -94,7 +94,9 @@ spec:
                   properties:
                     effect:
                       description: The effect of the taint on ClusterResourcePlacements
-                        that do not tolerate the taint. Valid effect is NoSchedule.
+                        that do not tolerate the taint. Only NoSchedule is supported.
+                      enum:
+                      - NoSchedule
                       type: string
                     key:
                       description: The taint key to be applied to a MemberCluster.
@@ -106,6 +108,7 @@ spec:
                   - effect
                   - key
                   type: object
+                maxItems: 100
                 type: array
             required:
             - identity

--- a/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
+++ b/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
@@ -86,6 +86,33 @@ spec:
                 - name
                 type: object
                 x-kubernetes-map-type: atomic
+              taints:
+                description: If specified, the MemberCluster's taints.
+                items:
+                  description: The node this Taint is attached to has the "effect"
+                    on any pod that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: Required. The effect of the taint on pods that
+                        do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule
+                        and NoExecute.
+                      type: string
+                    key:
+                      description: Required. The taint key to be applied to a node.
+                      type: string
+                    timeAdded:
+                      description: TimeAdded represents the time at which the taint
+                        was added. It is only written for NoExecute taints.
+                      format: date-time
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
             required:
             - identity
             type: object

--- a/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
+++ b/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
@@ -93,11 +93,11 @@ spec:
                     any ClusterResourcePlacement that does not tolerate the Taint.
                   properties:
                     effect:
-                      description: The effect of the taint on pods that do not tolerate
-                        the taint. Valid effect is NoSchedule.
+                      description: The effect of the taint on ClusterResourcePlacements
+                        that do not tolerate the taint. Valid effect is NoSchedule.
                       type: string
                     key:
-                      description: The taint key to be applied to a node.
+                      description: The taint key to be applied to a MemberCluster.
                       type: string
                     value:
                       description: The taint value corresponding to the taint key.

--- a/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
+++ b/config/crd/bases/cluster.kubernetes-fleet.io_memberclusters.yaml
@@ -89,21 +89,15 @@ spec:
               taints:
                 description: If specified, the MemberCluster's taints.
                 items:
-                  description: The node this Taint is attached to has the "effect"
-                    on any pod that does not tolerate the Taint.
+                  description: Taint attached to MemberCluster has the "effect" on
+                    any ClusterResourcePlacement that does not tolerate the Taint.
                   properties:
                     effect:
-                      description: Required. The effect of the taint on pods that
-                        do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule
-                        and NoExecute.
+                      description: The effect of the taint on pods that do not tolerate
+                        the taint. Valid effect is NoSchedule.
                       type: string
                     key:
-                      description: Required. The taint key to be applied to a node.
-                      type: string
-                    timeAdded:
-                      description: TimeAdded represents the time at which the taint
-                        was added. It is only written for NoExecute taints.
-                      format: date-time
+                      description: The taint key to be applied to a node.
                       type: string
                     value:
                       description: The taint value corresponding to the taint key.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -274,7 +274,8 @@ spec:
                     - PickFixed
                     type: string
                   tolerations:
-                    description: If specified, the ClusterResourcePlacement's tolerations.
+                    description: If specified, the ClusterResourcePlacement's Tolerations.
+                      Tolerations cannot be updated or deleted.
                     items:
                       description: Toleration allows ClusterResourcePlacement to tolerate
                         any taint that matches the triple <key,value,effect> using

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -299,8 +299,8 @@ spec:
                           description: Operator represents a key's relationship to
                             the value. Valid operators are Exists and Equal. Defaults
                             to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
+                            so that a ClusterResourcePlacement can tolerate all taints
+                            of a particular category.
                           enum:
                           - Equal
                           - Exists

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -276,14 +276,14 @@ spec:
                   tolerations:
                     description: If specified, the ClusterResourcePlacement's tolerations.
                     items:
-                      description: The pod this Toleration is attached to tolerates
+                      description: Toleration allows ClusterResourcePlacement to tolerate
                         any taint that matches the triple <key,value,effect> using
                         the matching operator <operator>.
                       properties:
                         effect:
                           description: Effect indicates the taint effect to match.
                             Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                            value is NoSchedule.
                           type: string
                         key:
                           description: Key is the taint key that the toleration applies
@@ -298,15 +298,6 @@ spec:
                             so that a pod can tolerate all taints of a particular
                             category.
                           type: string
-                        tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
-                          format: int64
-                          type: integer
                         value:
                           description: Value is the taint value the toleration matches
                             to. If the operator is Exists, the value should be empty,

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -273,6 +273,47 @@ spec:
                     - PickN
                     - PickFixed
                     type: string
+                  tolerations:
+                    description: If specified, the ClusterResourcePlacement's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   topologySpreadConstraints:
                     description: TopologySpreadConstraints describes how a group of
                       resources ought to spread across multiple topology domains.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -282,8 +282,10 @@ spec:
                       properties:
                         effect:
                           description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            value is NoSchedule.
+                            Empty means match all taint effects. When specified, only
+                            allowed value is NoSchedule.
+                          enum:
+                          - NoSchedule
                           type: string
                         key:
                           description: Key is the taint key that the toleration applies
@@ -292,11 +294,15 @@ spec:
                             all values and all keys.
                           type: string
                         operator:
+                          default: Equal
                           description: Operator represents a key's relationship to
                             the value. Valid operators are Exists and Equal. Defaults
                             to Equal. Exists is equivalent to wildcard for value,
                             so that a pod can tolerate all taints of a particular
                             category.
+                          enum:
+                          - Equal
+                          - Exists
                           type: string
                         value:
                           description: Value is the taint value the toleration matches
@@ -304,6 +310,7 @@ spec:
                             otherwise just a regular string.
                           type: string
                       type: object
+                    maxItems: 100
                     type: array
                   topologySpreadConstraints:
                     description: TopologySpreadConstraints describes how a group of

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
@@ -258,7 +258,8 @@ spec:
                     - PickFixed
                     type: string
                   tolerations:
-                    description: If specified, the ClusterResourcePlacement's tolerations.
+                    description: If specified, the ClusterResourcePlacement's Tolerations.
+                      Tolerations cannot be updated or deleted.
                     items:
                       description: Toleration allows ClusterResourcePlacement to tolerate
                         any taint that matches the triple <key,value,effect> using

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
@@ -266,8 +266,10 @@ spec:
                       properties:
                         effect:
                           description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            value is NoSchedule.
+                            Empty means match all taint effects. When specified, only
+                            allowed value is NoSchedule.
+                          enum:
+                          - NoSchedule
                           type: string
                         key:
                           description: Key is the taint key that the toleration applies
@@ -276,11 +278,15 @@ spec:
                             all values and all keys.
                           type: string
                         operator:
+                          default: Equal
                           description: Operator represents a key's relationship to
                             the value. Valid operators are Exists and Equal. Defaults
                             to Equal. Exists is equivalent to wildcard for value,
                             so that a pod can tolerate all taints of a particular
                             category.
+                          enum:
+                          - Equal
+                          - Exists
                           type: string
                         value:
                           description: Value is the taint value the toleration matches
@@ -288,6 +294,7 @@ spec:
                             otherwise just a regular string.
                           type: string
                       type: object
+                    maxItems: 100
                     type: array
                   topologySpreadConstraints:
                     description: TopologySpreadConstraints describes how a group of

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
@@ -257,6 +257,47 @@ spec:
                     - PickN
                     - PickFixed
                     type: string
+                  tolerations:
+                    description: If specified, the ClusterResourcePlacement's tolerations.
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                   topologySpreadConstraints:
                     description: TopologySpreadConstraints describes how a group of
                       resources ought to spread across multiple topology domains.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
@@ -283,8 +283,8 @@ spec:
                           description: Operator represents a key's relationship to
                             the value. Valid operators are Exists and Equal. Defaults
                             to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
+                            so that a ClusterResourcePlacement can tolerate all taints
+                            of a particular category.
                           enum:
                           - Equal
                           - Exists

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterschedulingpolicysnapshots.yaml
@@ -260,14 +260,14 @@ spec:
                   tolerations:
                     description: If specified, the ClusterResourcePlacement's tolerations.
                     items:
-                      description: The pod this Toleration is attached to tolerates
+                      description: Toleration allows ClusterResourcePlacement to tolerate
                         any taint that matches the triple <key,value,effect> using
                         the matching operator <operator>.
                       properties:
                         effect:
                           description: Effect indicates the taint effect to match.
                             Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                            value is NoSchedule.
                           type: string
                         key:
                           description: Key is the taint key that the toleration applies
@@ -282,15 +282,6 @@ spec:
                             so that a pod can tolerate all taints of a particular
                             category.
                           type: string
-                        tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
-                          format: int64
-                          type: integer
                         value:
                           description: Value is the taint value the toleration matches
                             to. If the operator is Exists, the value should be empty,


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

Decided to go with custom objects for taints and tolerations because,

- The objects from "k8s.io/api/core/v1" were specifically created for nodes, pods and hence has comments explicitly specifying they were related to nodes and pods 
![image](https://github.com/Azure/fleet/assets/17449572/7ccaa366-1027-4472-b556-698ace7892b7)
![image](https://github.com/Azure/fleet/assets/17449572/59c1651b-4d1c-4ddd-bdd4-152439a2e584)
    - Taint had TimeAdded field for NoExecute 
![image](https://github.com/Azure/fleet/assets/17449572/4412f889-878c-4ab3-b19a-dc2e7669f81d)
    - Toleration has TolerationSeconds field for NoExecute 
![image](https://github.com/Azure/fleet/assets/17449572/73ec309a-66f7-4b59-b85c-8a1d8de772f7)
