### PR TITLE
fix: change failure policy, timeout for validating webhooks

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -100,12 +100,13 @@ const (
 var (
 	admissionReviewVersions = []string{admv1.SchemeGroupVersion.Version, admv1beta1.SchemeGroupVersion.Version}
 
-	ignoreFailurePolicy   = admv1.Ignore
-	failFailurePolicy     = admv1.Fail
-	sideEffortsNone       = admv1.SideEffectClassNone
-	namespacedScope       = admv1.NamespacedScope
-	clusterScope          = admv1.ClusterScope
-	webhookTimeoutSeconds = pointer.Int32(1)
+	ignoreFailurePolicy      = admv1.Ignore
+	failFailurePolicy        = admv1.Fail
+	sideEffortsNone          = admv1.SideEffectClassNone
+	namespacedScope          = admv1.NamespacedScope
+	clusterScope             = admv1.ClusterScope
+	oneSecondWebhookTimeout  = pointer.Int32(1)
+	fiveSecondWebhookTimeout = pointer.Int32(5)
 )
 
 var AddToManagerFuncs []func(manager.Manager) error
@@ -236,6 +237,7 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule([]string{corev1.SchemeGroupVersion.Group}, []string{corev1.SchemeGroupVersion.Version}, []string{podResourceName}, &namespacedScope),
 				},
 			},
+			TimeoutSeconds: fiveSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.clusterresourceplacementv1alpha1.validating",
@@ -252,6 +254,7 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule([]string{fleetv1alpha1.GroupVersion.Group}, []string{fleetv1alpha1.GroupVersion.Version}, []string{fleetv1alpha1.ClusterResourcePlacementResource}, &clusterScope),
 				},
 			},
+			TimeoutSeconds: fiveSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.clusterresourceplacementv1beta1.validating",
@@ -268,6 +271,7 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule([]string{placementv1beta1.GroupVersion.Group}, []string{placementv1beta1.GroupVersion.Version}, []string{placementv1beta1.ClusterResourcePlacementResource}, &clusterScope),
 				},
 			},
+			TimeoutSeconds: fiveSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.replicaset.validating",
@@ -283,6 +287,7 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule([]string{appsv1.SchemeGroupVersion.Group}, []string{appsv1.SchemeGroupVersion.Version}, []string{replicaSetResourceName}, &namespacedScope),
 				},
 			},
+			TimeoutSeconds: fiveSecondWebhookTimeout,
 		},
 	}
 
@@ -415,7 +420,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 					Rule:       createRule([]string{apiextensionsv1.SchemeGroupVersion.Group}, []string{apiextensionsv1.SchemeGroupVersion.Version}, []string{crdResourceName}, &clusterScope),
 				},
 			},
-			TimeoutSeconds: webhookTimeoutSeconds,
+			TimeoutSeconds: oneSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.membercluster.validating",
@@ -429,7 +434,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 					Rule:       createRule([]string{clusterv1beta1.GroupVersion.Group}, []string{clusterv1beta1.GroupVersion.Version}, []string{memberClusterResourceName, memberClusterResourceName + "/status"}, &clusterScope),
 				},
 			},
-			TimeoutSeconds: webhookTimeoutSeconds,
+			TimeoutSeconds: oneSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.v1alpha1.membercluster.validating",
@@ -443,7 +448,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 					Rule:       createRule([]string{fleetv1alpha1.GroupVersion.Group}, []string{fleetv1alpha1.GroupVersion.Version}, []string{memberClusterResourceName, memberClusterResourceName + "/status"}, &clusterScope),
 				},
 			},
-			TimeoutSeconds: webhookTimeoutSeconds,
+			TimeoutSeconds: oneSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.fleetmembernamespacedresources.validating",
@@ -453,7 +458,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 			AdmissionReviewVersions: admissionReviewVersions,
 			NamespaceSelector:       fleetMemberNamespaceSelector,
 			Rules:                   namespacedResourcesRules,
-			TimeoutSeconds:          webhookTimeoutSeconds,
+			TimeoutSeconds:          oneSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.fleetsystemnamespacedresources.validating",
@@ -463,7 +468,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 			AdmissionReviewVersions: admissionReviewVersions,
 			NamespaceSelector:       fleetSystemNamespaceSelector,
 			Rules:                   namespacedResourcesRules,
-			TimeoutSeconds:          webhookTimeoutSeconds,
+			TimeoutSeconds:          oneSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.kubenamespacedresources.validating",
@@ -473,7 +478,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 			AdmissionReviewVersions: admissionReviewVersions,
 			NamespaceSelector:       kubeNamespaceSelector,
 			Rules:                   namespacedResourcesRules,
-			TimeoutSeconds:          webhookTimeoutSeconds,
+			TimeoutSeconds:          oneSecondWebhookTimeout,
 		},
 		{
 			Name:                    "fleet.namespace.validating",
@@ -487,7 +492,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 					Rule:       createRule([]string{corev1.SchemeGroupVersion.Group}, []string{corev1.SchemeGroupVersion.Version}, []string{namespaceResourceName}, &clusterScope),
 				},
 			},
-			TimeoutSeconds: webhookTimeoutSeconds,
+			TimeoutSeconds: oneSecondWebhookTimeout,
 		},
 	}
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -100,7 +100,8 @@ const (
 var (
 	admissionReviewVersions = []string{admv1.SchemeGroupVersion.Version, admv1beta1.SchemeGroupVersion.Version}
 
-	failPolicy            = admv1.Ignore
+	ignoreFailurePolicy   = admv1.Ignore
+	failFailurePolicy     = admv1.Fail
 	sideEffortsNone       = admv1.SideEffectClassNone
 	namespacedScope       = admv1.NamespacedScope
 	clusterScope          = admv1.ClusterScope
@@ -224,7 +225,7 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 		{
 			Name:                    "fleet.pod.validating",
 			ClientConfig:            w.createClientConfig(pod.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &failFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{
@@ -235,12 +236,11 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule([]string{corev1.SchemeGroupVersion.Group}, []string{corev1.SchemeGroupVersion.Version}, []string{podResourceName}, &namespacedScope),
 				},
 			},
-			TimeoutSeconds: webhookTimeoutSeconds,
 		},
 		{
 			Name:                    "fleet.clusterresourceplacementv1alpha1.validating",
 			ClientConfig:            w.createClientConfig(clusterresourceplacement.V1Alpha1CRPValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &failFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{
@@ -252,12 +252,11 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule([]string{fleetv1alpha1.GroupVersion.Group}, []string{fleetv1alpha1.GroupVersion.Version}, []string{fleetv1alpha1.ClusterResourcePlacementResource}, &clusterScope),
 				},
 			},
-			TimeoutSeconds: webhookTimeoutSeconds,
 		},
 		{
 			Name:                    "fleet.clusterresourceplacementv1beta1.validating",
 			ClientConfig:            w.createClientConfig(clusterresourceplacement.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &failFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{
@@ -269,12 +268,11 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule([]string{placementv1beta1.GroupVersion.Group}, []string{placementv1beta1.GroupVersion.Version}, []string{placementv1beta1.ClusterResourcePlacementResource}, &clusterScope),
 				},
 			},
-			TimeoutSeconds: webhookTimeoutSeconds,
 		},
 		{
 			Name:                    "fleet.replicaset.validating",
 			ClientConfig:            w.createClientConfig(replicaset.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &failFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{
@@ -285,7 +283,6 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule([]string{appsv1.SchemeGroupVersion.Group}, []string{appsv1.SchemeGroupVersion.Version}, []string{replicaSetResourceName}, &namespacedScope),
 				},
 			},
-			TimeoutSeconds: webhookTimeoutSeconds,
 		},
 	}
 
@@ -409,7 +406,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 		{
 			Name:                    "fleet.customresourcedefinition.validating",
 			ClientConfig:            w.createClientConfig(fleetresourcehandler.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &ignoreFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{
@@ -423,7 +420,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 		{
 			Name:                    "fleet.membercluster.validating",
 			ClientConfig:            w.createClientConfig(fleetresourcehandler.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &ignoreFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{
@@ -437,7 +434,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 		{
 			Name:                    "fleet.v1alpha1.membercluster.validating",
 			ClientConfig:            w.createClientConfig(fleetresourcehandler.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &ignoreFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{
@@ -451,7 +448,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 		{
 			Name:                    "fleet.fleetmembernamespacedresources.validating",
 			ClientConfig:            w.createClientConfig(fleetresourcehandler.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &ignoreFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			NamespaceSelector:       fleetMemberNamespaceSelector,
@@ -461,7 +458,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 		{
 			Name:                    "fleet.fleetsystemnamespacedresources.validating",
 			ClientConfig:            w.createClientConfig(fleetresourcehandler.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &ignoreFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			NamespaceSelector:       fleetSystemNamespaceSelector,
@@ -471,7 +468,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 		{
 			Name:                    "fleet.kubenamespacedresources.validating",
 			ClientConfig:            w.createClientConfig(fleetresourcehandler.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &ignoreFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			NamespaceSelector:       kubeNamespaceSelector,
@@ -481,7 +478,7 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 		{
 			Name:                    "fleet.namespace.validating",
 			ClientConfig:            w.createClientConfig(fleetresourcehandler.ValidationPath),
-			FailurePolicy:           &failPolicy,
+			FailurePolicy:           &ignoreFailurePolicy,
 			SideEffects:             &sideEffortsNone,
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

**fleet guard rail validating webhook configuration:**
<img width="790" alt="image" src="https://github.com/Azure/fleet/assets/17449572/302dd2f3-a384-426d-a186-2f79ef8819c4">

**fleet validating webhook configuration:**
<img width="836" alt="image" src="https://github.com/Azure/fleet/assets/17449572/940367ed-bf29-4d0c-bd0d-fb91451f991e">


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
