### PR TITLE
test: ITs for taints & tolerations plugin

### DIFF
--- a/test/scheduler/actuals_test.go
+++ b/test/scheduler/actuals_test.go
@@ -462,7 +462,7 @@ func pickNPolicySnapshotStatusUpdatedActual(
 			cmpopts.SortSlices(lessFuncClusterDecision),
 			cmpopts.EquateEmpty(),
 			// for PickN ignore unselected clusters since there are two possible states for policy snapshot status based on whether status update is successful.
-			cmpopts.IgnoreSliceElements(ignoreUnSelectedClusterDecision),
+			cmpopts.IgnoreSliceElements(ignoreUnselectedClusterDecision),
 		); diff != "" {
 			return fmt.Errorf("policy snapshot status cluster decisions (-got, +want): %s", diff)
 		}

--- a/test/scheduler/actuals_test.go
+++ b/test/scheduler/actuals_test.go
@@ -420,6 +420,7 @@ func pickNPolicySnapshotStatusUpdatedActual(
 	picked, notPicked, filtered []string,
 	scoreByCluster map[string]*placementv1beta1.ClusterScore,
 	policySnapshotName string,
+	opts []cmp.Option,
 ) func() error {
 	return func() error {
 		policySnapshot := &placementv1beta1.ClusterSchedulingPolicySnapshot{}
@@ -458,11 +459,7 @@ func pickNPolicySnapshotStatusUpdatedActual(
 		}
 		if diff := cmp.Diff(
 			policySnapshot.Status.ClusterDecisions, wantClusterDecisions,
-			ignoreClusterDecisionReasonField,
-			cmpopts.SortSlices(lessFuncClusterDecision),
-			cmpopts.EquateEmpty(),
-			// for PickN ignore unselected clusters since there are two possible states for policy snapshot status based on whether status update is successful.
-			cmpopts.IgnoreSliceElements(ignoreUnselectedClusterDecision),
+			opts...,
 		); diff != "" {
 			return fmt.Errorf("policy snapshot status cluster decisions (-got, +want): %s", diff)
 		}

--- a/test/scheduler/actuals_test.go
+++ b/test/scheduler/actuals_test.go
@@ -461,6 +461,8 @@ func pickNPolicySnapshotStatusUpdatedActual(
 			ignoreClusterDecisionReasonField,
 			cmpopts.SortSlices(lessFuncClusterDecision),
 			cmpopts.EquateEmpty(),
+			// for PickN ignore unselected clusters since there are two possible states for policy snapshot status based on whether status update is successful.
+			cmpopts.IgnoreSliceElements(ignoreUnSelectedClusterDecision),
 		); diff != "" {
 			return fmt.Errorf("policy snapshot status cluster decisions (-got, +want): %s", diff)
 		}

--- a/test/scheduler/pickall_integration_test.go
+++ b/test/scheduler/pickall_integration_test.go
@@ -29,7 +29,7 @@ var _ = Describe("scheduling CRPs with no scheduling policy specified", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot.
-			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName)
+			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -84,10 +84,10 @@ var _ = Describe("scheduling CRPs with no scheduling policy specified", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot.
-			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName)
+			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName, nil)
 
 			// Create a new member cluster.
-			createMemberCluster(newUnhealthyMemberClusterName)
+			createMemberCluster(newUnhealthyMemberClusterName, nil)
 
 			// Mark this cluster as healthy.
 			markClusterAsHealthy(newUnhealthyMemberClusterName)
@@ -131,10 +131,10 @@ var _ = Describe("scheduling CRPs with no scheduling policy specified", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot.
-			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName)
+			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName, nil)
 
 			// Create a new member cluster.
-			createMemberCluster(newUnhealthyMemberClusterName)
+			createMemberCluster(newUnhealthyMemberClusterName, nil)
 
 			// Mark this cluster as healthy.
 			markClusterAsHealthy(newUnhealthyMemberClusterName)
@@ -175,7 +175,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickAll placement type, along with its associated policy snapshot.
-			createPickAllCRPWithPolicySnapshot(crpName, nil, policySnapshotName)
+			createPickAllCRPWithPolicySnapshot(crpName, nil, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -253,7 +253,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 					},
 				},
 			}
-			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName)
+			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -338,7 +338,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 					},
 				},
 			}
-			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName)
+			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -431,7 +431,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 					},
 				},
 			}
-			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName1)
+			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName1, nil)
 
 			// Verify that bindings have been created as expected.
 			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(wantTargetClusters1, zeroScoreByCluster, crpName, policySnapshotName1)
@@ -560,7 +560,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 					},
 				},
 			}
-			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName)
+			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {

--- a/test/scheduler/pickall_integration_test.go
+++ b/test/scheduler/pickall_integration_test.go
@@ -2,7 +2,6 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
-
 package tests
 
 // This test suite features a number of test cases which cover the workflow of scheduling CRPs
@@ -175,7 +174,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickAll placement type, along with its associated policy snapshot.
-			createPickAllCRPWithPolicySnapshot(crpName, nil, policySnapshotName, nil)
+			createPickAllCRPWithPolicySnapshot(crpName, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -231,20 +230,23 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickAll placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										envLabel: "prod",
-									},
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      regionLabel,
-											Operator: metav1.LabelSelectorOpIn,
-											Values:   []string{"east", "west"},
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType: placementv1beta1.PickAllPlacementType,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											envLabel: "prod",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      regionLabel,
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"east", "west"},
+											},
 										},
 									},
 								},
@@ -253,7 +255,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 					},
 				},
 			}
-			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName, nil)
+			createPickAllCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -309,26 +311,29 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickAll placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										envLabel: "canary",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType: placementv1beta1.PickAllPlacementType,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											envLabel: "canary",
+										},
 									},
 								},
-							},
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      regionLabel,
-											Operator: metav1.LabelSelectorOpNotIn,
-											Values: []string{
-												"east",
-												"central",
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      regionLabel,
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values: []string{
+													"east",
+													"central",
+												},
 											},
 										},
 									},
@@ -338,7 +343,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 					},
 				},
 			}
-			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName, nil)
+			createPickAllCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -406,22 +411,25 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickAll placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										envLabel: "canary",
-									},
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      regionLabel,
-											Operator: metav1.LabelSelectorOpIn,
-											Values: []string{
-												"east",
-												"west",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType: placementv1beta1.PickAllPlacementType,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											envLabel: "canary",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      regionLabel,
+												Operator: metav1.LabelSelectorOpIn,
+												Values: []string{
+													"east",
+													"west",
+												},
 											},
 										},
 									},
@@ -431,7 +439,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 					},
 				},
 			}
-			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName1, nil)
+			createPickAllCRPWithPolicySnapshot(crpName, policySnapshotName1, policy)
 
 			// Verify that bindings have been created as expected.
 			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(wantTargetClusters1, zeroScoreByCluster, crpName, policySnapshotName1)
@@ -442,7 +450,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 			markBindingsAsBoundForClusters(crpName, boundClusters)
 
 			// Update the CRP with a new affinity.
-			affinity = &placementv1beta1.Affinity{
+			affinity := &placementv1beta1.Affinity{
 				ClusterAffinity: &placementv1beta1.ClusterAffinity{
 					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
 						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
@@ -530,27 +538,30 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										envLabel: "wonderland",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType: placementv1beta1.PickAllPlacementType,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											envLabel: "wonderland",
+										},
 									},
 								},
-							},
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      regionLabel,
-											Operator: metav1.LabelSelectorOpNotIn,
-											Values: []string{
-												"east",
-												"central",
-												"west",
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      regionLabel,
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values: []string{
+													"east",
+													"central",
+													"west",
+												},
 											},
 										},
 									},
@@ -560,7 +571,7 @@ var _ = Describe("scheduling CRPs of the PickAll placement type", func() {
 					},
 				},
 			}
-			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName, nil)
+			createPickAllCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {

--- a/test/scheduler/pickall_integration_test.go
+++ b/test/scheduler/pickall_integration_test.go
@@ -2,6 +2,7 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
+
 package tests
 
 // This test suite features a number of test cases which cover the workflow of scheduling CRPs

--- a/test/scheduler/pickn_integration_test.go
+++ b/test/scheduler/pickn_integration_test.go
@@ -2,7 +2,6 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
-
 package tests
 
 // This test suite features a number of test cases which cover the workflow of scheduling CRPs
@@ -53,7 +52,11 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName, nil)
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+			}
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -114,7 +117,11 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName, nil)
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+			}
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -158,7 +165,11 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName, nil)
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+			}
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -210,21 +221,25 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "east",
-									},
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      envLabel,
-											Operator: metav1.LabelSelectorOpIn,
-											Values: []string{
-												"prod",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "east",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      envLabel,
+												Operator: metav1.LabelSelectorOpIn,
+												Values: []string{
+													"prod",
+												},
 											},
 										},
 									},
@@ -234,7 +249,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -293,37 +308,41 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "east",
-									},
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      envLabel,
-											Operator: metav1.LabelSelectorOpIn,
-											Values: []string{
-												"prod",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "east",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      envLabel,
+												Operator: metav1.LabelSelectorOpIn,
+												Values: []string{
+													"prod",
+												},
 											},
 										},
 									},
 								},
-							},
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "west",
-									},
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      envLabel,
-											Operator: metav1.LabelSelectorOpNotIn,
-											Values: []string{
-												"prod",
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "west",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      envLabel,
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values: []string{
+													"prod",
+												},
 											},
 										},
 									},
@@ -333,7 +352,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -409,22 +428,26 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
-						{
-							Weight: 10,
-							Preference: placementv1beta1.ClusterSelectorTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "central",
-									},
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      envLabel,
-											Operator: metav1.LabelSelectorOpIn,
-											Values: []string{
-												"prod",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
+							{
+								Weight: 10,
+								Preference: placementv1beta1.ClusterSelectorTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "central",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      envLabel,
+												Operator: metav1.LabelSelectorOpIn,
+												Values: []string{
+													"prod",
+												},
 											},
 										},
 									},
@@ -434,7 +457,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -513,41 +536,45 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
-						{
-							Weight: 10,
-							Preference: placementv1beta1.ClusterSelectorTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "central",
-									},
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      envLabel,
-											Operator: metav1.LabelSelectorOpIn,
-											Values: []string{
-												"prod",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
+							{
+								Weight: 10,
+								Preference: placementv1beta1.ClusterSelectorTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "central",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      envLabel,
+												Operator: metav1.LabelSelectorOpIn,
+												Values: []string{
+													"prod",
+												},
 											},
 										},
 									},
 								},
 							},
-						},
-						{
-							Weight: 20,
-							Preference: placementv1beta1.ClusterSelectorTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "east",
-									},
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      envLabel,
-											Operator: metav1.LabelSelectorOpIn,
-											Values: []string{
-												"canary",
+							{
+								Weight: 20,
+								Preference: placementv1beta1.ClusterSelectorTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "east",
+										},
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      envLabel,
+												Operator: metav1.LabelSelectorOpIn,
+												Values: []string{
+													"canary",
+												},
 											},
 										},
 									},
@@ -557,7 +584,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -643,14 +670,18 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       regionLabel,
-					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				TopologySpreadConstraints: []placementv1beta1.TopologySpreadConstraint{
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       regionLabel,
+						WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -762,19 +793,23 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       regionLabel,
-					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
-				},
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       envLabel,
-					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				TopologySpreadConstraints: []placementv1beta1.TopologySpreadConstraint{
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       regionLabel,
+						WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+					},
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       envLabel,
+						WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -863,14 +898,18 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       regionLabel,
-					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				TopologySpreadConstraints: []placementv1beta1.TopologySpreadConstraint{
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       regionLabel,
+						WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -991,19 +1030,23 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       regionLabel,
-					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
-				},
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       envLabel,
-					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				TopologySpreadConstraints: []placementv1beta1.TopologySpreadConstraint{
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       regionLabel,
+						WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+					},
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       envLabel,
+						WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1090,18 +1133,22 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      regionLabel,
-											Operator: metav1.LabelSelectorOpNotIn,
-											Values: []string{
-												"west",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      regionLabel,
+												Operator: metav1.LabelSelectorOpNotIn,
+												Values: []string{
+													"west",
+												},
 											},
 										},
 									},
@@ -1110,15 +1157,15 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 						},
 					},
 				},
-			}
-			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       regionLabel,
-					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+				TopologySpreadConstraints: []placementv1beta1.TopologySpreadConstraint{
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       regionLabel,
+						WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1231,30 +1278,34 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
-						{
-							Weight: 30,
-							Preference: placementv1beta1.ClusterSelectorTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "east",
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
+							{
+								Weight: 30,
+								Preference: placementv1beta1.ClusterSelectorTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "east",
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			}
-			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       envLabel,
-					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+				TopologySpreadConstraints: []placementv1beta1.TopologySpreadConstraint{
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       envLabel,
+						WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1357,46 +1408,50 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			affinity := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
-						{
-							Weight: 40,
-							Preference: placementv1beta1.ClusterSelectorTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "east",
-									},
-								},
-							},
-						},
-					},
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
 							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										envLabel: "prod",
+								Weight: 40,
+								Preference: placementv1beta1.ClusterSelectorTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "east",
+										},
+									},
+								},
+							},
+						},
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											envLabel: "prod",
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			}
-			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
-				{
-					MaxSkew:           ptr.To(int32(2)),
-					TopologyKey:       envLabel,
-					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+				TopologySpreadConstraints: []placementv1beta1.TopologySpreadConstraint{
+					{
+						MaxSkew:           ptr.To(int32(2)),
+						TopologyKey:       envLabel,
+						WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+					},
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       regionLabel,
+						WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+					},
 				},
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       regionLabel,
-					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
-				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1464,7 +1519,11 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClustersBefore, nil, nil, policySnapshotName, nil)
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClustersBefore,
+			}
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 
 			// Verify that scheduling has been completed.
 			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, int(numOfClustersBefore))
@@ -1551,7 +1610,11 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClustersBefore, nil, nil, policySnapshotName, nil)
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClustersBefore,
+			}
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 
 			// Verify that scheduling has been completed.
 			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, int(numOfClustersBefore))
@@ -1731,46 +1794,50 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			affinityBefore := &placementv1beta1.Affinity{
-				ClusterAffinity: &placementv1beta1.ClusterAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
-						{
-							Weight: 40,
-							Preference: placementv1beta1.ClusterSelectorTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										regionLabel: "east",
-									},
-								},
-							},
-						},
-					},
-					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
-						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+			policy := &placementv1beta1.PlacementPolicy{
+				PlacementType:    placementv1beta1.PickNPlacementType,
+				NumberOfClusters: &numOfClusters,
+				Affinity: &placementv1beta1.Affinity{
+					ClusterAffinity: &placementv1beta1.ClusterAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []placementv1beta1.PreferredClusterSelector{
 							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										envLabel: "prod",
+								Weight: 40,
+								Preference: placementv1beta1.ClusterSelectorTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											regionLabel: "east",
+										},
+									},
+								},
+							},
+						},
+						RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+							ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											envLabel: "prod",
+										},
 									},
 								},
 							},
 						},
 					},
 				},
-			}
-			topologySpreadConstraintsBefore := []placementv1beta1.TopologySpreadConstraint{
-				{
-					MaxSkew:           ptr.To(int32(2)),
-					TopologyKey:       envLabel,
-					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+				TopologySpreadConstraints: []placementv1beta1.TopologySpreadConstraint{
+					{
+						MaxSkew:           ptr.To(int32(2)),
+						TopologyKey:       envLabel,
+						WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
+					},
+					{
+						MaxSkew:           ptr.To(int32(1)),
+						TopologyKey:       regionLabel,
+						WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+					},
 				},
-				{
-					MaxSkew:           ptr.To(int32(1)),
-					TopologyKey:       regionLabel,
-					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
-				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinityBefore, topologySpreadConstraintsBefore, policySnapshotNameBefore, nil)
+			createPickNCRPWithPolicySnapshot(crpName, policySnapshotNameBefore, policy)
 
 			// Verify that scheduling has been completed.
 			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, len(wantPickedClustersBefore))

--- a/test/scheduler/pickn_integration_test.go
+++ b/test/scheduler/pickn_integration_test.go
@@ -53,7 +53,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -114,7 +114,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -158,7 +158,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, nil, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -234,7 +234,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -333,7 +333,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -434,7 +434,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -557,7 +557,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					},
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -650,7 +650,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -774,7 +774,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -870,7 +870,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1003,7 +1003,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1118,7 +1118,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1254,7 +1254,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					WhenUnsatisfiable: placementv1beta1.ScheduleAnyway,
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1396,7 +1396,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, topologySpreadConstraints, policySnapshotName, nil)
 		})
 
 		It("should add scheduler cleanup finalizer to the CRP", func() {
@@ -1464,7 +1464,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClustersBefore, nil, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClustersBefore, nil, nil, policySnapshotName, nil)
 
 			// Verify that scheduling has been completed.
 			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, int(numOfClustersBefore))
@@ -1551,7 +1551,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
 			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
-			createPickNCRPWithPolicySnapshot(crpName, numOfClustersBefore, nil, nil, policySnapshotName)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClustersBefore, nil, nil, policySnapshotName, nil)
 
 			// Verify that scheduling has been completed.
 			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, int(numOfClustersBefore))
@@ -1770,7 +1770,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
 				},
 			}
-			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinityBefore, topologySpreadConstraintsBefore, policySnapshotNameBefore)
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinityBefore, topologySpreadConstraintsBefore, policySnapshotNameBefore, nil)
 
 			// Verify that scheduling has been completed.
 			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, len(wantPickedClustersBefore))

--- a/test/scheduler/pickn_integration_test.go
+++ b/test/scheduler/pickn_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,6 +21,14 @@ import (
 	"k8s.io/utils/ptr"
 
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+var (
+	pickNCmpOpts = []cmp.Option{
+		ignoreClusterDecisionReasonField,
+		cmpopts.SortSlices(lessFuncClusterDecision),
+		cmpopts.EquateEmpty(),
+	}
 )
 
 var _ = Describe("scheduling CRPs of the PickN placement type", func() {
@@ -78,7 +88,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, zeroScoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, zeroScoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -143,7 +153,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -185,7 +195,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), []string{}, []string{}, []string{}, zeroScoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), []string{}, []string{}, []string{}, zeroScoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -271,7 +281,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -374,7 +384,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -479,7 +489,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -606,7 +616,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -703,7 +713,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -831,7 +841,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -931,7 +941,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -1068,7 +1078,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -1187,7 +1197,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -1327,7 +1337,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -1473,7 +1483,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -1570,7 +1580,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClustersAfter, zeroScoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClustersAfter, zeroScoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -1661,7 +1671,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClustersAfter, zeroScoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClustersAfter, zeroScoreByCluster, policySnapshotName, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -1894,7 +1904,7 @@ var _ = Describe("scheduling CRPs of the PickN placement type", func() {
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClustersAfter, scoreByClusterAfter, policySnapshotNameAfter)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClustersAfter, scoreByClusterAfter, policySnapshotNameAfter, pickNCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})

--- a/test/scheduler/pickn_integration_test.go
+++ b/test/scheduler/pickn_integration_test.go
@@ -2,6 +2,7 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
+
 package tests
 
 // This test suite features a number of test cases which cover the workflow of scheduling CRPs

--- a/test/scheduler/tainttoleration_integration_test.go
+++ b/test/scheduler/tainttoleration_integration_test.go
@@ -2,6 +2,7 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
+
 package tests
 
 import (

--- a/test/scheduler/tainttoleration_integration_test.go
+++ b/test/scheduler/tainttoleration_integration_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,6 +19,16 @@ import (
 
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+var (
+	taintTolerationCmpOpts = []cmp.Option{
+		ignoreClusterDecisionReasonField,
+		cmpopts.SortSlices(lessFuncClusterDecision),
+		cmpopts.EquateEmpty(),
+		// for PickN ignore unselected clusters since there are two possible states for policy snapshot status based on whether status update is successful.
+		cmpopts.IgnoreSliceElements(ignoreUnselectedClusterDecision),
+	}
 )
 
 var _ = Describe("scheduling CRPs on member clusters with taints & tolerations", func() {
@@ -341,7 +353,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, []string{}, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, []string{}, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName, taintTolerationCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -364,7 +376,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, wantPickedClustersAfter, []string{}, wantFilteredClustersAfter, zeroScoreByCluster, policySnapshotNameAfter)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, wantPickedClustersAfter, []string{}, wantFilteredClustersAfter, zeroScoreByCluster, policySnapshotNameAfter, taintTolerationCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -559,7 +571,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, taintTolerationCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -612,7 +624,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClusters, scoreByClusterAfter, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClusters, scoreByClusterAfter, policySnapshotName, taintTolerationCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -727,7 +739,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName, taintTolerationCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -780,7 +792,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClusters, scoreByClusterAfter, policySnapshotName)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClusters, scoreByClusterAfter, policySnapshotName, taintTolerationCmpOpts)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})

--- a/test/scheduler/tainttoleration_integration_test.go
+++ b/test/scheduler/tainttoleration_integration_test.go
@@ -1,0 +1,702 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+package tests
+
+import (
+	"fmt"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
+	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+var _ = Describe("scheduling CRPs on member clusters with taints & tolerations", func() {
+	// This is a serial test as adding taints can affect other tests
+	Context("pickFixed, valid target clusters with taints", Serial, Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		policySnapshotName := fmt.Sprintf(policySnapshotNameTemplate, crpName, 1)
+		targetClusters := []string{memberCluster1EastProd, memberCluster4CentralProd, memberCluster6WestProd}
+		taintClusters := []string{memberCluster1EastProd, memberCluster4CentralProd, memberCluster6WestProd}
+
+		BeforeAll(func() {
+			// Ensure that no bindings have been created so far.
+			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+
+			// Add taints to some member clusters 1, 4, 6 from all regions.
+			addTaintsToMemberClusters(taintClusters, buildTaints(taintClusters))
+
+			// Create the CRP and its associated policy snapshot.
+			createPickFixedCRPWithPolicySnapshot(crpName, targetClusters, policySnapshotName)
+		})
+
+		It("should add scheduler cleanup finalizer to the CRP", func() {
+			finalizerAddedActual := crpSchedulerFinalizerAddedActual(crpName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add scheduler cleanup finalizer to CRP")
+		})
+
+		It("should create scheduled bindings for valid target clusters", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(targetClusters, nilScoreByCluster, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+		})
+
+		It("should report status correctly", func() {
+			statusUpdatedActual := pickFixedPolicySnapshotStatusUpdatedActual(targetClusters, []string{}, policySnapshotName)
+			Eventually(statusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report correct policy snapshot status")
+			Consistently(statusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report correct policy snapshot status")
+		})
+
+		AfterAll(func() {
+			// Remove taints
+			removeTaintsFromMemberClusters(taintClusters)
+			// Delete the CRP.
+			ensureCRPAndAllRelatedResourcesDeletion(crpName)
+		})
+	})
+
+	// This is a serial test as adding taints can affect other tests.
+	Context("pick all valid cluster with no taints, ignore valid cluster with taints, CRP with no matching toleration", Serial, Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		policySnapshotName := fmt.Sprintf(policySnapshotNameTemplate, crpName, 1)
+		taintClusters := []string{memberCluster1EastProd, memberCluster4CentralProd, memberCluster7WestCanary}
+		selectedClusters := []string{memberCluster2EastProd, memberCluster3EastCanary, memberCluster5CentralProd, memberCluster6WestProd}
+		unSelectedClusters := []string{memberCluster1EastProd, memberCluster4CentralProd, memberCluster7WestCanary, memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
+
+		BeforeAll(func() {
+			// Ensure that no bindings have been created so far.
+			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+
+			// Add taints to some member clusters 1, 4, 7 from all regions.
+			addTaintsToMemberClusters(taintClusters, buildTaints(taintClusters))
+
+			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot, with no tolerations specified.
+			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName, nil)
+		})
+
+		It("should add scheduler cleanup finalizer to the CRP", func() {
+			finalizerAddedActual := crpSchedulerFinalizerAddedActual(crpName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add scheduler cleanup finalizer to CRP")
+		})
+
+		It("should create scheduled bindings for all healthy clusters with no taints", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(selectedClusters, zeroScoreByCluster, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+		})
+
+		It("should not create any binding for unhealthy clusters, healthy cluster with taints", func() {
+			noBindingsCreatedActual := noBindingsCreatedForClustersActual(unSelectedClusters, crpName)
+			Eventually(noBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+		})
+
+		It("should report status correctly", func() {
+			statusUpdatedActual := pickAllPolicySnapshotStatusUpdatedActual(selectedClusters, unSelectedClusters, policySnapshotName)
+			Eventually(statusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update status")
+			Consistently(statusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to update status")
+		})
+
+		AfterAll(func() {
+			// Remove taints
+			removeTaintsFromMemberClusters(taintClusters)
+			// Delete the CRP.
+			ensureCRPAndAllRelatedResourcesDeletion(crpName)
+		})
+	})
+
+	// This is a serial test as adding taints, tolerations can affect other tests.
+	Context("pick all valid cluster with tolerated taints, ignore valid clusters with taints, CRP has some matching tolerations on creation", Serial, Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		policySnapshotName := fmt.Sprintf(policySnapshotNameTemplate, crpName, 1)
+		taintClusters := []string{memberCluster1EastProd, memberCluster2EastProd, memberCluster6WestProd}
+		tolerateClusters := []string{memberCluster1EastProd, memberCluster2EastProd}
+		selectedClusters := []string{memberCluster1EastProd, memberCluster2EastProd}
+		unSelectedClusters := []string{memberCluster3EastCanary, memberCluster4CentralProd, memberCluster5CentralProd, memberCluster6WestProd, memberCluster7WestCanary, memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
+
+		BeforeAll(func() {
+			// Ensure that no bindings have been created so far.
+			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+
+			// Add taints to some member clusters 1, 2, 6 from all regions.
+			addTaintsToMemberClusters(taintClusters, buildTaints(taintClusters))
+
+			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot, with no tolerations.
+			// Add tolerations for some clusters 1, 2.
+			affinity := &placementv1beta1.Affinity{
+				ClusterAffinity: &placementv1beta1.ClusterAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										envLabel: "prod",
+									},
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      regionLabel,
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"east", "west"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			// Create CRP with tolerations for clusters 1,2.
+			createPickAllCRPWithPolicySnapshot(crpName, affinity, policySnapshotName, buildTolerations(tolerateClusters))
+		})
+
+		It("should add scheduler cleanup finalizer to the CRP", func() {
+			finalizerAddedActual := crpSchedulerFinalizerAddedActual(crpName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add scheduler cleanup finalizer to CRP")
+		})
+
+		It("should create scheduled bindings for clusters with tolerated taints", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(selectedClusters, zeroScoreByCluster, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+		})
+
+		It("should not create any binding for clusters with untolerated taints", func() {
+			noBindingsCreatedActual := noBindingsCreatedForClustersActual(unSelectedClusters, crpName)
+			Eventually(noBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+		})
+
+		It("should report status correctly", func() {
+			statusUpdatedActual := pickAllPolicySnapshotStatusUpdatedActual(selectedClusters, unSelectedClusters, policySnapshotName)
+			Eventually(statusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update status")
+			Consistently(statusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to update status")
+		})
+
+		AfterAll(func() {
+			// Remove taints
+			removeTaintsFromMemberClusters(taintClusters)
+			// Delete the CRP.
+			ensureCRPAndAllRelatedResourcesDeletion(crpName)
+		})
+	})
+
+	// This is a serial test as adding taints, tolerations can affect other tests.
+	Context("pick N clusters with affinity specified, ignore valid clusters with taints, CRP has some matching tolerations after update", Serial, Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		policySnapshotName1 := fmt.Sprintf(policySnapshotNameTemplate, crpName, 1)
+		policySnapshotName2 := fmt.Sprintf(policySnapshotNameTemplate, crpName, 2)
+		numOfClusters := int32(2) // Less than the number of clusters available (7) in the fleet.
+		taintClusters := []string{memberCluster1EastProd, memberCluster2EastProd}
+		tolerateClusters := []string{memberCluster1EastProd, memberCluster2EastProd}
+		// The scheduler is designed to produce only deterministic decisions; if there are no
+		// comparable scores available for selected clusters, the scheduler will rank the clusters
+		// by their names.
+		wantPickedClusters := []string{memberCluster1EastProd, memberCluster2EastProd}
+		wantFilteredClusters1 := []string{memberCluster1EastProd, memberCluster2EastProd, memberCluster3EastCanary, memberCluster4CentralProd, memberCluster5CentralProd, memberCluster6WestProd, memberCluster7WestCanary, memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
+		wantFilteredClusters2 := []string{memberCluster3EastCanary, memberCluster4CentralProd, memberCluster5CentralProd, memberCluster6WestProd, memberCluster7WestCanary, memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
+
+		BeforeAll(func() {
+			// Ensure that no bindings have been created so far.
+			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+
+			// Add taints to some member clusters 1, 2.
+			addTaintsToMemberClusters(taintClusters, buildTaints(taintClusters))
+
+			affinity := &placementv1beta1.Affinity{
+				ClusterAffinity: &placementv1beta1.ClusterAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &placementv1beta1.ClusterSelector{
+						ClusterSelectorTerms: []placementv1beta1.ClusterSelectorTerm{
+							{
+								LabelSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										regionLabel: "east",
+									},
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      envLabel,
+											Operator: metav1.LabelSelectorOpIn,
+											Values: []string{
+												"prod",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Create a CRP of the PickN placement type, along with its associated policy snapshot, no tolerations specified.
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, affinity, nil, policySnapshotName1, nil)
+		})
+
+		It("should add scheduler cleanup finalizer to the CRP", func() {
+			finalizerAddedActual := crpSchedulerFinalizerAddedActual(crpName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add scheduler cleanup finalizer to CRP")
+		})
+
+		It("should create N bindings", func() {
+			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, 0)
+			Eventually(hasNScheduledOrBoundBindingsActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create N bindings")
+			Consistently(hasNScheduledOrBoundBindingsActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create N bindings")
+		})
+
+		It("should create scheduled bindings for selected clusters", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual([]string{}, zeroScoreByCluster, crpName, policySnapshotName1)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+		})
+
+		It("should report status correctly", func() {
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, []string{}, []string{}, wantFilteredClusters1, zeroScoreByCluster, policySnapshotName1)
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
+			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
+		})
+
+		It("update CRP with new tolerations", func() {
+			// Update CRP with tolerations for clusters 1,2.
+			updatePickNCRPWithTolerations(crpName, buildTolerations(tolerateClusters), policySnapshotName1, policySnapshotName2)
+		})
+
+		It("should create N bindings", func() {
+			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, 2)
+			Eventually(hasNScheduledOrBoundBindingsActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create N bindings")
+			Consistently(hasNScheduledOrBoundBindingsActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create N bindings")
+		})
+
+		It("should create scheduled bindings for selected clusters", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual([]string{}, zeroScoreByCluster, crpName, policySnapshotName2)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+		})
+
+		It("should report status correctly", func() {
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, wantPickedClusters, []string{}, wantFilteredClusters2, zeroScoreByCluster, policySnapshotName2)
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
+			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
+		})
+
+		AfterAll(func() {
+			// Remove taints
+			removeTaintsFromMemberClusters(taintClusters)
+			// Delete the CRP.
+			ensureCRPAndAllRelatedResourcesDeletion(crpName)
+		})
+	})
+
+	// This is a serial test as adding a new member cluster may interrupt other test cases.
+	Context("pickAll, add a new healthy cluster with taint", Serial, Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		policySnapshotName := fmt.Sprintf(policySnapshotNameTemplate, crpName, 1)
+		// Prepare a new cluster to avoid interrupting other concurrently running test cases.
+		newUnhealthyMemberClusterName := fmt.Sprintf(provisionalClusterNameTemplate, GinkgoParallelProcess())
+
+		BeforeAll(func() {
+			// Ensure that no bindings have been created so far.
+			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+
+			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot.
+			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName, nil)
+
+			// Create a new member cluster.
+			createMemberCluster(newUnhealthyMemberClusterName, buildTaints([]string{newUnhealthyMemberClusterName}))
+
+			// Mark this cluster as healthy.
+			markClusterAsHealthy(newUnhealthyMemberClusterName)
+		})
+
+		It("should create scheduled bindings for existing clusters, and exclude new cluster with taint", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(healthyClusters, zeroScoreByCluster, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+		})
+
+		AfterAll(func() {
+			// Delete the CRP.
+			ensureCRPAndAllRelatedResourcesDeletion(crpName)
+			// Delete the provisional cluster.
+			ensureProvisionalClusterDeletion(newUnhealthyMemberClusterName)
+		})
+	})
+
+	// This is a serial test as adding a new member cluster may interrupt other test cases.
+	Context("pickAll, add a new healthy cluster with taint and matching toleration", Serial, Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		policySnapshotName := fmt.Sprintf(policySnapshotNameTemplate, crpName, 1)
+		// Prepare a new cluster to avoid interrupting other concurrently running test cases.
+		newUnhealthyMemberClusterName := fmt.Sprintf(provisionalClusterNameTemplate, GinkgoParallelProcess())
+		updatedHealthyClusters := healthyClusters
+		updatedHealthyClusters = append(updatedHealthyClusters, newUnhealthyMemberClusterName)
+		// Copy the map to avoid interrupting other concurrently running test cases.
+		updatedZeroScoreByCluster := make(map[string]*placementv1beta1.ClusterScore)
+		for k, v := range zeroScoreByCluster {
+			updatedZeroScoreByCluster[k] = v
+		}
+		updatedZeroScoreByCluster[newUnhealthyMemberClusterName] = &zeroScore
+
+		BeforeAll(func() {
+			// Ensure that no bindings have been created so far.
+			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+
+			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot, and toleration for new cluster.
+			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName, buildTolerations([]string{newUnhealthyMemberClusterName}))
+
+			// Create a new member cluster.
+			createMemberCluster(newUnhealthyMemberClusterName, buildTaints([]string{newUnhealthyMemberClusterName}))
+
+			// Mark this cluster as healthy.
+			markClusterAsHealthy(newUnhealthyMemberClusterName)
+		})
+
+		It("should create scheduled bindings for the newly recovered cluster with tolerated taint", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(updatedHealthyClusters, updatedZeroScoreByCluster, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create the expected set of bindings")
+		})
+
+		AfterAll(func() {
+			// Delete the CRP.
+			ensureCRPAndAllRelatedResourcesDeletion(crpName)
+			// Delete the provisional cluster.
+			ensureProvisionalClusterDeletion(newUnhealthyMemberClusterName)
+		})
+	})
+
+	// This is a serial test as adding a new member cluster may interrupt other test cases.
+	Context("pickN with required topology spread constraints, add new cluster with taint, upscaling doesn't pick new cluster", Serial, Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		policySnapshotName := fmt.Sprintf(policySnapshotNameTemplate, crpName, 1)
+		// Prepare a new cluster to avoid interrupting other concurrently running test cases.
+		newUnhealthyMemberClusterName := fmt.Sprintf(provisionalClusterNameTemplate, GinkgoParallelProcess())
+		numOfClusters := int32(2)
+		numOfClustersAfter := int32(3)
+		wantPickedClusters := []string{memberCluster7WestCanary, memberCluster5CentralProd}
+		wantNotPickedClusters := []string{memberCluster1EastProd, memberCluster2EastProd, memberCluster3EastCanary, memberCluster4CentralProd, memberCluster6WestProd}
+		wantFilteredClusters := []string{memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
+		wantPickedClustersAfter := []string{memberCluster7WestCanary, memberCluster5CentralProd, memberCluster3EastCanary}
+		wantNotPickedClustersAfter := []string{memberCluster1EastProd, memberCluster2EastProd, memberCluster4CentralProd, memberCluster6WestProd, newUnhealthyMemberClusterName}
+		scoreByCluster := map[string]*placementv1beta1.ClusterScore{
+			memberCluster1EastProd:    &zeroScore,
+			memberCluster2EastProd:    &zeroScore,
+			memberCluster3EastCanary:  &zeroScore,
+			memberCluster4CentralProd: &zeroScore,
+			// Cluster 5 is picked in the second iteration, as placing resources on it does
+			// not violate any topology spread constraints + does not increase the skew. It
+			// is assigned a topology spread score of 0 as the skew is unchanged.
+			memberCluster5CentralProd: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(0)),
+			},
+			// Cluster 6 is considered to be unschedulable in the second iteration as placing
+			// resources on it would violate the topology spread constraint (skew becomes 2,
+			// the limit is 1); unschedulable clusters do not have scores assigned.
+			memberCluster6WestProd: nil,
+			// Cluster 7 is picked in the first iteration, as placing resources on it does not
+			// violate any topology spread constraints + increases the skew only by one (so do other
+			// clusters), and its name is the largest in alphanumeric order. It is assigned
+			// a topology spread score of -1 as placing resources on it increases the skew.
+			memberCluster7WestCanary: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(-1)),
+			},
+		}
+		scoreByClusterAfter := map[string]*placementv1beta1.ClusterScore{
+			memberCluster1EastProd: &zeroScore,
+			memberCluster2EastProd: &zeroScore,
+			// Cluster 3 is picked in the third iteration, as placing resources on it does
+			// not violate any topology spread constraints + does not increase the skew. It
+			// is assigned a topology spread score of 0 as the skew is unchanged.
+			memberCluster3EastCanary: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(0)),
+			},
+			memberCluster4CentralProd: nil,
+			memberCluster5CentralProd: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(0)),
+			},
+			memberCluster6WestProd: nil,
+			memberCluster7WestCanary: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(-1)),
+			},
+			newUnhealthyMemberClusterName: nil,
+		}
+
+		BeforeAll(func() {
+			// Ensure that no bindings have been created so far.
+			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+
+			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
+			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
+				{
+					MaxSkew:           ptr.To(int32(1)),
+					TopologyKey:       regionLabel,
+					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+				},
+			}
+			// Create CRP with no tolerations specified.
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, nil)
+		})
+
+		It("should add scheduler cleanup finalizer to the CRP", func() {
+			finalizerAddedActual := crpSchedulerFinalizerAddedActual(crpName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add scheduler cleanup finalizer to CRP")
+		})
+
+		It("should create N bindings", func() {
+			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, len(wantPickedClusters))
+			Eventually(hasNScheduledOrBoundBindingsActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create N bindings")
+			Consistently(hasNScheduledOrBoundBindingsActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create N bindings")
+		})
+
+		It("should create scheduled bindings for selected clusters", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(wantPickedClusters, scoreByCluster, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+		})
+
+		It("should report status correctly", func() {
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
+			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
+		})
+
+		It("create a new member cluster", func() {
+			// Create a new member cluster.
+			createMemberCluster(newUnhealthyMemberClusterName, buildTaints([]string{newUnhealthyMemberClusterName}))
+			// Retrieve the cluster object.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: newUnhealthyMemberClusterName}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Add the region label.
+			memberCluster.Labels = map[string]string{
+				regionLabel: "north",
+				envLabel:    "prod",
+			}
+			Expect(hubClient.Update(ctx, memberCluster)).To(Succeed(), "Failed to update member cluster")
+			// Mark this cluster as healthy.
+			markClusterAsHealthy(newUnhealthyMemberClusterName)
+		})
+
+		It("upscale policy to pick 3 clusters", func() {
+			// Update the policy snapshot.
+			//
+			// Normally upscaling is done by increasing the number of clusters field in the CRP;
+			// however, since in the integration test environment, CRP controller is not available,
+			// we directly manipulate the number of clusters annoation on the policy snapshot
+			// to trigger upscaling.
+			Eventually(func() error {
+				policySnapshot := &placementv1beta1.ClusterSchedulingPolicySnapshot{}
+				if err := hubClient.Get(ctx, types.NamespacedName{Name: policySnapshotName}, policySnapshot); err != nil {
+					return err
+				}
+
+				policySnapshot.Annotations[placementv1beta1.NumberOfClustersAnnotation] = strconv.Itoa(int(numOfClustersAfter))
+				return hubClient.Update(ctx, policySnapshot)
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update policy snapshot")
+		})
+
+		It("should create N bindings", func() {
+			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, int(numOfClustersAfter))
+			Eventually(hasNScheduledOrBoundBindingsActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create N bindings")
+			Consistently(hasNScheduledOrBoundBindingsActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create N bindings")
+		})
+
+		It("should create scheduled bindings for selected clusters", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(wantPickedClustersAfter, scoreByClusterAfter, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+		})
+
+		It("should report status correctly", func() {
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClusters, scoreByClusterAfter, policySnapshotName)
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
+			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
+		})
+
+		AfterAll(func() {
+			// Delete the CRP.
+			ensureCRPAndAllRelatedResourcesDeletion(crpName)
+			// Delete the provisional cluster.
+			ensureProvisionalClusterDeletion(newUnhealthyMemberClusterName)
+		})
+	})
+
+	// This is a serial test as adding a new member cluster may interrupt other test cases.
+	Context("pickN with required topology spread constraints, add new cluster with taint, upscaling picks new cluster with tolerated taint", Serial, Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		policySnapshotName := fmt.Sprintf(policySnapshotNameTemplate, crpName, 1)
+		// Prepare a new cluster to avoid interrupting other concurrently running test cases.
+		newUnhealthyMemberClusterName := fmt.Sprintf(provisionalClusterNameTemplate, GinkgoParallelProcess())
+		numOfClusters := int32(2)
+		numOfClustersAfter := int32(3)
+		wantPickedClusters := []string{memberCluster7WestCanary, memberCluster5CentralProd}
+		wantNotPickedClusters := []string{memberCluster1EastProd, memberCluster2EastProd, memberCluster3EastCanary, memberCluster4CentralProd, memberCluster6WestProd}
+		wantFilteredClusters := []string{memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
+		wantPickedClustersAfter := []string{memberCluster7WestCanary, memberCluster5CentralProd, newUnhealthyMemberClusterName}
+		wantNotPickedClustersAfter := []string{memberCluster1EastProd, memberCluster2EastProd, memberCluster3EastCanary, memberCluster4CentralProd, memberCluster6WestProd}
+		scoreByCluster := map[string]*placementv1beta1.ClusterScore{
+			memberCluster1EastProd:    &zeroScore,
+			memberCluster2EastProd:    &zeroScore,
+			memberCluster3EastCanary:  &zeroScore,
+			memberCluster4CentralProd: &zeroScore,
+			// Cluster 5 is picked in the second iteration, as placing resources on it does
+			// not violate any topology spread constraints + does not increase the skew. It
+			// is assigned a topology spread score of 0 as the skew is unchanged.
+			memberCluster5CentralProd: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(0)),
+			},
+			// Cluster 6 is considered to be unschedulable in the second iteration as placing
+			// resources on it would violate the topology spread constraint (skew becomes 2,
+			// the limit is 1); unschedulable clusters do not have scores assigned.
+			memberCluster6WestProd: nil,
+			// Cluster 7 is picked in the first iteration, as placing resources on it does not
+			// violate any topology spread constraints + increases the skew only by one (so do other
+			// clusters), and its name is the largest in alphanumeric order. It is assigned
+			// a topology spread score of -1 as placing resources on it increases the skew.
+			memberCluster7WestCanary: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(-1)),
+			},
+		}
+		scoreByClusterAfter := map[string]*placementv1beta1.ClusterScore{
+			memberCluster1EastProd:    &zeroScore,
+			memberCluster2EastProd:    &zeroScore,
+			memberCluster3EastCanary:  &zeroScore,
+			memberCluster4CentralProd: nil,
+			memberCluster5CentralProd: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(0)),
+			},
+			memberCluster6WestProd: nil,
+			memberCluster7WestCanary: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(-1)),
+			},
+			// new cluster is picked in the third iteration, as placing resources on it does
+			// not violate any topology spread constraints + does not increase the skew. It
+			// is assigned a topology spread score of 0 as the skew is unchanged.
+			newUnhealthyMemberClusterName: {
+				AffinityScore:       ptr.To(int32(0)),
+				TopologySpreadScore: ptr.To(int32(0)),
+			},
+		}
+
+		BeforeAll(func() {
+			// Ensure that no bindings have been created so far.
+			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
+			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
+
+			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
+			topologySpreadConstraints := []placementv1beta1.TopologySpreadConstraint{
+				{
+					MaxSkew:           ptr.To(int32(1)),
+					TopologyKey:       regionLabel,
+					WhenUnsatisfiable: placementv1beta1.DoNotSchedule,
+				},
+			}
+			// Create CRP with toleration for new cluster.
+			createPickNCRPWithPolicySnapshot(crpName, numOfClusters, nil, topologySpreadConstraints, policySnapshotName, buildTolerations([]string{newUnhealthyMemberClusterName}))
+		})
+
+		It("should add scheduler cleanup finalizer to the CRP", func() {
+			finalizerAddedActual := crpSchedulerFinalizerAddedActual(crpName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add scheduler cleanup finalizer to CRP")
+		})
+
+		It("should create N bindings", func() {
+			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, len(wantPickedClusters))
+			Eventually(hasNScheduledOrBoundBindingsActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create N bindings")
+			Consistently(hasNScheduledOrBoundBindingsActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create N bindings")
+		})
+
+		It("should create scheduled bindings for selected clusters", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(wantPickedClusters, scoreByCluster, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+		})
+
+		It("should report status correctly", func() {
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClusters), wantPickedClusters, wantNotPickedClusters, wantFilteredClusters, scoreByCluster, policySnapshotName)
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
+			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
+		})
+
+		It("create a new member cluster", func() {
+			// Create a new member cluster.
+			createMemberCluster(newUnhealthyMemberClusterName, buildTaints([]string{newUnhealthyMemberClusterName}))
+			// Retrieve the cluster object.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: newUnhealthyMemberClusterName}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Add the region label.
+			memberCluster.Labels = map[string]string{
+				regionLabel: "north",
+				envLabel:    "prod",
+			}
+			Expect(hubClient.Update(ctx, memberCluster)).To(Succeed(), "Failed to update member cluster")
+			// Mark this cluster as healthy.
+			markClusterAsHealthy(newUnhealthyMemberClusterName)
+		})
+
+		It("upscale policy to pick 3 clusters", func() {
+			// Update the policy snapshot.
+			//
+			// Normally upscaling is done by increasing the number of clusters field in the CRP;
+			// however, since in the integration test environment, CRP controller is not available,
+			// we directly manipulate the number of clusters annoation on the policy snapshot
+			// to trigger upscaling.
+			Eventually(func() error {
+				policySnapshot := &placementv1beta1.ClusterSchedulingPolicySnapshot{}
+				if err := hubClient.Get(ctx, types.NamespacedName{Name: policySnapshotName}, policySnapshot); err != nil {
+					return err
+				}
+
+				policySnapshot.Annotations[placementv1beta1.NumberOfClustersAnnotation] = strconv.Itoa(int(numOfClustersAfter))
+				return hubClient.Update(ctx, policySnapshot)
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update policy snapshot")
+		})
+
+		It("should create N bindings", func() {
+			hasNScheduledOrBoundBindingsActual := hasNScheduledOrBoundBindingsPresentActual(crpName, int(numOfClustersAfter))
+			Eventually(hasNScheduledOrBoundBindingsActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create N bindings")
+			Consistently(hasNScheduledOrBoundBindingsActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create N bindings")
+		})
+
+		It("should create scheduled bindings for selected clusters", func() {
+			scheduledBindingsCreatedActual := scheduledBindingsCreatedOrUpdatedForClustersActual(wantPickedClustersAfter, scoreByClusterAfter, crpName, policySnapshotName)
+			Eventually(scheduledBindingsCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+			Consistently(scheduledBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to create scheduled bindings for selected clusters")
+		})
+
+		It("should report status correctly", func() {
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(int(numOfClustersAfter), wantPickedClustersAfter, wantNotPickedClustersAfter, wantFilteredClusters, scoreByClusterAfter, policySnapshotName)
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
+			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
+		})
+
+		AfterAll(func() {
+			// Delete the CRP.
+			ensureCRPAndAllRelatedResourcesDeletion(crpName)
+			// Delete the provisional cluster.
+			ensureProvisionalClusterDeletion(newUnhealthyMemberClusterName)
+		})
+	})
+})

--- a/test/scheduler/tainttoleration_integration_test.go
+++ b/test/scheduler/tainttoleration_integration_test.go
@@ -222,7 +222,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 			policy := &placementv1beta1.PlacementPolicy{
 				PlacementType: placementv1beta1.PickAllPlacementType,
 			}
-			// Create CRP with PickAll.
+			// Create CRP with PickAll, no tolerations specified.
 			createPickAllCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
@@ -303,6 +303,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 			// Add taints to some member clusters 1, 2.
 			addTaintsToMemberClusters(taintClusters, buildTaints(taintClusters))
 
+			// Create a CRP of the PickN placement type, along with its associated policy snapshot, no tolerations specified.
 			policy := &placementv1beta1.PlacementPolicy{
 				PlacementType:    placementv1beta1.PickNPlacementType,
 				NumberOfClusters: &numOfClusters,
@@ -331,7 +332,6 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 					},
 				},
 			}
-			// Create a CRP of the PickN placement type, along with its associated policy snapshot, no tolerations specified.
 			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 
@@ -401,7 +401,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
-			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot.
+			// Create a CRP with no scheduling policy specified, along with its associated policy snapshot, no tolerations specified.
 			createNilSchedulingPolicyCRPWithPolicySnapshot(crpName, policySnapshotName, nil)
 
 			// Create a new member cluster.
@@ -537,7 +537,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 			noBindingsCreatedActual := noBindingsCreatedForCRPActual(crpName)
 			Consistently(noBindingsCreatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Some bindings have been created unexpectedly")
 
-			// Create a CRP of the PickN placement type, along with its associated policy snapshot.
+			// Create a CRP of the PickN placement type, along with its associated policy snapshot, no tolerations specified.
 			policy := &placementv1beta1.PlacementPolicy{
 				PlacementType:    placementv1beta1.PickNPlacementType,
 				NumberOfClusters: &numOfClusters,
@@ -549,7 +549,6 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 					},
 				},
 			}
-			// Create CRP with no tolerations specified.
 			createPickNCRPWithPolicySnapshot(crpName, policySnapshotName, policy)
 		})
 

--- a/test/scheduler/tainttoleration_integration_test.go
+++ b/test/scheduler/tainttoleration_integration_test.go
@@ -201,9 +201,9 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		// The scheduler is designed to produce only deterministic decisions; if there are no
 		// comparable scores available for selected clusters, the scheduler will rank the clusters
 		// by their names.
-		wantPickedClusters := []string{memberCluster1EastProd, memberCluster2EastProd}
-		wantFilteredClusters1 := []string{memberCluster1EastProd, memberCluster2EastProd, memberCluster3EastCanary, memberCluster4CentralProd, memberCluster5CentralProd, memberCluster6WestProd, memberCluster7WestCanary, memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
-		wantFilteredClusters2 := []string{memberCluster3EastCanary, memberCluster4CentralProd, memberCluster5CentralProd, memberCluster6WestProd, memberCluster7WestCanary, memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
+		wantFilteredClusters := []string{memberCluster1EastProd, memberCluster2EastProd, memberCluster3EastCanary, memberCluster4CentralProd, memberCluster5CentralProd, memberCluster6WestProd, memberCluster7WestCanary, memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
+		wantPickedClustersAfter := []string{memberCluster1EastProd, memberCluster2EastProd}
+		wantFilteredClustersAfter := []string{memberCluster3EastCanary, memberCluster4CentralProd, memberCluster5CentralProd, memberCluster6WestProd, memberCluster7WestCanary, memberCluster8UnhealthyEastProd, memberCluster9LeftCentralProd}
 
 		BeforeAll(func() {
 			// Ensure that no bindings have been created so far.
@@ -260,7 +260,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, []string{}, []string{}, wantFilteredClusters1, zeroScoreByCluster, policySnapshotName1)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, []string{}, []string{}, wantFilteredClusters, zeroScoreByCluster, policySnapshotName1)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})
@@ -283,7 +283,7 @@ var _ = Describe("scheduling CRPs on member clusters with taints & tolerations",
 		})
 
 		It("should report status correctly", func() {
-			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, wantPickedClusters, []string{}, wantFilteredClusters2, zeroScoreByCluster, policySnapshotName2)
+			crpStatusUpdatedActual := pickNPolicySnapshotStatusUpdatedActual(2, wantPickedClustersAfter, []string{}, wantFilteredClustersAfter, zeroScoreByCluster, policySnapshotName2)
 			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to report status correctly")
 			Consistently(crpStatusUpdatedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to report status correctly")
 		})

--- a/test/scheduler/utils_test.go
+++ b/test/scheduler/utils_test.go
@@ -89,6 +89,9 @@ var (
 	lessFuncClusterDecision = func(decision1, decision2 placementv1beta1.ClusterDecision) bool {
 		return decision1.ClusterName < decision2.ClusterName
 	}
+	ignoreUnSelectedClusterDecision = func(decision placementv1beta1.ClusterDecision) bool {
+		return decision.Selected
+	}
 
 	ignoreClusterDecisionReasonField          = cmpopts.IgnoreFields(placementv1beta1.ClusterDecision{}, "Reason")
 	ignoreObjectMetaNameField                 = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name")

--- a/test/scheduler/utils_test.go
+++ b/test/scheduler/utils_test.go
@@ -676,8 +676,8 @@ func buildTaints(memberClusterNames []string) []clusterv1beta1.Taint {
 		} else {
 			// for new member clusters added.
 			labels = map[string]string{
-				regionLabel: "north",
-				envLabel:    "prod",
+				regionLabel: "unknown",
+				envLabel:    "unknown",
 			}
 		}
 		taints[i].Key = labels[regionLabel]

--- a/test/scheduler/utils_test.go
+++ b/test/scheduler/utils_test.go
@@ -632,14 +632,13 @@ func updatePickNCRPWithNewAffinityAndTopologySpreadConstraints(
 }
 
 func updatePickNCRPWithTolerations(crpName string, tolerations []placementv1beta1.Toleration, oldPolicySnapshotName, newPolicySnapshotName string) {
-	// Update the CRP.
 	crp := &placementv1beta1.ClusterResourcePlacement{}
-	Expect(hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp)).To(Succeed(), "Failed to get CRP")
+	Expect(hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp)).To(Succeed(), "Failed to get cluster resource placement")
 
 	policy := crp.Spec.Policy.DeepCopy()
 	policy.Tolerations = tolerations
 	numOfClusters := policy.NumberOfClusters
-	Expect(hubClient.Update(ctx, crp)).To(Succeed(), "Failed to update CRP")
+	Expect(hubClient.Update(ctx, crp)).To(Succeed(), "Failed to update cluster resource placement")
 
 	crpGeneration := crp.Generation
 
@@ -716,7 +715,7 @@ func addTaintsToMemberClusters(memberClusterNames []string, taints []clusterv1be
 		var mc clusterv1beta1.MemberCluster
 		Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName}, &mc)).Should(Succeed(), "Failed to get member cluster")
 		mc.Spec.Taints = []clusterv1beta1.Taint{taints[i]}
-		Expect(hubClient.Update(ctx, &mc)).Should(Succeed(), "Failed to update MC")
+		Expect(hubClient.Update(ctx, &mc)).Should(Succeed(), "Failed to update member cluster")
 	}
 }
 
@@ -725,6 +724,6 @@ func removeTaintsFromMemberClusters(memberClusterNames []string) {
 		var mc clusterv1beta1.MemberCluster
 		Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName}, &mc)).Should(Succeed(), "Failed to get member cluster")
 		mc.Spec.Taints = nil
-		Expect(hubClient.Update(ctx, &mc)).Should(Succeed(), "Failed to update MC")
+		Expect(hubClient.Update(ctx, &mc)).Should(Succeed(), "Failed to update member cluster")
 	}
 }

--- a/test/scheduler/utils_test.go
+++ b/test/scheduler/utils_test.go
@@ -89,8 +89,8 @@ var (
 	lessFuncClusterDecision = func(decision1, decision2 placementv1beta1.ClusterDecision) bool {
 		return decision1.ClusterName < decision2.ClusterName
 	}
-	ignoreUnSelectedClusterDecision = func(decision placementv1beta1.ClusterDecision) bool {
-		return decision.Selected
+	ignoreUnselectedClusterDecision = func(decision placementv1beta1.ClusterDecision) bool {
+		return !decision.Selected
 	}
 
 	ignoreClusterDecisionReasonField          = cmpopts.IgnoreFields(placementv1beta1.ClusterDecision{}, "Reason")


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Integration tests with the plugin enabled only for tests.

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->

### Special notes for your reviewer

Main Workflows covered:
- Special case for PickFixed adding taints shouldn't matter since plugin won't be run
- Add taint to existing cluster, Create CRP without tolerations, cluster is not picked
- Add taint to existing cluster, Create CRP with tolerations, cluster is picked with matching toleration
- Add taint to existing cluster, Create CRP without tolerations, , cluster is not picked, CRP is updated with tolerations, cluster is picked with matching toleration after CRP udpate
- Create CRP without tolerations, Create new cluster with taints and mark it as healthy to trigger scheduling cycle, cluster is not picked
- Create CRP with tolerations, Create new cluster with taints and mark it as healthy to trigger scheduling cycle, cluster is not picked

Specific Workflows tested:

- Add taints on eligible existing clusters to be selected, Create PickFixed CRP which selecets member clusters with taints - clusters get selected as plugin is not run for PickFixed
- Add taints on some eligible existing clusters to be selected, Create PickAll CRP with no tolerations - clusters with taints aren't picked
- Add taints on some eligible existing clusters to be selected, Create PickAll CRP with affinity, tolerations which tolerate some taints - cluster with untolerated taints aren't picked, cluster with tolerated taints are picked
- Add taints on existing elighible clusters to be seleceted, PickN CRP with affinity - no cluster is picked, then CRP is updated with matching tolerations, clusters are picked
- Create PickAll CRP, Add new cluster with taint - new cluster is not picked
- Create PickAll CRP with matching toleration for new cluster's taint, Add new cluster with taint is added - new cluster is picked
- Create PickN CRP, Add new cluster with taint, upscale doesn't pick new cluster
- Create PickN CRP with matching toleration for new cluster's taint, add new cluster with taint, upscale picks new cluster

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
