### PR TITLE
fix: swap the example formulas for sorting properties in the API comments

### DIFF
--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -239,10 +239,10 @@ const (
 	//
 	// * a weight of 100 to the cluster with the maximum observed value (100); and
 	// * a weight of 0 to the cluster with the minimum observed value (10); and
-	// * a weight of 89 to the cluster with an observed value of 20.
+	// * a weight of 11 to the cluster with an observed value of 20.
 	//
 	//   It is calculated using the formula below:
-	//   (1 - ((20 - 10) / (100 - 10))) * 100 = 89
+	//   ((20 - 10)) / (100 - 10)) * 100 = 11
 	Descending PropertySortOrder = "Descending"
 
 	// Ascending instructs Fleet to sort in ascending order, that is, the clusters with lower
@@ -255,10 +255,10 @@ const (
 	//
 	// * a weight of 0 to the cluster with the  maximum observed value (100); and
 	// * a weight of 100 to the cluster with the minimum observed value (10); and
-	// * a weight of 11 to the cluster with an observed value of 20.
+	// * a weight of 89 to the cluster with an observed value of 20.
 	//
 	//   It is calculated using the formula below:
-	//   ((20 - 10)) / (100 - 10)) * 100 = 11
+	//   (1 - ((20 - 10) / (100 - 10))) * 100 = 89
 	Ascending PropertySortOrder = "Ascending"
 )
 


### PR DESCRIPTION
### Description of your changes

This PR fixes a minor issue where the example formulas for sorting properties are misplaced in the API comments.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A
