### PR TITLE
feat: property-based scheduling: add property provider support to MC controller

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -452,6 +452,14 @@ func (r *Reconciler) syncInternalMemberClusterStatus(imc *clusterv1beta1.Interna
 	r.aggregateJoinedCondition(mc)
 	// Copy resource usages.
 	mc.Status.ResourceUsage = imc.Status.ResourceUsage
+	// Copy additional conditions.
+	for idx := range imc.Status.Conditions {
+		cond := imc.Status.Conditions[idx]
+		cond.ObservedGeneration = imc.GetGeneration()
+		meta.SetStatusCondition(&mc.Status.Conditions, cond)
+	}
+	// Copy the cluster properties.
+	mc.Status.Properties = imc.Status.Properties
 }
 
 // updateMemberClusterStatus is used to update member cluster status.

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -455,7 +455,7 @@ func (r *Reconciler) syncInternalMemberClusterStatus(imc *clusterv1beta1.Interna
 	// Copy additional conditions.
 	for idx := range imc.Status.Conditions {
 		cond := imc.Status.Conditions[idx]
-		cond.ObservedGeneration = imc.GetGeneration()
+		cond.ObservedGeneration = mc.GetGeneration()
 		meta.SetStatusCondition(&mc.Status.Conditions, cond)
 	}
 	// Copy the cluster properties.


### PR DESCRIPTION
### Description of your changes

This PR enables the MC controller to copy status fields for property-based scheduling from IMC to MC.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests

### Special notes for your reviewer

E2E tests will be added in a separate PR.
