### PR TITLE
feat: property-based scheduling: add support for property-based scheduling in the scheduler member cluster watcher

### DIFF
--- a/pkg/scheduler/watchers/membercluster/controller.go
+++ b/pkg/scheduler/watchers/membercluster/controller.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -225,38 +226,20 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// Capture resource usage changes.
 			oldCapacity := oldCluster.Status.ResourceUsage.Capacity
 			newCapacity := newCluster.Status.ResourceUsage.Capacity
-			if len(oldCapacity) != len(newCapacity) {
+			if !equality.Semantic.DeepEqual(oldCapacity, newCapacity) {
 				return true
-			}
-			for oldK, oldV := range oldCapacity {
-				newV, ok := newCapacity[oldK]
-				if !ok || !oldV.Equal(newV) {
-					return true
-				}
 			}
 
 			oldAllocatable := oldCluster.Status.ResourceUsage.Allocatable
 			newAllocatable := newCluster.Status.ResourceUsage.Allocatable
-			if len(oldAllocatable) != len(newAllocatable) {
+			if !equality.Semantic.DeepEqual(oldAllocatable, newAllocatable) {
 				return true
-			}
-			for oldK, oldV := range oldAllocatable {
-				newV, ok := newAllocatable[oldK]
-				if !ok || !oldV.Equal(newV) {
-					return true
-				}
 			}
 
 			oldAvailable := oldCluster.Status.ResourceUsage.Available
 			newAvailable := newCluster.Status.ResourceUsage.Available
-			if len(oldAvailable) != len(newAvailable) {
+			if !equality.Semantic.DeepEqual(oldAvailable, newAvailable) {
 				return true
-			}
-			for oldK, oldV := range oldAvailable {
-				newV, ok := newAvailable[oldK]
-				if !ok || !oldV.Equal(newV) {
-					return true
-				}
 			}
 
 			// Check the resource placement eligibility for the old and new cluster object.

--- a/pkg/scheduler/watchers/membercluster/controller_integration_test.go
+++ b/pkg/scheduler/watchers/membercluster/controller_integration_test.go
@@ -14,6 +14,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -32,6 +34,9 @@ const (
 	dummyReason     = "dummyReason"
 	dummyLabel      = "dummy-label"
 	dummyLabelValue = "dummy-label-value"
+
+	dummyNonResourcePropertyName  = "dummy-non-resource-property"
+	dummyNonResourcePropertyValue = "0"
 )
 
 var (
@@ -138,6 +143,112 @@ var _ = Describe("scheduler member cluster source controller", Serial, Ordered, 
 				dummyLabel: dummyLabelValue,
 			}
 			Expect(hubClient.Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster labels")
+		})
+
+		It("should enqueue CRPs (case 1a)", func() {
+			Eventually(qualifiedKeysEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+		})
+
+		AfterAll(func() {
+			keyCollector.Reset()
+		})
+	})
+
+	Context("ready cluster has a non-resource property change", func() {
+		BeforeAll(func() {
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+
+			// Retrieve the cluster.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName1}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Update the list of non-resource properties.
+			memberCluster.Status.Properties = map[clusterv1beta1.PropertyName]clusterv1beta1.PropertyValue{
+				dummyNonResourcePropertyName: {
+					Value:           dummyNonResourcePropertyValue,
+					ObservationTime: metav1.NewTime(time.Now()),
+				},
+			}
+			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
+		})
+
+		It("should enqueue CRPs (case 1a)", func() {
+			Eventually(qualifiedKeysEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+		})
+
+		AfterAll(func() {
+			keyCollector.Reset()
+		})
+	})
+
+	Context("ready cluster has a total capacity change", func() {
+		BeforeAll(func() {
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+
+			// Retrieve the cluster.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName1}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Update the list of non-resource properties.
+			memberCluster.Status.ResourceUsage.Capacity = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			}
+			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
+		})
+
+		It("should enqueue CRPs (case 1a)", func() {
+			Eventually(qualifiedKeysEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+		})
+
+		AfterAll(func() {
+			keyCollector.Reset()
+		})
+	})
+
+	Context("ready cluster has an allocatable capacity change", func() {
+		BeforeAll(func() {
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+
+			// Retrieve the cluster.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName1}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Update the list of non-resource properties.
+			memberCluster.Status.ResourceUsage.Allocatable = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			}
+			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
+		})
+
+		It("should enqueue CRPs (case 1a)", func() {
+			Eventually(qualifiedKeysEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+		})
+
+		AfterAll(func() {
+			keyCollector.Reset()
+		})
+	})
+
+	Context("ready cluster has an available capacity change", func() {
+		BeforeAll(func() {
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+
+			// Retrieve the cluster.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName1}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Update the list of non-resource properties.
+			memberCluster.Status.ResourceUsage.Available = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			}
+			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
 		})
 
 		It("should enqueue CRPs (case 1a)", func() {

--- a/pkg/scheduler/watchers/membercluster/controller_integration_test.go
+++ b/pkg/scheduler/watchers/membercluster/controller_integration_test.go
@@ -35,8 +35,9 @@ const (
 	dummyLabel      = "dummy-label"
 	dummyLabelValue = "dummy-label-value"
 
-	dummyNonResourcePropertyName  = "dummy-non-resource-property"
-	dummyNonResourcePropertyValue = "0"
+	dummyNonResourcePropertyName   = "dummy-non-resource-property"
+	dummyNonResourcePropertyValue1 = "0"
+	dummyNonResourcePropertyValue2 = "1"
 )
 
 var (
@@ -166,7 +167,33 @@ var _ = Describe("scheduler member cluster source controller", Serial, Ordered, 
 			// Update the list of non-resource properties.
 			memberCluster.Status.Properties = map[clusterv1beta1.PropertyName]clusterv1beta1.PropertyValue{
 				dummyNonResourcePropertyName: {
-					Value:           dummyNonResourcePropertyValue,
+					Value:           dummyNonResourcePropertyValue1,
+					ObservationTime: metav1.NewTime(time.Now()),
+				},
+			}
+			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
+		})
+
+		It("should enqueue CRPs (case 1a)", func() {
+			Eventually(qualifiedKeysEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+		})
+
+		It("can empty the key collector", func() {
+			keyCollector.Reset()
+			Eventually(noKeyEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Workqueue is not empty")
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+		})
+
+		It("can update the property", func() {
+			// Retrieve the cluster.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName1}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Update the list of non-resource properties.
+			memberCluster.Status.Properties = map[clusterv1beta1.PropertyName]clusterv1beta1.PropertyValue{
+				dummyNonResourcePropertyName: {
+					Value:           dummyNonResourcePropertyValue2,
 					ObservationTime: metav1.NewTime(time.Now()),
 				},
 			}
@@ -204,6 +231,30 @@ var _ = Describe("scheduler member cluster source controller", Serial, Ordered, 
 			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
 		})
 
+		It("can empty the key collector", func() {
+			keyCollector.Reset()
+			Eventually(noKeyEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Workqueue is not empty")
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+		})
+
+		It("can update the total capacity", func() {
+			// Retrieve the cluster.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName1}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Update the list of non-resource properties.
+			memberCluster.Status.ResourceUsage.Capacity = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2000m"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			}
+			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
+		})
+
+		It("should enqueue CRPs (case 1a)", func() {
+			Eventually(qualifiedKeysEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+		})
+
 		AfterAll(func() {
 			keyCollector.Reset()
 		})
@@ -230,6 +281,30 @@ var _ = Describe("scheduler member cluster source controller", Serial, Ordered, 
 			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
 		})
 
+		It("can empty the key collector", func() {
+			keyCollector.Reset()
+			Eventually(noKeyEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Workqueue is not empty")
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+		})
+
+		It("can update the allocatable capacity", func() {
+			// Retrieve the cluster.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName1}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Update the list of non-resource properties.
+			memberCluster.Status.ResourceUsage.Allocatable = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2000m"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			}
+			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
+		})
+
+		It("should enqueue CRPs (case 1a)", func() {
+			Eventually(qualifiedKeysEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+		})
+
 		AfterAll(func() {
 			keyCollector.Reset()
 		})
@@ -247,6 +322,30 @@ var _ = Describe("scheduler member cluster source controller", Serial, Ordered, 
 			memberCluster.Status.ResourceUsage.Available = corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1000m"),
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			}
+			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
+		})
+
+		It("should enqueue CRPs (case 1a)", func() {
+			Eventually(qualifiedKeysEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+			Consistently(qualifiedKeysEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Keys are not enqueued as expected")
+		})
+
+		It("can empty the key collector", func() {
+			keyCollector.Reset()
+			Eventually(noKeyEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Workqueue is not empty")
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+		})
+
+		It("can update the available capacity", func() {
+			// Retrieve the cluster.
+			memberCluster := &clusterv1beta1.MemberCluster{}
+			Expect(hubClient.Get(ctx, types.NamespacedName{Name: clusterName1}, memberCluster)).To(Succeed(), "Failed to get member cluster")
+
+			// Update the list of non-resource properties.
+			memberCluster.Status.ResourceUsage.Available = corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2000m"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			}
 			Expect(hubClient.Status().Update(ctx, memberCluster)).Should(Succeed(), "Failed to update member cluster non-resource properties")
 		})


### PR DESCRIPTION
### Description of your changes

This PR adds support for property-based scheduling in the scheduler member cluster watcher.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Integration tests

### Special notes for your reviewer

N/A
