### PR TITLE
feat: support apply strategy

### DIFF
--- a/pkg/controllers/work/applied_work_syncer_integration_test.go
+++ b/pkg/controllers/work/applied_work_syncer_integration_test.go
@@ -44,8 +44,6 @@ var _ = Describe("Work Status Reconciler", func() {
 	var cm, cm2 *corev1.ConfigMap
 	var rns corev1.Namespace
 
-	workNamespace := testWorkNamespace
-
 	BeforeEach(func() {
 		resourceNamespace = utilrand.String(5)
 		rns = corev1.Namespace{
@@ -53,8 +51,7 @@ var _ = Describe("Work Status Reconciler", func() {
 				Name: resourceNamespace,
 			},
 		}
-		err := k8sClient.Create(context.Background(), &rns)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(k8sClient.Create(context.Background(), &rns)).Should(Succeed(), "Failed to create the resource namespace")
 
 		// Create the Work object with some type of Manifest resource.
 		cm = &corev1.ConfigMap{
@@ -88,7 +85,7 @@ var _ = Describe("Work Status Reconciler", func() {
 		work = &fleetv1beta1.Work{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "work-" + utilrand.String(5),
-				Namespace: workNamespace,
+				Namespace: testWorkNamespace,
 			},
 			Spec: fleetv1beta1.WorkSpec{
 				Workload: fleetv1beta1.WorkloadTemplate{
@@ -116,7 +113,7 @@ var _ = Describe("Work Status Reconciler", func() {
 		Expect(k8sClient.Create(context.Background(), work)).ToNot(HaveOccurred())
 
 		By("Make sure that the work is applied")
-		currentWork := waitForWorkToApply(work.Name, workNamespace)
+		currentWork := waitForWorkToApply(work.Name, testWorkNamespace)
 		var appliedWork fleetv1beta1.AppliedWork
 		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: work.Name}, &appliedWork)).Should(Succeed())
 		Expect(len(appliedWork.Status.AppliedResources)).Should(Equal(2))
@@ -174,14 +171,14 @@ var _ = Describe("Work Status Reconciler", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		By("Remove configMap 2 from the work")
-		currentWork := waitForWorkToApply(work.Name, workNamespace)
+		currentWork := waitForWorkToApply(work.Name, testWorkNamespace)
 		currentWork.Spec.Workload.Manifests = []fleetv1beta1.Manifest{
 			{
 				RawExtension: runtime.RawExtension{Object: cm},
 			},
 		}
 		Expect(k8sClient.Update(context.Background(), currentWork)).Should(Succeed())
-		currentWork = waitForWorkToApply(work.Name, workNamespace)
+		currentWork = waitForWorkToApply(work.Name, testWorkNamespace)
 		Expect(len(currentWork.Status.ManifestConditions)).Should(Equal(1))
 
 		By("Verify that configMap 2 is removed from the appliedWork")
@@ -197,14 +194,14 @@ var _ = Describe("Work Status Reconciler", func() {
 		}, timeout, interval).Should(BeTrue())
 
 		By("Remove configMap 2 from the work2")
-		currentWork = waitForWorkToApply(work2.Name, workNamespace)
+		currentWork = waitForWorkToApply(work2.Name, testWorkNamespace)
 		currentWork.Spec.Workload.Manifests = []fleetv1beta1.Manifest{
 			{
 				RawExtension: runtime.RawExtension{Object: cm},
 			},
 		}
 		Expect(k8sClient.Update(context.Background(), currentWork)).Should(Succeed())
-		currentWork = waitForWorkToApply(work.Name, workNamespace)
+		currentWork = waitForWorkToApply(work.Name, testWorkNamespace)
 		Expect(len(currentWork.Status.ManifestConditions)).Should(Equal(1))
 
 		By("Verify that the resource is removed from the appliedWork")
@@ -225,7 +222,7 @@ var _ = Describe("Work Status Reconciler", func() {
 		Expect(k8sClient.Create(context.Background(), work)).ToNot(HaveOccurred())
 
 		By("Make sure that the work is applied")
-		currentWork := waitForWorkToApply(work.Name, workNamespace)
+		currentWork := waitForWorkToApply(work.Name, testWorkNamespace)
 		var appliedWork fleetv1beta1.AppliedWork
 		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: work.Name}, &appliedWork)).Should(Succeed())
 		Expect(len(appliedWork.Status.AppliedResources)).Should(Equal(2))
@@ -238,7 +235,7 @@ var _ = Describe("Work Status Reconciler", func() {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "broadcastjob-" + utilrand.String(5),
-				Namespace: workNamespace,
+				Namespace: testWorkNamespace,
 			},
 			Spec: kruisev1alpha1.BroadcastJobSpec{
 				Paused: true,
@@ -274,7 +271,7 @@ var _ = Describe("Work Status Reconciler", func() {
 		Expect(k8sClient.Create(context.Background(), work)).ToNot(HaveOccurred())
 
 		By("Make sure that the work is applied")
-		currentWork := waitForWorkToApply(work.Name, workNamespace)
+		currentWork := waitForWorkToApply(work.Name, testWorkNamespace)
 		var appliedWork fleetv1beta1.AppliedWork
 		Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: work.Name}, &appliedWork)).Should(Succeed())
 		Expect(len(appliedWork.Status.AppliedResources)).Should(Equal(2))

--- a/pkg/controllers/work/applied_work_syncer_integration_test.go
+++ b/pkg/controllers/work/applied_work_syncer_integration_test.go
@@ -40,31 +40,20 @@ import (
 
 var _ = Describe("Work Status Reconciler", func() {
 	var resourceNamespace string
-	var workNamespace string
 	var work *fleetv1beta1.Work
 	var cm, cm2 *corev1.ConfigMap
-
-	var wns corev1.Namespace
 	var rns corev1.Namespace
 
+	workNamespace := testWorkNamespace
+
 	BeforeEach(func() {
-		workNamespace = "cluster-" + utilrand.String(5)
 		resourceNamespace = utilrand.String(5)
-
-		wns = corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: workNamespace,
-			},
-		}
-		err := k8sClient.Create(context.Background(), &wns)
-		Expect(err).ToNot(HaveOccurred())
-
 		rns = corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: resourceNamespace,
 			},
 		}
-		err = k8sClient.Create(context.Background(), &rns)
+		err := k8sClient.Create(context.Background(), &rns)
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create the Work object with some type of Manifest resource.
@@ -119,7 +108,6 @@ var _ = Describe("Work Status Reconciler", func() {
 	AfterEach(func() {
 		// TODO: Ensure that all resources are being deleted.
 		Expect(k8sClient.Delete(context.Background(), work)).Should(Succeed())
-		Expect(k8sClient.Delete(context.Background(), &wns)).Should(Succeed())
 		Expect(k8sClient.Delete(context.Background(), &rns)).Should(Succeed())
 	})
 

--- a/pkg/controllers/work/applier.go
+++ b/pkg/controllers/work/applier.go
@@ -95,10 +95,12 @@ func validateOwnerReference(ctx context.Context, hubClient client.Client, namesp
 		return applyConflictBetweenPlacements, controller.NewUserError(err)
 	}
 
-	// check if the existing manifest is managed by the work
+	// skip if the current resource is not derived from the work and co-ownership is disallowed
+	// Note: if the co-ownership is added afterwards, e.g., by a controller using on the user-side, all resource changes
+	// will fail to be updated.
 	if !strategy.AllowCoOwnership && !isManifestManagedByWork(ownerRefs) {
-		err := fmt.Errorf("resource exists and is not managed by the fleet controller")
-		klog.ErrorS(err, "Co-ownership is not allowed", "ownerRefs", ownerRefs)
+		err := fmt.Errorf("resource exists and is not managed by the fleet controller and co-ownernship is disallowed")
+		klog.ErrorS(err, "Skip applying a manifest managed by non-fleet applier", "ownerRefs", ownerRefs)
 		return manifestAlreadyOwnedByOthers, controller.NewUserError(err)
 	}
 	return "", nil

--- a/pkg/controllers/work/applier.go
+++ b/pkg/controllers/work/applier.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package work
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/utils/controller"
+	"go.goms.io/fleet/pkg/utils/defaulter"
+)
+
+var (
+	conflictBetweenPlacementsErrorFormat = "manifest is already managed by placement %s but with different apply strategy or the placement strategy is changed"
+)
+
+// Applier is the interface to apply the resources on the member clusters.
+type Applier interface {
+	ApplyUnstructured(ctx context.Context, applyStrategy *fleetv1beta1.ApplyStrategy, gvr schema.GroupVersionResource, manifestObj *unstructured.Unstructured) (*unstructured.Unstructured, ApplyAction, error)
+}
+
+// serverSideApply uses server side apply to apply the manifest.
+func serverSideApply(ctx context.Context, client dynamic.Interface, force bool, gvr schema.GroupVersionResource,
+	manifestObj *unstructured.Unstructured) (*unstructured.Unstructured, ApplyAction, error) {
+	manifestRef := klog.KObj(manifestObj)
+	options := metav1.ApplyOptions{
+		FieldManager: workFieldManagerName,
+		Force:        force,
+	}
+	manifestRes, err := client.Resource(gvr).Namespace(manifestObj.GetNamespace()).Apply(ctx, manifestObj.GetName(), manifestObj, options)
+	if err != nil {
+		klog.ErrorS(err, "Failed to apply object", "gvr", gvr, "manifest", manifestRef)
+		return nil, errorApplyAction, controller.NewAPIServerError(false, err)
+	}
+	klog.V(2).InfoS("Manifest apply succeeded", "gvr", gvr, "manifest", manifestRef)
+	return manifestRes, manifestServerSideAppliedAction, nil
+}
+
+// findConflictedWork checks if the manifest is owned by other placements which have configured different strategy.
+// It returns the first conflicted work it finds.
+func findConflictedWork(ctx context.Context, hubClient client.Client, namespace string, strategy *fleetv1beta1.ApplyStrategy, ownerRefs []metav1.OwnerReference) (*fleetv1beta1.Work, error) {
+	for _, ownerRef := range ownerRefs {
+		if ownerRef.APIVersion != fleetv1beta1.GroupVersion.String() || ownerRef.Kind != fleetv1beta1.AppliedWorkKind {
+			continue
+		}
+
+		// we need to check if the appliedWork is using the same strategy as the work
+		// Note, the resource could be already owned by the current work and apply strategy of the work may be changed
+		// too during the check.
+		// We'll return the user error to retry again.
+		work := &fleetv1beta1.Work{}
+		name := types.NamespacedName{Namespace: namespace, Name: ownerRef.Name}
+		if err := hubClient.Get(ctx, name, work); err != nil {
+			klog.ErrorS(err, "Failed to retrieve the work", "work", name)
+			if errors.IsNotFound(err) {
+				// The work may be just deleted by the time we are checking it and the ownerRef is already stale.
+				// Or it could be manually deleted by the user.
+				// Return the error to retry.
+				return nil, controller.NewExpectedBehaviorError(err)
+			}
+			return nil, controller.NewAPIServerError(true, err)
+		}
+		// TODO, could be removed once we have the defaulting webhook
+		defaulter.SetDefaultsWork(work)
+		if !equality.Semantic.DeepEqual(strategy, work.Spec.ApplyStrategy) {
+			return work, nil
+		}
+	}
+	return nil, nil
+}

--- a/pkg/controllers/work/applier_fail_if_exists.go
+++ b/pkg/controllers/work/applier_fail_if_exists.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package work
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/utils/controller"
+)
+
+// FailIfExistsApplier applies the manifest to the cluster and fails if the resource already exists.
+type FailIfExistsApplier struct {
+	HubClient          client.Client
+	WorkNamespace      string
+	SpokeDynamicClient dynamic.Interface
+}
+
+// ApplyUnstructured determines if an unstructured manifest object can & should be applied. It first validates
+// the size of the last modified annotation of the manifest, it removes the annotation if the size crosses the annotation size threshold
+// and then creates/updates the resource on the cluster using server side apply instead of three-way merge patch.
+func (applier *FailIfExistsApplier) ApplyUnstructured(ctx context.Context, applyStrategy *fleetv1beta1.ApplyStrategy, gvr schema.GroupVersionResource, manifestObj *unstructured.Unstructured) (*unstructured.Unstructured, ApplyAction, error) {
+	manifestRef := klog.KObj(manifestObj)
+
+	// compute the hash without taking into consider the last applied annotation
+	if err := setManifestHashAnnotation(manifestObj); err != nil {
+		return nil, errorApplyAction, controller.NewUnexpectedBehaviorError(err)
+	}
+
+	// extract the common create procedure to reuse
+	var createFunc = func() (*unstructured.Unstructured, ApplyAction, error) {
+		// record the raw manifest with the hash annotation in the manifest
+		if _, err := setModifiedConfigurationAnnotation(manifestObj); err != nil {
+			return nil, errorApplyAction, controller.NewUnexpectedBehaviorError(err)
+		}
+		actual, err := applier.SpokeDynamicClient.Resource(gvr).Namespace(manifestObj.GetNamespace()).Create(
+			ctx, manifestObj, metav1.CreateOptions{FieldManager: workFieldManagerName})
+		if err == nil {
+			klog.V(2).InfoS("successfully created the manifest", "gvr", gvr, "manifest", manifestRef)
+			return actual, manifestCreatedAction, nil
+		}
+		return nil, errorApplyAction, controller.NewAPIServerError(false, err)
+	}
+
+	// support resources with generated name
+	if manifestObj.GetName() == "" && manifestObj.GetGenerateName() != "" {
+		klog.V(2).InfoS("Create the resource with generated name regardless", "gvr", gvr, "manifest", manifestRef)
+		return createFunc()
+	}
+
+	// get the current object and create one if not found
+	curObj, err := applier.SpokeDynamicClient.Resource(gvr).Namespace(manifestObj.GetNamespace()).Get(ctx, manifestObj.GetName(), metav1.GetOptions{})
+	switch {
+	case errors.IsNotFound(err):
+		return createFunc()
+	case err != nil:
+		return nil, errorApplyAction, controller.NewAPIServerError(false, err)
+	}
+
+	conflictedWork, err := findConflictedWork(ctx, applier.HubClient, applier.WorkNamespace, applyStrategy, curObj.GetOwnerReferences())
+	if err != nil {
+		return nil, errorApplyAction, err
+	}
+	if conflictedWork != nil {
+		placement := conflictedWork.Labels[fleetv1beta1.CRPTrackingLabel]
+		err := fmt.Errorf(conflictBetweenPlacementsErrorFormat, placement)
+		klog.ErrorS(err, "Skip applying a manifest managed by another placement but with different apply strategy",
+			"gvr", gvr, "manifest", manifestRef, "applyStrategy", applyStrategy,
+			"conflictedWork", conflictedWork.Name, "conflictedPlacement", placement, "conflictedWorkApplyStrategy", conflictedWork.Spec.ApplyStrategy)
+		return nil, applyConflictBetweenPlacements, controller.NewUserError(err)
+	}
+
+	// check if the existing manifest is managed by the work
+	if !isManifestManagedByWork(curObj.GetOwnerReferences()) {
+		err = fmt.Errorf("resource is not managed by the work controller")
+		klog.ErrorS(err, "Skip applying a not managed manifest", "gvr", gvr, "obj", manifestRef)
+		return nil, errorApplyAction, controller.NewExpectedBehaviorError(err)
+	}
+
+	// We only try to update the object if its spec hash value has changed.
+	if manifestObj.GetAnnotations()[fleetv1beta1.ManifestHashAnnotation] != curObj.GetAnnotations()[fleetv1beta1.ManifestHashAnnotation] {
+		// we need to merge the owner reference between the current and the manifest since we support one manifest
+		// belong to multiple work, so it contains the union of all the appliedWork.
+		manifestObj.SetOwnerReferences(mergeOwnerReference(curObj.GetOwnerReferences(), manifestObj.GetOwnerReferences()))
+		// record the raw manifest with the hash annotation in the manifest.
+		isModifiedConfigAnnotationNotEmpty, err := setModifiedConfigurationAnnotation(manifestObj)
+		if err != nil {
+			return nil, errorApplyAction, err
+		}
+		if !isModifiedConfigAnnotationNotEmpty {
+			klog.V(2).InfoS("Using server side apply for manifest", "gvr", gvr, "manifest", manifestRef)
+			return serverSideApply(ctx, applier.SpokeDynamicClient, true, gvr, manifestObj)
+		}
+		klog.V(2).InfoS("Using three way merge for manifest", "gvr", gvr, "manifest", manifestRef)
+		return applier.patchCurrentResource(ctx, gvr, manifestObj, curObj)
+	}
+
+	return curObj, errorApplyAction, nil
+}
+
+// patchCurrentResource uses three-way merge to patch the current resource with the new manifest we get from the work.
+func (applier *FailIfExistsApplier) patchCurrentResource(ctx context.Context, gvr schema.GroupVersionResource,
+	manifestObj, curObj *unstructured.Unstructured) (*unstructured.Unstructured, ApplyAction, error) {
+	manifestRef := klog.KObj(manifestObj)
+	klog.V(2).InfoS("Manifest is modified", "gvr", gvr, "manifest", manifestRef,
+		"new hash", manifestObj.GetAnnotations()[fleetv1beta1.ManifestHashAnnotation],
+		"existing hash", curObj.GetAnnotations()[fleetv1beta1.ManifestHashAnnotation])
+	// create the three-way merge patch between the current, original and manifest similar to how kubectl apply does
+	patch, err := threeWayMergePatch(curObj, manifestObj)
+	if err != nil {
+		klog.ErrorS(err, "Failed to generate the three way patch", "gvr", gvr, "manifest", manifestRef)
+		return nil, errorApplyAction, controller.NewUnexpectedBehaviorError(err)
+	}
+	data, err := patch.Data(manifestObj)
+	if err != nil {
+		klog.ErrorS(err, "Failed to generate the three way patch", "gvr", gvr, "manifest", manifestRef)
+		return nil, errorApplyAction, controller.NewUnexpectedBehaviorError(err)
+	}
+	// Use client side apply the patch to the member cluster
+	manifestObj, patchErr := applier.SpokeDynamicClient.Resource(gvr).Namespace(manifestObj.GetNamespace()).
+		Patch(ctx, manifestObj.GetName(), patch.Type(), data, metav1.PatchOptions{FieldManager: workFieldManagerName})
+	if patchErr != nil {
+		klog.ErrorS(patchErr, "Failed to patch the manifest", "gvr", gvr, "manifest", manifestRef)
+		return nil, errorApplyAction, controller.NewAPIServerError(false, patchErr)
+	}
+	klog.V(2).InfoS("Manifest patch succeeded", "gvr", gvr, "manifest", manifestRef)
+	return manifestObj, manifestThreeWayMergePatchAction, nil
+}

--- a/pkg/controllers/work/applier_server_side.go
+++ b/pkg/controllers/work/applier_server_side.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package work
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/utils/controller"
+)
+
+// ServerSideApplier applies the manifest to the cluster using server side apply.
+type ServerSideApplier struct {
+	HubClient          client.Client
+	WorkNamespace      string
+	SpokeDynamicClient dynamic.Interface
+}
+
+// ApplyUnstructured applies the manifest to the cluster using server side apply according to the given apply strategy.
+func (applier *ServerSideApplier) ApplyUnstructured(ctx context.Context, applyStrategy *fleetv1beta1.ApplyStrategy, gvr schema.GroupVersionResource, manifestObj *unstructured.Unstructured) (*unstructured.Unstructured, ApplyAction, error) {
+	force := applyStrategy.ServerSideApplyConfig.ForceConflicts
+
+	manifestRef := klog.KObj(manifestObj)
+	// support resources with generated name
+	if manifestObj.GetName() == "" && manifestObj.GetGenerateName() != "" {
+		klog.V(2).InfoS("Create the resource with generated name regardless", "gvr", gvr, "manifest", manifestRef)
+		return serverSideApply(ctx, applier.SpokeDynamicClient, force, gvr, manifestObj)
+	}
+
+	curObj, err := applier.SpokeDynamicClient.Resource(gvr).Namespace(manifestObj.GetNamespace()).Get(ctx, manifestObj.GetName(), metav1.GetOptions{})
+	switch {
+	case errors.IsNotFound(err):
+		return serverSideApply(ctx, applier.SpokeDynamicClient, force, gvr, manifestObj)
+	case err != nil:
+		return nil, errorApplyAction, controller.NewAPIServerError(false, err)
+	}
+
+	conflictedWork, err := findConflictedWork(ctx, applier.HubClient, applier.WorkNamespace, applyStrategy, curObj.GetOwnerReferences())
+	if err != nil {
+		return nil, errorApplyAction, err
+	}
+	if conflictedWork != nil {
+		placement := conflictedWork.Labels[fleetv1beta1.CRPTrackingLabel]
+		err := fmt.Errorf(conflictBetweenPlacementsErrorFormat, placement)
+		klog.ErrorS(err, "Skip applying a manifest managed by another placement but with different apply strategy",
+			"gvr", gvr, "manifest", manifestRef, "applyStrategy", applyStrategy,
+			"conflictedWork", conflictedWork.Name, "conflictedPlacement", placement, "conflictedWorkApplyStrategy", conflictedWork.Spec.ApplyStrategy)
+		return nil, applyConflictBetweenPlacements, controller.NewUserError(err)
+	}
+	return serverSideApply(ctx, applier.SpokeDynamicClient, force, gvr, manifestObj)
+}

--- a/pkg/controllers/work/applier_server_side_test.go
+++ b/pkg/controllers/work/applier_server_side_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package work
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	testingclient "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/utils/controller"
+)
+
+func TestApplyUnstructured(t *testing.T) {
+	tests := []struct {
+		name            string
+		manifest        *unstructured.Unstructured
+		owners          []metav1.OwnerReference
+		doeExist        bool // return whether the deployment exists
+		works           []placementv1beta1.Work
+		wantApplyAction ApplyAction
+		wantErr         error
+	}{
+		{
+			name: "the deployment has a generated name",
+			manifest: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"namespace":    "test-namespace",
+						"generateName": "Test",
+					},
+				},
+			},
+			wantApplyAction: manifestServerSideAppliedAction,
+		},
+		{
+			name: "the deployment does not exist",
+			manifest: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"namespace": "test-namespace",
+						"name":      "test",
+					},
+				},
+			},
+			wantApplyAction: manifestServerSideAppliedAction,
+		},
+		{
+			name: "the deployment exists and has conflicts with other work",
+			manifest: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"namespace": "test-namespace",
+						"name":      "test",
+					},
+				},
+			},
+			owners: []metav1.OwnerReference{
+				{
+					APIVersion: placementv1beta1.GroupVersion.String(),
+					Kind:       "another-type",
+					Name:       "work1",
+				},
+				{
+					APIVersion: placementv1beta1.GroupVersion.String(),
+					Kind:       placementv1beta1.AppliedWorkKind,
+					Name:       "work2",
+				},
+			},
+			doeExist: true,
+			works: []placementv1beta1.Work{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testWorkNamespace,
+						Name:      "work2",
+					},
+					Spec: placementv1beta1.WorkSpec{
+						ApplyStrategy: &placementv1beta1.ApplyStrategy{
+							Type: placementv1beta1.ApplyStrategyTypeServerSideApply,
+							ServerSideApplyConfig: &placementv1beta1.ServerSideApplyConfig{
+								ForceConflicts: true,
+							},
+						},
+					},
+				},
+			},
+			wantApplyAction: applyConflictBetweenPlacements,
+			wantErr:         controller.ErrUserError,
+		},
+		{
+			name: "the deployment exists and has no conflicts with other work",
+			manifest: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"namespace": "test-namespace",
+						"name":      "test",
+					},
+				},
+			},
+			owners: []metav1.OwnerReference{
+				{
+					APIVersion: placementv1beta1.GroupVersion.String(),
+					Kind:       placementv1beta1.AppliedWorkKind,
+					Name:       "work2",
+				},
+			},
+			doeExist: true,
+			works: []placementv1beta1.Work{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testWorkNamespace,
+						Name:      "work2",
+					},
+					Spec: placementv1beta1.WorkSpec{
+						ApplyStrategy: &placementv1beta1.ApplyStrategy{
+							Type: placementv1beta1.ApplyStrategyTypeServerSideApply,
+							ServerSideApplyConfig: &placementv1beta1.ServerSideApplyConfig{
+								ForceConflicts: false,
+							},
+						},
+					},
+				},
+			},
+			wantApplyAction: manifestServerSideAppliedAction,
+		},
+		{
+			name: "the deployment exists and is owned by other non-work resource",
+			manifest: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"namespace": "test-namespace",
+						"name":      "test",
+					},
+				},
+			},
+			owners: []metav1.OwnerReference{
+				{
+					APIVersion: placementv1beta1.GroupVersion.String(),
+					Kind:       "another-type",
+					Name:       "work1",
+				},
+			},
+			doeExist:        true,
+			wantApplyAction: manifestServerSideAppliedAction,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+			// The fake client does not support PatchType ApplyPatchType
+			// see issue: https://github.com/kubernetes/kubernetes/issues/103816
+			// always return true for the patch action
+			dynamicClient.PrependReactor("patch", "*", func(action testingclient.Action) (handled bool, ret runtime.Object, err error) {
+				return true, tc.manifest.DeepCopy(), nil
+			})
+			dynamicClient.PrependReactor("get", "*", func(action testingclient.Action) (handled bool, ret runtime.Object, err error) {
+				if tc.doeExist {
+					res := tc.manifest.DeepCopy()
+					res.SetOwnerReferences(tc.owners)
+					return true, res, nil
+				}
+				return true, nil, &apierrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status: metav1.StatusFailure,
+						Reason: metav1.StatusReasonNotFound,
+					}}
+			})
+
+			var objects []client.Object
+			for i := range tc.works {
+				objects = append(objects, &tc.works[i])
+			}
+			scheme := serviceScheme(t)
+			hubClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+			applier := &ServerSideApplier{
+				SpokeDynamicClient: dynamicClient,
+				HubClient:          hubClient,
+				WorkNamespace:      testWorkNamespace,
+			}
+			ctx := context.Background()
+			applyStrategy := &placementv1beta1.ApplyStrategy{
+				Type: placementv1beta1.ApplyStrategyTypeServerSideApply,
+				ServerSideApplyConfig: &placementv1beta1.ServerSideApplyConfig{
+					ForceConflicts: false,
+				},
+			}
+			gvr := schema.GroupVersionResource{
+				Group:    "apps",
+				Version:  "v1",
+				Resource: "Deployment",
+			}
+
+			// We don't check the returned unstructured object because the fake client always return the same object we pass in.
+			_, gotApplyAction, err := applier.ApplyUnstructured(ctx, applyStrategy, gvr, tc.manifest)
+			if gotErr, wantErr := err != nil, tc.wantErr != nil; gotErr != wantErr || !errors.Is(err, tc.wantErr) {
+				t.Fatalf("ApplyUnstructured() got error %v, want error %v", err, tc.wantErr)
+			}
+			// no matter error or not, we should check the apply action
+			if gotApplyAction != tc.wantApplyAction {
+				t.Errorf("ApplyUnstructured() got apply action %v, want apply action %v", gotApplyAction, tc.wantApplyAction)
+			}
+		})
+	}
+}

--- a/pkg/controllers/work/applier_server_side_test.go
+++ b/pkg/controllers/work/applier_server_side_test.go
@@ -30,7 +30,7 @@ func TestApplyUnstructured(t *testing.T) {
 		allowCoOwnership bool
 		manifest         *unstructured.Unstructured
 		owners           []metav1.OwnerReference
-		doeExist         bool // return whether the deployment exists
+		doesExist        bool // return whether the deployment exists
 		works            []placementv1beta1.Work
 		wantApplyAction  ApplyAction
 		wantErr          error
@@ -87,7 +87,7 @@ func TestApplyUnstructured(t *testing.T) {
 					Name:       "work2",
 				},
 			},
-			doeExist: true,
+			doesExist: true,
 			works: []placementv1beta1.Work{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -126,7 +126,7 @@ func TestApplyUnstructured(t *testing.T) {
 					Name:       "work2",
 				},
 			},
-			doeExist: true,
+			doesExist: true,
 			works: []placementv1beta1.Work{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -165,7 +165,7 @@ func TestApplyUnstructured(t *testing.T) {
 					Name:       "work1",
 				},
 			},
-			doeExist:        true,
+			doesExist:       true,
 			wantApplyAction: manifestServerSideAppliedAction,
 		},
 		{
@@ -187,7 +187,7 @@ func TestApplyUnstructured(t *testing.T) {
 					Name:       "work1",
 				},
 			},
-			doeExist:        true,
+			doesExist:       true,
 			wantApplyAction: manifestAlreadyOwnedByOthers,
 			wantErr:         controller.ErrUserError,
 		},
@@ -203,7 +203,7 @@ func TestApplyUnstructured(t *testing.T) {
 				return true, tc.manifest.DeepCopy(), nil
 			})
 			dynamicClient.PrependReactor("get", "*", func(action testingclient.Action) (handled bool, ret runtime.Object, err error) {
-				if tc.doeExist {
+				if tc.doesExist {
 					res := tc.manifest.DeepCopy()
 					res.SetOwnerReferences(tc.owners)
 					return true, res, nil

--- a/pkg/controllers/work/applier_test.go
+++ b/pkg/controllers/work/applier_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package work
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+var (
+	testWorkNamespace = "test-work-namespace"
+)
+
+func serviceScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	if err := fleetv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestFindConflictedWork(t *testing.T) {
+	tests := []struct {
+		name          string
+		applyStrategy fleetv1beta1.ApplyStrategy
+		ownerRefs     []metav1.OwnerReference
+		works         []fleetv1beta1.Work
+		wantWorkName  string
+		wantErr       error
+	}{
+		{
+			name: "no conflicted work",
+			applyStrategy: fleetv1beta1.ApplyStrategy{
+				Type: fleetv1beta1.ApplyStrategyTypeFailIfExists,
+			},
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "work1",
+				},
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "work2",
+				},
+			},
+			works: []fleetv1beta1.Work{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testWorkNamespace,
+						Name:      "work1",
+					},
+					Spec: fleetv1beta1.WorkSpec{
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type: fleetv1beta1.ApplyStrategyTypeFailIfExists,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testWorkNamespace,
+						Name:      "work2",
+					},
+				},
+			},
+		},
+		{
+			name: "owner is not a work",
+			applyStrategy: fleetv1beta1.ApplyStrategy{
+				Type: fleetv1beta1.ApplyStrategyTypeFailIfExists,
+			},
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: "invalid",
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "work1",
+				},
+				{
+					APIVersion: "invalid",
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "work2",
+				},
+			},
+			wantWorkName: "",
+		},
+		{
+			name: "conflicted work found for failIfExists strategy",
+			applyStrategy: fleetv1beta1.ApplyStrategy{
+				Type: fleetv1beta1.ApplyStrategyTypeFailIfExists,
+			},
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "work1",
+				},
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "work2",
+				},
+			},
+			works: []fleetv1beta1.Work{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testWorkNamespace,
+						Name:      "work1",
+					},
+					Spec: fleetv1beta1.WorkSpec{
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type: fleetv1beta1.ApplyStrategyTypeServerSideApply,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testWorkNamespace,
+						Name:      "work2",
+					},
+				},
+			},
+			wantWorkName: "work1",
+		},
+		{
+			name: "conflicted work found for serverSideApply strategy",
+			applyStrategy: fleetv1beta1.ApplyStrategy{
+				Type:                  fleetv1beta1.ApplyStrategyTypeServerSideApply,
+				ServerSideApplyConfig: &fleetv1beta1.ServerSideApplyConfig{ForceConflicts: false},
+			},
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "work1",
+				},
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "work2",
+				},
+			},
+			works: []fleetv1beta1.Work{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testWorkNamespace,
+						Name:      "work1",
+					},
+					Spec: fleetv1beta1.WorkSpec{
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type: fleetv1beta1.ApplyStrategyTypeServerSideApply,
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testWorkNamespace,
+						Name:      "work2",
+					},
+					Spec: fleetv1beta1.WorkSpec{
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type:                  fleetv1beta1.ApplyStrategyTypeServerSideApply,
+							ServerSideApplyConfig: &fleetv1beta1.ServerSideApplyConfig{ForceConflicts: true},
+						},
+					},
+				},
+			},
+			wantWorkName: "work2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			var objects []client.Object
+			for i := range tc.works {
+				objects = append(objects, &tc.works[i])
+			}
+			scheme := serviceScheme(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+			got, err := findConflictedWork(ctx, fakeClient, testWorkNamespace, &tc.applyStrategy, tc.ownerRefs)
+			if gotErr, wantErr := err != nil, tc.wantErr != nil; gotErr != wantErr || !errors.Is(err, tc.wantErr) {
+				t.Fatalf("findConflictedWork() got error %v, want error %v", err, tc.wantErr)
+			}
+			if tc.wantErr != nil {
+				return
+			}
+			if got == nil && tc.wantWorkName != "" || got != nil && got.Name != tc.wantWorkName {
+				t.Errorf("findConflictedWork() got %v, want %v", got.Name, tc.wantWorkName)
+			}
+		})
+	}
+}

--- a/pkg/controllers/work/apply_controller.go
+++ b/pkg/controllers/work/apply_controller.go
@@ -54,6 +54,7 @@ import (
 	"go.goms.io/fleet/pkg/utils"
 	"go.goms.io/fleet/pkg/utils/condition"
 	"go.goms.io/fleet/pkg/utils/controller"
+	"go.goms.io/fleet/pkg/utils/defaulter"
 	"go.goms.io/fleet/pkg/utils/resource"
 )
 
@@ -71,6 +72,9 @@ const (
 	workNotTrackableReason        = "WorkNotTrackable"
 	// ManifestApplyFailedReason is the reason string of condition when it failed to apply manifest.
 	ManifestApplyFailedReason = "ManifestApplyFailed"
+	// ApplyConflictBetweenPlacementsReason is the reason string of condition when the manifest is owned by multiple placements,
+	// and they have conflicts.
+	ApplyConflictBetweenPlacementsReason = "ApplyConflictBetweenPlacements"
 	// ManifestAlreadyUpToDateReason is the reason string of condition when the manifest is already up to date.
 	ManifestAlreadyUpToDateReason  = "ManifestAlreadyUpToDate"
 	manifestAlreadyUpToDateMessage = "Manifest is already up to date"
@@ -89,6 +93,7 @@ type ApplyWorkReconciler struct {
 	concurrency        int
 	workNameSpace      string
 	joined             *atomic.Bool
+	appliers           map[fleetv1beta1.ApplyStrategyType]Applier
 }
 
 func NewApplyWorkReconciler(hubClient client.Client, spokeDynamicClient dynamic.Interface, spokeClient client.Client,
@@ -105,39 +110,43 @@ func NewApplyWorkReconciler(hubClient client.Client, spokeDynamicClient dynamic.
 	}
 }
 
-// applyAction represents the action we take to apply the manifest.
+// ApplyAction represents the action we take to apply the manifest.
 // It is used only internally to track the result of the apply function.
 // +enum
-type applyAction string
+type ApplyAction string
 
 const (
 	// manifestCreatedAction indicates that we created the manifest for the first time.
-	manifestCreatedAction applyAction = "ManifestCreated"
+	manifestCreatedAction ApplyAction = "ManifestCreated"
 
 	// manifestThreeWayMergePatchAction indicates that we updated the manifest using three-way merge patch.
-	manifestThreeWayMergePatchAction applyAction = "ManifestThreeWayMergePatched"
+	manifestThreeWayMergePatchAction ApplyAction = "ManifestThreeWayMergePatched"
 
 	// manifestServerSideAppliedAction indicates that we updated the manifest using server side apply.
-	manifestServerSideAppliedAction applyAction = "ManifestServerSideApplied"
+	manifestServerSideAppliedAction ApplyAction = "ManifestServerSideApplied"
 
 	// errorApplyAction indicates that there was an error during the apply action.
-	errorApplyAction applyAction = "ErrorApply"
+	errorApplyAction ApplyAction = "ErrorApply"
+
+	// applyConflictBetweenPlacements indicates that it fails to apply the manifest as it's owned by multiple placements,
+	// and they have conflict apply strategy.
+	applyConflictBetweenPlacements ApplyAction = "ApplyConflictBetweenPlacements"
 
 	// manifestNotAvailableYetAction indicates that we still need to wait for the manifest to be available.
-	manifestNotAvailableYetAction applyAction = "ManifestNotAvailableYet"
+	manifestNotAvailableYetAction ApplyAction = "ManifestNotAvailableYet"
 
 	// manifestNotTrackableAction indicates that the manifest is already up to date but we don't have a way to track its availabilities.
-	manifestNotTrackableAction applyAction = "ManifestNotTrackable"
+	manifestNotTrackableAction ApplyAction = "ManifestNotTrackable"
 
 	// manifestAvailableAction indicates that the manifest is available.
-	manifestAvailableAction applyAction = "ManifestAvailable"
+	manifestAvailableAction ApplyAction = "ManifestAvailable"
 )
 
 // applyResult contains the result of a manifest being applied.
 type applyResult struct {
 	identifier fleetv1beta1.WorkResourceIdentifier
 	generation int64
-	action     applyAction
+	action     ApplyAction
 	applyErr   error
 }
 
@@ -172,6 +181,10 @@ func (r *ApplyWorkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		klog.V(2).InfoS("Resource is in the process of being deleted", work.Kind, logObjRef)
 		return r.garbageCollectAppliedWork(ctx, work)
 	}
+
+	// set default value so that the following call can skip checking nil
+	// TODO, could be removed once we have the defaulting webhook
+	defaulter.SetDefaultsWork(work)
 
 	// ensure that the appliedWork and the finalizer exist
 	appliedWork, err := r.ensureAppliedWork(ctx, work)
@@ -348,7 +361,7 @@ func (r *ApplyWorkReconciler) applyManifests(ctx context.Context, manifests []fl
 
 		default:
 			addOwnerRef(owner, rawObj)
-			appliedObj, result.action, result.applyErr = r.applyUnstructured(ctx, gvr, rawObj)
+			appliedObj, result.action, result.applyErr = r.applyUnstructuredAndTrackAvailability(ctx, gvr, rawObj, applyStrategy)
 			result.identifier = buildResourceIdentifier(index, rawObj, gvr)
 			logObjRef := klog.ObjectRef{
 				Name:      result.identifier.Name,
@@ -383,82 +396,32 @@ func (r *ApplyWorkReconciler) decodeManifest(manifest fleetv1beta1.Manifest) (sc
 	return mapping.Resource, unstructuredObj, nil
 }
 
-// applyUnstructured determines if an unstructured manifest object can & should be applied. It first validates
+// applyUnstructuredAndTrackAvailability determines if an unstructured manifest object can & should be applied. It first validates
 // the size of the last modified annotation of the manifest, it removes the annotation if the size crosses the annotation size threshold
 // and then creates/updates the resource on the cluster using server side apply instead of three-way merge patch.
-func (r *ApplyWorkReconciler) applyUnstructured(ctx context.Context, gvr schema.GroupVersionResource,
-	manifestObj *unstructured.Unstructured) (*unstructured.Unstructured, applyAction, error) {
-	manifestRef := klog.ObjectRef{
-		Name:      manifestObj.GetName(),
-		Namespace: manifestObj.GetNamespace(),
+func (r *ApplyWorkReconciler) applyUnstructuredAndTrackAvailability(ctx context.Context, gvr schema.GroupVersionResource,
+	manifestObj *unstructured.Unstructured, applyStrategy *fleetv1beta1.ApplyStrategy) (*unstructured.Unstructured, ApplyAction, error) {
+	objManifest := klog.KObj(manifestObj)
+	applier := r.appliers[applyStrategy.Type]
+	if applier == nil {
+		err := fmt.Errorf("unknown apply strategy type %s", applyStrategy.Type)
+		klog.ErrorS(err, "Apply strategy type is unsupported", "gvr", gvr, "manifest", objManifest, "applyStrategyType", applyStrategy.Type)
+		return nil, errorApplyAction, controller.NewUserError(err)
 	}
 
-	// compute the hash without taking into consider the last applied annotation
-	if err := setManifestHashAnnotation(manifestObj); err != nil {
-		return nil, errorApplyAction, err
+	curObj, applyActionRes, err := applier.ApplyUnstructured(ctx, applyStrategy, gvr, manifestObj)
+	if err != nil {
+		klog.ErrorS(err, "Failed to apply the manifest", "gvr", gvr, "manifest", objManifest, "applyStrategyType", applyStrategy.Type)
+		return nil, applyActionRes, err // do not overwrite the applyActionRes
 	}
+	klog.V(2).InfoS("Applied the manifest", "gvr", gvr, "manifest", objManifest, "applyStrategyType", applyStrategy.Type)
 
-	// extract the common create procedure to reuse
-	var createFunc = func() (*unstructured.Unstructured, applyAction, error) {
-		// record the raw manifest with the hash annotation in the manifest
-		if _, err := setModifiedConfigurationAnnotation(manifestObj); err != nil {
-			return nil, errorApplyAction, err
-		}
-		actual, err := r.spokeDynamicClient.Resource(gvr).Namespace(manifestObj.GetNamespace()).Create(
-			ctx, manifestObj, metav1.CreateOptions{FieldManager: workFieldManagerName})
-		if err == nil {
-			klog.V(2).InfoS("Successfully created the manifest", "gvr", gvr, "manifest", manifestRef)
-			return actual, manifestCreatedAction, nil
-		}
-		return nil, errorApplyAction, err
-	}
-
-	// support resources with generated name
-	if manifestObj.GetName() == "" && manifestObj.GetGenerateName() != "" {
-		klog.InfoS("Create the resource with generated name regardless", "gvr", gvr, "manifest", manifestRef)
-		return createFunc()
-	}
-
-	// get the current object and create one if not found
-	curObj, err := r.spokeDynamicClient.Resource(gvr).Namespace(manifestObj.GetNamespace()).Get(ctx, manifestObj.GetName(), metav1.GetOptions{})
-	switch {
-	case apierrors.IsNotFound(err):
-		return createFunc()
-	case err != nil:
-		return nil, errorApplyAction, controller.NewAPIServerError(false, err)
-	}
-
-	// check if the existing manifest is managed by the work
-	if !isManifestManagedByWork(curObj.GetOwnerReferences()) {
-		// TODO: honer the applyStrategy to decide if we should overwrite the existing resource
-		err = fmt.Errorf("resource is not managed by the work controller")
-		klog.ErrorS(err, "Skip applying a not managed manifest", "gvr", gvr, "obj", manifestRef)
-		return nil, errorApplyAction, controller.NewExpectedBehaviorError(err)
-	}
-
-	// We only try to update the object if its spec hash value has changed.
-	if manifestObj.GetAnnotations()[fleetv1beta1.ManifestHashAnnotation] != curObj.GetAnnotations()[fleetv1beta1.ManifestHashAnnotation] {
-		// we need to merge the owner reference between the current and the manifest since we support one manifest
-		// belong to multiple work, so it contains the union of all the appliedWork.
-		manifestObj.SetOwnerReferences(mergeOwnerReference(curObj.GetOwnerReferences(), manifestObj.GetOwnerReferences()))
-		// record the raw manifest with the hash annotation in the manifest.
-		isModifiedConfigAnnotationNotEmpty, err := setModifiedConfigurationAnnotation(manifestObj)
-		if err != nil {
-			return nil, errorApplyAction, err
-		}
-		if !isModifiedConfigAnnotationNotEmpty {
-			klog.V(2).InfoS("Using server side apply for manifest", "gvr", gvr, "manifest", manifestRef)
-			return r.serversideApplyObject(ctx, gvr, manifestObj)
-		}
-		klog.V(2).InfoS("Using three way merge for manifest", "gvr", gvr, "manifest", manifestRef)
-		return r.patchCurrentResource(ctx, gvr, manifestObj, curObj)
-	}
 	// the manifest is already up to date, we just need to track its availability
-	applyAction, err := trackResourceAvailability(gvr, curObj)
-	return curObj, applyAction, err
+	applyActionRes, err = trackResourceAvailability(gvr, curObj)
+	return curObj, applyActionRes, err
 }
 
-func trackResourceAvailability(gvr schema.GroupVersionResource, curObj *unstructured.Unstructured) (applyAction, error) {
+func trackResourceAvailability(gvr schema.GroupVersionResource, curObj *unstructured.Unstructured) (ApplyAction, error) {
 	switch gvr {
 	case utils.DeploymentGVR:
 		return trackDeploymentAvailability(curObj)
@@ -478,7 +441,7 @@ func trackResourceAvailability(gvr schema.GroupVersionResource, curObj *unstruct
 	}
 }
 
-func trackDeploymentAvailability(curObj *unstructured.Unstructured) (applyAction, error) {
+func trackDeploymentAvailability(curObj *unstructured.Unstructured) (ApplyAction, error) {
 	var deployment appv1.Deployment
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(curObj.Object, &deployment); err != nil {
 		return errorApplyAction, controller.NewUnexpectedBehaviorError(err)
@@ -500,7 +463,7 @@ func trackDeploymentAvailability(curObj *unstructured.Unstructured) (applyAction
 	return manifestNotAvailableYetAction, nil
 }
 
-func trackStatefulSetAvailability(curObj *unstructured.Unstructured) (applyAction, error) {
+func trackStatefulSetAvailability(curObj *unstructured.Unstructured) (ApplyAction, error) {
 	var statefulSet appv1.StatefulSet
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(curObj.Object, &statefulSet); err != nil {
 		return errorApplyAction, controller.NewUnexpectedBehaviorError(err)
@@ -522,7 +485,7 @@ func trackStatefulSetAvailability(curObj *unstructured.Unstructured) (applyActio
 	return manifestNotAvailableYetAction, nil
 }
 
-func trackDaemonSetAvailability(curObj *unstructured.Unstructured) (applyAction, error) {
+func trackDaemonSetAvailability(curObj *unstructured.Unstructured) (ApplyAction, error) {
 	var daemonSet appv1.DaemonSet
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(curObj.Object, &daemonSet); err != nil {
 		return errorApplyAction, controller.NewUnexpectedBehaviorError(err)
@@ -539,7 +502,7 @@ func trackDaemonSetAvailability(curObj *unstructured.Unstructured) (applyAction,
 	return manifestNotAvailableYetAction, nil
 }
 
-func trackJobAvailability(curObj *unstructured.Unstructured) (applyAction, error) {
+func trackJobAvailability(curObj *unstructured.Unstructured) (ApplyAction, error) {
 	var job batchv1.Job
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(curObj.Object, &job); err != nil {
 		return errorApplyAction, controller.NewUnexpectedBehaviorError(err)
@@ -560,58 +523,6 @@ func trackJobAvailability(curObj *unstructured.Unstructured) (applyAction, error
 	// this field only exists in k8s 1.24+ by default, so we can't track the availability of the job without it
 	klog.V(2).InfoS("Job does not have ready status, we can't track its availability", "job", klog.KObj(curObj))
 	return manifestNotTrackableAction, nil
-}
-
-// serversideApplyObject uses server side apply to apply the manifest.
-func (r *ApplyWorkReconciler) serversideApplyObject(ctx context.Context, gvr schema.GroupVersionResource,
-	manifestObj *unstructured.Unstructured) (*unstructured.Unstructured, applyAction, error) {
-	manifestRef := klog.ObjectRef{
-		Name:      manifestObj.GetName(),
-		Namespace: manifestObj.GetNamespace(),
-	}
-	options := metav1.ApplyOptions{
-		FieldManager: workFieldManagerName,
-		Force:        true,
-	}
-	manifestObj, err := r.spokeDynamicClient.Resource(gvr).Namespace(manifestObj.GetNamespace()).Apply(ctx, manifestObj.GetName(), manifestObj, options)
-	if err != nil {
-		klog.ErrorS(err, "Failed to apply object", "gvr", gvr, "manifest", manifestRef)
-		return nil, errorApplyAction, err
-	}
-	klog.V(2).InfoS("Manifest apply succeeded", "gvr", gvr, "manifest", manifestRef)
-	return manifestObj, manifestServerSideAppliedAction, nil
-}
-
-// patchCurrentResource uses three-way merge to patch the current resource with the new manifest we get from the work.
-func (r *ApplyWorkReconciler) patchCurrentResource(ctx context.Context, gvr schema.GroupVersionResource,
-	manifestObj, curObj *unstructured.Unstructured) (*unstructured.Unstructured, applyAction, error) {
-	manifestRef := klog.ObjectRef{
-		Name:      manifestObj.GetName(),
-		Namespace: manifestObj.GetNamespace(),
-	}
-	klog.V(2).InfoS("Manifest is modified", "gvr", gvr, "manifest", manifestRef,
-		"new hash", manifestObj.GetAnnotations()[fleetv1beta1.ManifestHashAnnotation],
-		"existing hash", curObj.GetAnnotations()[fleetv1beta1.ManifestHashAnnotation])
-	// create the three-way merge patch between the current, original and manifest similar to how kubectl apply does
-	patch, err := threeWayMergePatch(curObj, manifestObj)
-	if err != nil {
-		klog.ErrorS(err, "Failed to generate the three way patch", "gvr", gvr, "manifest", manifestRef)
-		return nil, errorApplyAction, err
-	}
-	data, err := patch.Data(manifestObj)
-	if err != nil {
-		klog.ErrorS(err, "Failed to generate the three way patch", "gvr", gvr, "manifest", manifestRef)
-		return nil, errorApplyAction, err
-	}
-	// Use client side apply the patch to the member cluster
-	manifestObj, patchErr := r.spokeDynamicClient.Resource(gvr).Namespace(manifestObj.GetNamespace()).
-		Patch(ctx, manifestObj.GetName(), patch.Type(), data, metav1.PatchOptions{FieldManager: workFieldManagerName})
-	if patchErr != nil {
-		klog.ErrorS(patchErr, "Failed to patch the manifest", "gvr", gvr, "manifest", manifestRef)
-		return nil, errorApplyAction, patchErr
-	}
-	klog.V(2).InfoS("Manifest patch succeeded", "gvr", gvr, "manifest", manifestRef)
-	return manifestObj, manifestThreeWayMergePatchAction, nil
 }
 
 // constructWorkCondition constructs the work condition based on the apply result
@@ -691,6 +602,18 @@ func (r *ApplyWorkReconciler) Leave(ctx context.Context) error {
 
 // SetupWithManager wires up the controller.
 func (r *ApplyWorkReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.appliers = map[fleetv1beta1.ApplyStrategyType]Applier{
+		fleetv1beta1.ApplyStrategyTypeServerSideApply: &ServerSideApplier{
+			HubClient:          r.client,
+			WorkNamespace:      r.workNameSpace,
+			SpokeDynamicClient: r.spokeDynamicClient,
+		},
+		fleetv1beta1.ApplyStrategyTypeFailIfExists: &FailIfExistsApplier{
+			HubClient:          r.client,
+			WorkNamespace:      r.workNameSpace,
+			SpokeDynamicClient: r.spokeDynamicClient,
+		},
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(ctrloption.Options{
 			MaxConcurrentReconciles: r.concurrency,
@@ -729,13 +652,18 @@ func computeManifestHash(obj *unstructured.Unstructured) (string, error) {
 
 // isManifestManagedByWork determines if an object is managed by the work controller.
 func isManifestManagedByWork(ownerRefs []metav1.OwnerReference) bool {
-	// an object is managed by the work if any of its owner reference is of type appliedWork
+	if len(ownerRefs) == 0 {
+		return false
+	}
+
+	// an object is NOT managed by the work if any of its owner reference is not of type appliedWork
+	// We'll fail the operation if the resource is owned by other applier.
 	for _, ownerRef := range ownerRefs {
-		if ownerRef.APIVersion == fleetv1beta1.GroupVersion.String() && ownerRef.Kind == fleetv1beta1.AppliedWorkKind {
-			return true
+		if ownerRef.APIVersion != fleetv1beta1.GroupVersion.String() || ownerRef.Kind != fleetv1beta1.AppliedWorkKind {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 // findManifestConditionByIdentifier return a ManifestCondition by identifier
@@ -793,7 +721,7 @@ func buildResourceIdentifier(index int, object *unstructured.Unstructured, gvr s
 	}
 }
 
-func buildManifestCondition(err error, action applyAction, observedGeneration int64) []metav1.Condition {
+func buildManifestCondition(err error, action ApplyAction, observedGeneration int64) []metav1.Condition {
 	applyCondition := metav1.Condition{
 		Type:               fleetv1beta1.WorkConditionTypeApplied,
 		LastTransitionTime: metav1.Now(),
@@ -808,10 +736,15 @@ func buildManifestCondition(err error, action applyAction, observedGeneration in
 
 	if err != nil {
 		applyCondition.Status = metav1.ConditionFalse
-		applyCondition.Reason = ManifestApplyFailedReason
+		switch action {
+		case applyConflictBetweenPlacements:
+			applyCondition.Reason = ApplyConflictBetweenPlacementsReason
+		default:
+			applyCondition.Reason = ManifestApplyFailedReason
+		}
 		applyCondition.Message = fmt.Sprintf("Failed to apply manifest: %v", err)
 		availableCondition.Status = metav1.ConditionUnknown
-		availableCondition.Reason = ManifestApplyFailedReason
+		availableCondition.Reason = applyCondition.Reason
 		availableCondition.Message = "Manifest is not applied yet"
 	} else {
 		applyCondition.Status = metav1.ConditionTrue

--- a/pkg/controllers/work/apply_controller_integration_test.go
+++ b/pkg/controllers/work/apply_controller_integration_test.go
@@ -49,7 +49,6 @@ const timeout = time.Second * 10
 const interval = time.Millisecond * 250
 
 var _ = Describe("Work Controller", func() {
-	workNamespace := testWorkNamespace
 	var cm *corev1.ConfigMap
 	var work *fleetv1beta1.Work
 	const defaultNS = "default"
@@ -73,7 +72,7 @@ var _ = Describe("Work Controller", func() {
 			}
 
 			By("create the work")
-			work = createWorkWithManifest(workNamespace, cm)
+			work = createWorkWithManifest(testWorkNamespace, cm)
 			err := k8sClient.Create(context.Background(), work)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -142,7 +141,7 @@ var _ = Describe("Work Controller", func() {
 				},
 			}
 
-			work1 := createWorkWithManifest(workNamespace, cm)
+			work1 := createWorkWithManifest(testWorkNamespace, cm)
 			work2 := work1.DeepCopy()
 			work2.Name = "work-" + utilrand.String(5)
 
@@ -154,8 +153,8 @@ var _ = Describe("Work Controller", func() {
 			err = k8sClient.Create(context.Background(), work2)
 			Expect(err).ToNot(HaveOccurred())
 
-			waitForWorkToApply(work1.GetName(), workNamespace)
-			waitForWorkToApply(work2.GetName(), workNamespace)
+			waitForWorkToApply(work1.GetName(), testWorkNamespace)
+			waitForWorkToApply(work2.GetName(), testWorkNamespace)
 
 			By("Check applied config map")
 			var configMap corev1.ConfigMap
@@ -212,7 +211,7 @@ var _ = Describe("Work Controller", func() {
 			}
 
 			By("create the work")
-			work = createWorkWithManifest(workNamespace, cm)
+			work = createWorkWithManifest(testWorkNamespace, cm)
 			Expect(k8sClient.Create(context.Background(), work)).ToNot(HaveOccurred())
 
 			By("wait for the work to be available")
@@ -274,7 +273,7 @@ var _ = Describe("Work Controller", func() {
 			}
 
 			By("create the work")
-			work = createWorkWithManifest(workNamespace, cm)
+			work = createWorkWithManifest(testWorkNamespace, cm)
 			err := k8sClient.Create(context.Background(), work)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -377,7 +376,7 @@ var _ = Describe("Work Controller", func() {
 			}
 
 			By("create the work")
-			work = createWorkWithManifest(workNamespace, cloneSet)
+			work = createWorkWithManifest(testWorkNamespace, cloneSet)
 			err := k8sClient.Create(context.Background(), work)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -467,11 +466,11 @@ var _ = Describe("Work Controller", func() {
 			}
 
 			By("create the work")
-			work = createWorkWithManifest(workNamespace, cm)
+			work = createWorkWithManifest(testWorkNamespace, cm)
 			Expect(k8sClient.Create(context.Background(), work)).ToNot(HaveOccurred())
 
 			By("create another work that includes the configMap")
-			work2 := createWorkWithManifest(workNamespace, cm)
+			work2 := createWorkWithManifest(testWorkNamespace, cm)
 			Expect(k8sClient.Create(context.Background(), work2)).ToNot(HaveOccurred())
 
 			By("wait for the change of the work1 to be applied")
@@ -519,7 +518,7 @@ var _ = Describe("Work Controller", func() {
 			}
 
 			By("create the work")
-			work = createWorkWithManifest(workNamespace, cm)
+			work = createWorkWithManifest(testWorkNamespace, cm)
 			err := k8sClient.Create(ctx, work)
 			Expect(err).Should(Succeed())
 
@@ -579,7 +578,7 @@ var _ = Describe("Work Controller", func() {
 					Paused: true,
 				},
 			}
-			work = createWorkWithManifest(workNamespace, broadcastJob)
+			work = createWorkWithManifest(testWorkNamespace, broadcastJob)
 			err := k8sClient.Create(context.Background(), work)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -649,7 +648,7 @@ var _ = Describe("Work Controller", func() {
 				}
 				// make sure we can call join as many as possible
 				Expect(workController.Join(ctx)).Should(Succeed())
-				work = createWorkWithManifest(workNamespace, cm)
+				work = createWorkWithManifest(testWorkNamespace, cm)
 				err := k8sClient.Create(ctx, work)
 				Expect(err).ToNot(HaveOccurred())
 				By(fmt.Sprintf("created the work = %s", work.GetName()))
@@ -676,7 +675,7 @@ var _ = Describe("Work Controller", func() {
 			}
 			for i := 0; i < numWork; i++ {
 				var resultWork fleetv1beta1.Work
-				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: works[i].GetName(), Namespace: workNamespace}, &resultWork)).Should(Succeed())
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: works[i].GetName(), Namespace: testWorkNamespace}, &resultWork)).Should(Succeed())
 				Expect(controllerutil.ContainsFinalizer(&resultWork, fleetv1beta1.WorkFinalizer)).Should(BeFalse())
 				// make sure that leave can be called as many times as possible
 				Expect(workController.Leave(ctx)).Should(Succeed())
@@ -703,7 +702,7 @@ var _ = Describe("Work Controller", func() {
 				for i := 0; i < numWork; i++ {
 					By(fmt.Sprintf("updated the work = %s", works[i].GetName()))
 					var resultWork fleetv1beta1.Work
-					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: works[i].GetName(), Namespace: workNamespace}, &resultWork)
+					err := k8sClient.Get(context.Background(), types.NamespacedName{Name: works[i].GetName(), Namespace: testWorkNamespace}, &resultWork)
 					Expect(err).Should(Succeed())
 					Expect(controllerutil.ContainsFinalizer(&resultWork, fleetv1beta1.WorkFinalizer)).Should(BeFalse())
 					applyCond := meta.FindStatusCondition(resultWork.Status.Conditions, fleetv1beta1.WorkConditionTypeApplied)

--- a/pkg/controllers/work/apply_controller_test.go
+++ b/pkg/controllers/work/apply_controller_test.go
@@ -54,7 +54,7 @@ import (
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/utils"
 	"go.goms.io/fleet/pkg/utils/controller"
-	controller2 "go.goms.io/fleet/test/utils/controller"
+	testcontroller "go.goms.io/fleet/test/utils/controller"
 )
 
 var (
@@ -62,6 +62,7 @@ var (
 	ownerRef          = metav1.OwnerReference{
 		APIVersion: fleetv1beta1.GroupVersion.String(),
 		Kind:       "AppliedWork",
+		Name:       "default-work",
 	}
 	testDeployment = appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -277,6 +278,22 @@ func TestIsManifestManagedByWork(t *testing.T) {
 			},
 			isManaged: true,
 		},
+		"include one non-appliedWork owner": {
+			ownerRefs: []metav1.OwnerReference{
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       utilrand.String(10),
+					UID:        types.UID(utilrand.String(10)),
+				},
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       "another-kind",
+					UID:        types.UID(utilrand.String(10)),
+				},
+			},
+			isManaged: false,
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -288,7 +305,7 @@ func TestIsManifestManagedByWork(t *testing.T) {
 func TestBuildManifestCondition(t *testing.T) {
 	tests := map[string]struct {
 		err    error
-		action applyAction
+		action ApplyAction
 		want   []metav1.Condition
 	}{
 		"TestNoErrorManifestCreated": {
@@ -387,7 +404,7 @@ func TestBuildManifestCondition(t *testing.T) {
 				},
 			},
 		},
-		"TestWithError": {
+		"TestApplyError": {
 			err:    errors.New("test error"),
 			action: errorApplyAction,
 			want: []metav1.Condition{
@@ -403,12 +420,28 @@ func TestBuildManifestCondition(t *testing.T) {
 				},
 			},
 		},
+		"TestApplyConflictBetweenPlacements": {
+			err:    errors.New("test error"),
+			action: applyConflictBetweenPlacements,
+			want: []metav1.Condition{
+				{
+					Type:   fleetv1beta1.WorkConditionTypeApplied,
+					Status: metav1.ConditionFalse,
+					Reason: ApplyConflictBetweenPlacementsReason,
+				},
+				{
+					Type:   fleetv1beta1.WorkConditionTypeAvailable,
+					Status: metav1.ConditionUnknown,
+					Reason: ApplyConflictBetweenPlacementsReason,
+				},
+			},
+		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			conditions := buildManifestCondition(tt.err, tt.action, 1)
-			diff := controller2.CompareConditions(tt.want, conditions)
+			diff := testcontroller.CompareConditions(tt.want, conditions)
 			assert.Empty(t, diff, "buildManifestCondition() test %v failed, (-want +got):\n%s", name, diff)
 		})
 	}
@@ -773,7 +806,7 @@ func TestGenerateWorkCondition(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			conditions := buildWorkCondition(tt.manifestConditions, 1)
-			diff := controller2.CompareConditions(tt.expected, conditions)
+			diff := testcontroller.CompareConditions(tt.expected, conditions)
 			assert.Empty(t, diff, "buildWorkCondition() test %v failed, (-want +got):\n%s", name, diff)
 		})
 	}
@@ -783,7 +816,7 @@ func TestTrackResourceAvailability(t *testing.T) {
 	tests := map[string]struct {
 		gvr      schema.GroupVersionResource
 		obj      *unstructured.Unstructured
-		expected applyAction
+		expected ApplyAction
 		err      error
 	}{
 		"Test a mal-formated object": {
@@ -1096,7 +1129,7 @@ func TestTrackResourceAvailability(t *testing.T) {
 	}
 }
 
-func TestApplyUnstructured(t *testing.T) {
+func TestApplyUnstructuredAndTrackAvailability(t *testing.T) {
 	correctObj, correctDynamicClient, correctSpecHash, err := createObjAndDynamicClient(testManifest.Raw)
 	if err != nil {
 		t.Errorf("failed to create obj and dynamic client: %s", err)
@@ -1166,6 +1199,29 @@ func TestApplyUnstructured(t *testing.T) {
 	_, diffOwnerDynamicClient, _, err := createObjAndDynamicClient(rawTestDeploymentWithDifferentOwner)
 	if err != nil {
 		t.Errorf("failed to create obj and dynamic client: %s", err)
+	}
+
+	testDeploymentOwnedByAnotherWork := appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "Deployment",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: fleetv1beta1.GroupVersion.String(),
+					Kind:       fleetv1beta1.AppliedWorkKind,
+					Name:       "another-work",
+					UID:        types.UID(utilrand.String(10)),
+				},
+			},
+		},
+	}
+	rawTestDeploymentByAnotherWork, _ := json.Marshal(testDeploymentOwnedByAnotherWork)
+	_, deploymentOwnedByAnotherWorkClient, _, err := createObjAndDynamicClient(rawTestDeploymentByAnotherWork)
+	if err != nil {
+		t.Errorf("Failed to create obj and dynamic client: %s", err)
 	}
 
 	specHashFailObj := correctObj.DeepCopy()
@@ -1239,7 +1295,7 @@ func TestApplyUnstructured(t *testing.T) {
 		reconciler     ApplyWorkReconciler
 		workObj        *unstructured.Unstructured
 		resultSpecHash string
-		resultAction   applyAction
+		resultAction   ApplyAction
 		resultErr      error
 	}{
 		"test creation succeeds when the object does not exist": {
@@ -1252,7 +1308,7 @@ func TestApplyUnstructured(t *testing.T) {
 			},
 			workObj:        correctObj.DeepCopy(),
 			resultSpecHash: correctSpecHash,
-			resultAction:   manifestCreatedAction,
+			resultAction:   manifestNotAvailableYetAction,
 			resultErr:      nil,
 		},
 		"test creation succeeds when the object has a generated name": {
@@ -1265,7 +1321,7 @@ func TestApplyUnstructured(t *testing.T) {
 			},
 			workObj:        generatedSpecObj.DeepCopy(),
 			resultSpecHash: generatedSpecHash,
-			resultAction:   manifestCreatedAction,
+			resultAction:   manifestNotAvailableYetAction,
 			resultErr:      nil,
 		},
 		"client error looking for object / fail": {
@@ -1292,10 +1348,68 @@ func TestApplyUnstructured(t *testing.T) {
 			resultAction: errorApplyAction,
 			resultErr:    errors.New("resource is not managed by the work controller"),
 		},
+		"resource is owned by another conflicted work (not found)": {
+			reconciler: ApplyWorkReconciler{
+				client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						return apierrors.NewNotFound(schema.GroupResource{}, key.Name)
+					},
+				},
+				spokeDynamicClient: deploymentOwnedByAnotherWorkClient,
+				spokeClient:        &test.MockClient{},
+				restMapper:         testMapper{},
+				recorder:           utils.NewFakeRecorder(1),
+			},
+			workObj:      correctObj.DeepCopy(),
+			resultAction: errorApplyAction,
+			resultErr:    controller.ErrExpectedBehavior,
+		},
+		"resource is owned by another conflicted work": {
+			reconciler: ApplyWorkReconciler{
+				client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						o, _ := obj.(*fleetv1beta1.Work)
+						*o = fleetv1beta1.Work{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "another-work",
+							},
+							Spec: fleetv1beta1.WorkSpec{
+								ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeServerSideApply},
+							},
+						}
+						return nil
+					},
+				},
+				spokeDynamicClient: deploymentOwnedByAnotherWorkClient,
+				spokeClient:        &test.MockClient{},
+				restMapper:         testMapper{},
+				recorder:           utils.NewFakeRecorder(1),
+			},
+			workObj:      correctObj.DeepCopy(),
+			resultAction: applyConflictBetweenPlacements,
+			resultErr:    errors.New("manifest is already managed by placement"),
+		},
+		// TODO add a test case: resource is co-owned by another work
+		// Right now the mock framework cannot send back the correct result unless we mock the behavior.
+		// Need to rewrite the setup to use the fake client.
 		"equal spec hash of current vs work object /  not available yet": {
 			reconciler: ApplyWorkReconciler{
 				spokeDynamicClient: correctDynamicClient,
 				recorder:           utils.NewFakeRecorder(1),
+				client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						o, _ := obj.(*fleetv1beta1.Work)
+						*o = fleetv1beta1.Work{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "default-work",
+							},
+							Spec: fleetv1beta1.WorkSpec{
+								ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+							},
+						}
+						return nil
+					},
+				},
 			},
 			workObj:        correctObj.DeepCopy(),
 			resultSpecHash: correctSpecHash,
@@ -1306,20 +1420,48 @@ func TestApplyUnstructured(t *testing.T) {
 			reconciler: ApplyWorkReconciler{
 				spokeDynamicClient: patchFailClient,
 				recorder:           utils.NewFakeRecorder(1),
+				client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						o, _ := obj.(*fleetv1beta1.Work)
+						*o = fleetv1beta1.Work{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "default-work",
+							},
+							Spec: fleetv1beta1.WorkSpec{
+								ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+							},
+						}
+						return nil
+					},
+				},
 			},
 			workObj:      correctObj.DeepCopy(),
 			resultAction: errorApplyAction,
 			resultErr:    errors.New("patch failed"),
 		},
-		"happy path - with updates": {
+		"happy path - with updates (three way merge patch)": {
 			reconciler: ApplyWorkReconciler{
 				spokeDynamicClient: diffSpecDynamicClient,
 				restMapper:         testMapper{},
 				recorder:           utils.NewFakeRecorder(1),
+				client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						o, _ := obj.(*fleetv1beta1.Work)
+						*o = fleetv1beta1.Work{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "default-work",
+							},
+							Spec: fleetv1beta1.WorkSpec{
+								ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+							},
+						}
+						return nil
+					},
+				},
 			},
 			workObj:        correctObj,
 			resultSpecHash: diffSpecHash,
-			resultAction:   manifestThreeWayMergePatchAction,
+			resultAction:   manifestNotAvailableYetAction,
 			resultErr:      nil,
 		},
 		"test create succeeds for large manifest when object does not exist": {
@@ -1330,7 +1472,7 @@ func TestApplyUnstructured(t *testing.T) {
 			},
 			workObj:        largeObj,
 			resultSpecHash: largeObjSpecHash,
-			resultAction:   manifestCreatedAction,
+			resultAction:   manifestNotAvailableYetAction,
 			resultErr:      nil,
 		},
 		"test apply succeeds on update for large manifest when object exists": {
@@ -1338,10 +1480,24 @@ func TestApplyUnstructured(t *testing.T) {
 				spokeDynamicClient: dynamicClientLargeObjFound,
 				restMapper:         testMapper{},
 				recorder:           utils.NewFakeRecorder(1),
+				client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						o, _ := obj.(*fleetv1beta1.Work)
+						*o = fleetv1beta1.Work{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "default-work",
+							},
+							Spec: fleetv1beta1.WorkSpec{
+								ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+							},
+						}
+						return nil
+					},
+				},
 			},
 			workObj:        updatedLargeObj,
 			resultSpecHash: updatedLargeObjSpecHash,
-			resultAction:   manifestServerSideAppliedAction,
+			resultAction:   manifestNotAvailableYetAction,
 			resultErr:      nil,
 		},
 		"test create fails for large manifest when object does not exist": {
@@ -1359,6 +1515,20 @@ func TestApplyUnstructured(t *testing.T) {
 				spokeDynamicClient: dynamicClientLargeObjApplyFail,
 				restMapper:         testMapper{},
 				recorder:           utils.NewFakeRecorder(1),
+				client: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						o, _ := obj.(*fleetv1beta1.Work)
+						*o = fleetv1beta1.Work{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "default-work",
+							},
+							Spec: fleetv1beta1.WorkSpec{
+								ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+							},
+						}
+						return nil
+					},
+				},
 			},
 			workObj:      updatedLargeObj,
 			resultAction: errorApplyAction,
@@ -1368,7 +1538,16 @@ func TestApplyUnstructured(t *testing.T) {
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			applyResult, applyAction, err := testCase.reconciler.applyUnstructured(context.Background(), utils.DeploymentGVR, testCase.workObj)
+			r := testCase.reconciler
+			r.appliers = map[fleetv1beta1.ApplyStrategyType]Applier{
+				fleetv1beta1.ApplyStrategyTypeFailIfExists: &FailIfExistsApplier{
+					HubClient:          r.client,
+					WorkNamespace:      r.workNameSpace,
+					SpokeDynamicClient: r.spokeDynamicClient,
+				},
+			}
+			strategy := &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists}
+			applyResult, applyAction, err := r.applyUnstructuredAndTrackAvailability(context.Background(), utils.DeploymentGVR, testCase.workObj, strategy)
 			assert.Equalf(t, testCase.resultAction, applyAction, "updated boolean not matching for Testcase %s", testName)
 			if testCase.resultErr != nil {
 				assert.Containsf(t, err.Error(), testCase.resultErr.Error(), "error not matching for Testcase %s", testName)
@@ -1419,9 +1598,8 @@ func TestApplyManifest(t *testing.T) {
 	testCases := map[string]struct {
 		reconciler     ApplyWorkReconciler
 		manifestList   []fleetv1beta1.Manifest
-		applyStrategy  *fleetv1beta1.ApplyStrategy
 		wantGeneration int64
-		wantAction     applyAction
+		wantAction     ApplyAction
 		wantGvr        schema.GroupVersionResource
 		wantErr        error
 	}{
@@ -1436,7 +1614,7 @@ func TestApplyManifest(t *testing.T) {
 			},
 			manifestList:   []fleetv1beta1.Manifest{testManifest},
 			wantGeneration: 0,
-			wantAction:     manifestCreatedAction,
+			wantAction:     manifestNotAvailableYetAction,
 			wantGvr:        expectedGvr,
 			wantErr:        nil,
 		},
@@ -1473,7 +1651,7 @@ func TestApplyManifest(t *testing.T) {
 			wantGvr:        emptyGvr,
 			wantErr:        errors.New("failed to find group/version/resource from restmapping: test error: mapping does not exist"),
 		},
-		"manifest is in proper format/ should fail applyUnstructured": {
+		"manifest is in proper format/ should fail applyUnstructuredAndTrackAvailability": {
 			reconciler: ApplyWorkReconciler{
 				client:             &test.MockClient{},
 				spokeDynamicClient: clientFailDynamicClient,
@@ -1492,7 +1670,16 @@ func TestApplyManifest(t *testing.T) {
 
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			resultList := testCase.reconciler.applyManifests(context.Background(), testCase.manifestList, ownerRef, testCase.applyStrategy)
+			r := testCase.reconciler
+			r.appliers = map[fleetv1beta1.ApplyStrategyType]Applier{
+				fleetv1beta1.ApplyStrategyTypeFailIfExists: &FailIfExistsApplier{
+					HubClient:          r.client,
+					WorkNamespace:      r.workNameSpace,
+					SpokeDynamicClient: r.spokeDynamicClient,
+				},
+			}
+			applyStrategy := &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists}
+			resultList := r.applyManifests(context.Background(), testCase.manifestList, ownerRef, applyStrategy)
 			for _, result := range resultList {
 				if testCase.wantErr != nil {
 					assert.Containsf(t, result.applyErr.Error(), testCase.wantErr.Error(), "Incorrect error for Testcase %s", testName)
@@ -1540,11 +1727,14 @@ func TestReconcile(t *testing.T) {
 		o, _ := obj.(*fleetv1beta1.Work)
 		*o = fleetv1beta1.Work{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:  workNamespace,
-				Name:       workName,
+				Namespace:  key.Namespace,
+				Name:       key.Name,
 				Finalizers: []string{fleetv1beta1.WorkFinalizer},
 			},
-			Spec: fleetv1beta1.WorkSpec{Workload: fleetv1beta1.WorkloadTemplate{Manifests: []fleetv1beta1.Manifest{testManifest}}},
+			Spec: fleetv1beta1.WorkSpec{
+				Workload:      fleetv1beta1.WorkloadTemplate{Manifests: []fleetv1beta1.Manifest{testManifest}},
+				ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+			},
 		}
 		return nil
 	}
@@ -1811,7 +2001,16 @@ func TestReconcile(t *testing.T) {
 	}
 	for testName, testCase := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			ctrlResult, err := testCase.reconciler.Reconcile(context.Background(), testCase.req)
+			r := testCase.reconciler
+			r.workNameSpace = workNamespace
+			r.appliers = map[fleetv1beta1.ApplyStrategyType]Applier{
+				fleetv1beta1.ApplyStrategyTypeFailIfExists: &FailIfExistsApplier{
+					HubClient:          r.client,
+					WorkNamespace:      r.workNameSpace,
+					SpokeDynamicClient: r.spokeDynamicClient,
+				},
+			}
+			ctrlResult, err := r.Reconcile(context.Background(), testCase.req)
 			if testCase.wantErr != nil {
 				assert.Containsf(t, err.Error(), testCase.wantErr.Error(), "incorrect error for Testcase %s", testName)
 			} else {

--- a/pkg/utils/defaulter/work.go
+++ b/pkg/utils/defaulter/work.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+// Package defaulter sets default values for the fleet resources.
+package defaulter
+
+import fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+
+// SetDefaultsWork sets the default values for the Work resource.
+func SetDefaultsWork(w *fleetv1beta1.Work) {
+	if w.Spec.ApplyStrategy == nil {
+		w.Spec.ApplyStrategy = &fleetv1beta1.ApplyStrategy{}
+	}
+
+	if w.Spec.ApplyStrategy.Type == "" {
+		w.Spec.ApplyStrategy.Type = fleetv1beta1.ApplyStrategyTypeFailIfExists
+	}
+
+	if w.Spec.ApplyStrategy.Type == fleetv1beta1.ApplyStrategyTypeServerSideApply && w.Spec.ApplyStrategy.ServerSideApplyConfig == nil {
+		w.Spec.ApplyStrategy.ServerSideApplyConfig = &fleetv1beta1.ServerSideApplyConfig{
+			ForceConflicts: false,
+		}
+	}
+}

--- a/pkg/utils/defaulter/work.go
+++ b/pkg/utils/defaulter/work.go
@@ -6,20 +6,20 @@ Licensed under the MIT license.
 // Package defaulter sets default values for the fleet resources.
 package defaulter
 
-import fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+import placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 
 // SetDefaultsWork sets the default values for the Work resource.
-func SetDefaultsWork(w *fleetv1beta1.Work) {
+func SetDefaultsWork(w *placementv1beta1.Work) {
 	if w.Spec.ApplyStrategy == nil {
-		w.Spec.ApplyStrategy = &fleetv1beta1.ApplyStrategy{}
+		w.Spec.ApplyStrategy = &placementv1beta1.ApplyStrategy{}
 	}
 
 	if w.Spec.ApplyStrategy.Type == "" {
-		w.Spec.ApplyStrategy.Type = fleetv1beta1.ApplyStrategyTypeFailIfExists
+		w.Spec.ApplyStrategy.Type = placementv1beta1.ApplyStrategyTypeClientSideApply
 	}
 
-	if w.Spec.ApplyStrategy.Type == fleetv1beta1.ApplyStrategyTypeServerSideApply && w.Spec.ApplyStrategy.ServerSideApplyConfig == nil {
-		w.Spec.ApplyStrategy.ServerSideApplyConfig = &fleetv1beta1.ServerSideApplyConfig{
+	if w.Spec.ApplyStrategy.Type == placementv1beta1.ApplyStrategyTypeServerSideApply && w.Spec.ApplyStrategy.ServerSideApplyConfig == nil {
+		w.Spec.ApplyStrategy.ServerSideApplyConfig = &placementv1beta1.ServerSideApplyConfig{
 			ForceConflicts: false,
 		}
 	}

--- a/pkg/utils/defaulter/work_test.go
+++ b/pkg/utils/defaulter/work_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package defaulter
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+func TestSetDefaultsWork(t *testing.T) {
+	tests := []struct {
+		name string
+		work fleetv1beta1.Work
+		want fleetv1beta1.Work
+	}{
+		{
+			name: "nil applyStrategy",
+			work: fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{},
+			},
+			want: fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{
+					ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+				},
+			},
+		},
+		{
+			name: "empty strategy type",
+			work: fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{
+					ApplyStrategy: &fleetv1beta1.ApplyStrategy{},
+				},
+			},
+			want: fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{
+					ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+				},
+			},
+		},
+		{
+			name: "nil server side apply config",
+			work: fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{
+					ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeServerSideApply},
+				},
+			},
+			want: fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{
+					ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+						Type:                  fleetv1beta1.ApplyStrategyTypeServerSideApply,
+						ServerSideApplyConfig: &fleetv1beta1.ServerSideApplyConfig{ForceConflicts: false},
+					},
+				},
+			},
+		},
+		{
+			name: "all fields are set",
+			work: fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{
+					ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+						Type:                  fleetv1beta1.ApplyStrategyTypeServerSideApply,
+						ServerSideApplyConfig: &fleetv1beta1.ServerSideApplyConfig{ForceConflicts: true},
+					},
+				},
+			},
+			want: fleetv1beta1.Work{
+				Spec: fleetv1beta1.WorkSpec{
+					ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+						Type:                  fleetv1beta1.ApplyStrategyTypeServerSideApply,
+						ServerSideApplyConfig: &fleetv1beta1.ServerSideApplyConfig{ForceConflicts: true},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			SetDefaultsWork(&tc.work)
+			if diff := cmp.Diff(tc.work, tc.work); diff != "" {
+				t.Errorf("SetDefaultsWork() mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/utils/defaulter/work_test.go
+++ b/pkg/utils/defaulter/work_test.go
@@ -10,70 +10,70 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 )
 
 func TestSetDefaultsWork(t *testing.T) {
 	tests := []struct {
 		name string
-		work fleetv1beta1.Work
-		want fleetv1beta1.Work
+		work placementv1beta1.Work
+		want placementv1beta1.Work
 	}{
 		{
 			name: "nil applyStrategy",
-			work: fleetv1beta1.Work{
-				Spec: fleetv1beta1.WorkSpec{},
+			work: placementv1beta1.Work{
+				Spec: placementv1beta1.WorkSpec{},
 			},
-			want: fleetv1beta1.Work{
-				Spec: fleetv1beta1.WorkSpec{
-					ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+			want: placementv1beta1.Work{
+				Spec: placementv1beta1.WorkSpec{
+					ApplyStrategy: &placementv1beta1.ApplyStrategy{Type: placementv1beta1.ApplyStrategyTypeClientSideApply},
 				},
 			},
 		},
 		{
 			name: "empty strategy type",
-			work: fleetv1beta1.Work{
-				Spec: fleetv1beta1.WorkSpec{
-					ApplyStrategy: &fleetv1beta1.ApplyStrategy{},
+			work: placementv1beta1.Work{
+				Spec: placementv1beta1.WorkSpec{
+					ApplyStrategy: &placementv1beta1.ApplyStrategy{},
 				},
 			},
-			want: fleetv1beta1.Work{
-				Spec: fleetv1beta1.WorkSpec{
-					ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeFailIfExists},
+			want: placementv1beta1.Work{
+				Spec: placementv1beta1.WorkSpec{
+					ApplyStrategy: &placementv1beta1.ApplyStrategy{Type: placementv1beta1.ApplyStrategyTypeClientSideApply},
 				},
 			},
 		},
 		{
 			name: "nil server side apply config",
-			work: fleetv1beta1.Work{
-				Spec: fleetv1beta1.WorkSpec{
-					ApplyStrategy: &fleetv1beta1.ApplyStrategy{Type: fleetv1beta1.ApplyStrategyTypeServerSideApply},
+			work: placementv1beta1.Work{
+				Spec: placementv1beta1.WorkSpec{
+					ApplyStrategy: &placementv1beta1.ApplyStrategy{Type: placementv1beta1.ApplyStrategyTypeServerSideApply},
 				},
 			},
-			want: fleetv1beta1.Work{
-				Spec: fleetv1beta1.WorkSpec{
-					ApplyStrategy: &fleetv1beta1.ApplyStrategy{
-						Type:                  fleetv1beta1.ApplyStrategyTypeServerSideApply,
-						ServerSideApplyConfig: &fleetv1beta1.ServerSideApplyConfig{ForceConflicts: false},
+			want: placementv1beta1.Work{
+				Spec: placementv1beta1.WorkSpec{
+					ApplyStrategy: &placementv1beta1.ApplyStrategy{
+						Type:                  placementv1beta1.ApplyStrategyTypeServerSideApply,
+						ServerSideApplyConfig: &placementv1beta1.ServerSideApplyConfig{ForceConflicts: false},
 					},
 				},
 			},
 		},
 		{
 			name: "all fields are set",
-			work: fleetv1beta1.Work{
-				Spec: fleetv1beta1.WorkSpec{
-					ApplyStrategy: &fleetv1beta1.ApplyStrategy{
-						Type:                  fleetv1beta1.ApplyStrategyTypeServerSideApply,
-						ServerSideApplyConfig: &fleetv1beta1.ServerSideApplyConfig{ForceConflicts: true},
+			work: placementv1beta1.Work{
+				Spec: placementv1beta1.WorkSpec{
+					ApplyStrategy: &placementv1beta1.ApplyStrategy{
+						Type:                  placementv1beta1.ApplyStrategyTypeServerSideApply,
+						ServerSideApplyConfig: &placementv1beta1.ServerSideApplyConfig{ForceConflicts: true},
 					},
 				},
 			},
-			want: fleetv1beta1.Work{
-				Spec: fleetv1beta1.WorkSpec{
-					ApplyStrategy: &fleetv1beta1.ApplyStrategy{
-						Type:                  fleetv1beta1.ApplyStrategyTypeServerSideApply,
-						ServerSideApplyConfig: &fleetv1beta1.ServerSideApplyConfig{ForceConflicts: true},
+			want: placementv1beta1.Work{
+				Spec: placementv1beta1.WorkSpec{
+					ApplyStrategy: &placementv1beta1.ApplyStrategy{
+						Type:                  placementv1beta1.ApplyStrategyTypeServerSideApply,
+						ServerSideApplyConfig: &placementv1beta1.ServerSideApplyConfig{ForceConflicts: true},
 					},
 				},
 			},
@@ -82,7 +82,7 @@ func TestSetDefaultsWork(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			SetDefaultsWork(&tc.work)
-			if diff := cmp.Diff(tc.work, tc.work); diff != "" {
+			if diff := cmp.Diff(tc.want, tc.work); diff != "" {
 				t.Errorf("SetDefaultsWork() mismatch (-want, +got):\n%s", diff)
 			}
 		})

--- a/test/e2e/placement_selecting_resources_test.go
+++ b/test/e2e/placement_selecting_resources_test.go
@@ -844,7 +844,7 @@ var _ = Describe("validating CRP when failed to apply resources", Ordered, func(
 								Condition: metav1.Condition{
 									Type:               placementv1beta1.WorkConditionTypeApplied,
 									Status:             metav1.ConditionFalse,
-									Reason:             work.ManifestApplyFailedReason,
+									Reason:             work.ManifestsAlreadyOwnedByOthersReason,
 									ObservedGeneration: 0,
 								},
 							},


### PR DESCRIPTION
### Description of your changes
- Refactor code to support server side apply
- Add the conflict work check for both types. If the existing resource is owned by other work, the apply strategy should be the same.

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Add new UT
existing tests should make sure no regression.

### Special notes for your reviewer
upstream does not have a fake client to support apply method very well.
Will add IT/e2e tests in a separate PR.
