### PR TITLE
fix: (temporarily) use a fixed version of `envtest` due to Go version mismatches in the latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ GOLANGCI_LINT := $(abspath $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT
 # ENVTEST_K8S_VERSION refers to the version of k8s binary assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.28.0
 # ENVTEST_VER is the version of the ENVTEST binary
-ENVTEST_VER = latest
+ENVTEST_VER = v0.0.0-20240317073005-bd9ea79e8d18
 ENVTEST_BIN := setup-envtest
 ENVTEST :=  $(abspath $(TOOLS_BIN_DIR)/$(ENVTEST_BIN)-$(ENVTEST_VER))
 


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where unit tests would fail due to the latest version of envtest refers to a Go version that is too new.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

