### PR TITLE
fix: include applyFailedUpdateCandidates length in need rollout check

### DIFF
--- a/pkg/controllers/rollout/controller.go
+++ b/pkg/controllers/rollout/controller.go
@@ -412,7 +412,7 @@ func (r *Reconciler) pickBindingsToRoll(ctx context.Context, allBindings []*flee
 
 	// the list of bindings that are to be updated by this rolling phase
 	toBeUpdatedBindingList := make([]toBeUpdatedBinding, 0)
-	if len(removeCandidates)+len(updateCandidates)+len(boundingCandidates) == 0 {
+	if len(removeCandidates)+len(updateCandidates)+len(boundingCandidates)+len(applyFailedUpdateCandidates) == 0 {
 		return toBeUpdatedBindingList, nil, false, nil
 	}
 

--- a/pkg/controllers/rollout/controller_test.go
+++ b/pkg/controllers/rollout/controller_test.go
@@ -1079,7 +1079,24 @@ func TestPickBindingsToRoll(t *testing.T) {
 			wantStaleUnselectedBindings: []int{},
 			wantNeedRoll:                false,
 		},
-		"test bound with failed to apply bindings": {
+		"test bound with only failed to apply binding": {
+			allBindings: []*fleetv1beta1.ClusterResourceBinding{
+				generateFailedToApplyClusterResourceBinding(fleetv1beta1.BindingStateBound, "snapshot-1", cluster1),
+			},
+			latestResourceSnapshotName: "snapshot-2",
+			crp: clusterResourcePlacementForTest("test",
+				createPlacementPolicyForTest(fleetv1beta1.PickNPlacementType, 5)),
+			wantTobeUpdatedBindings: []int{0},
+			wantDesiredBindingsSpec: []fleetv1beta1.ResourceBindingSpec{
+				{
+					State:                fleetv1beta1.BindingStateBound,
+					TargetCluster:        cluster1,
+					ResourceSnapshotName: "snapshot-2",
+				},
+			},
+			wantNeedRoll: true,
+		},
+		"test bound with failed to apply binding, unselected bound bindings": {
 			allBindings: []*fleetv1beta1.ClusterResourceBinding{
 				generateFailedToApplyClusterResourceBinding(fleetv1beta1.BindingStateBound, "snapshot-1", cluster1),
 				generateClusterResourceBinding(fleetv1beta1.BindingStateBound, "snapshot-1", cluster2),


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer
Full agent logs: [hub-agent-logs.txt](https://github.com/Azure/fleet/files/14878291/hub-agent-logs.txt)

Noticed that rollout had stalled when testing, logs that pointed to the issue

I0404 21:22:48.072775       1 rollout/controller.go:408] "Calculated the targetNumber" clusterResourcePlacement="crp-3" targetNumber=1 readyBindingNumber=0 canBeUnavailableBindingNumber=0 canBeReadyBindingNumber=0 boundingCandidateNumber=0 removeCandidateNumber=0 updateCandidateNumber=0 applyFailedUpdateCandidateNumber=1
I0404 21:22:48.072953       1 rollout/controller.go:147] "No bindings are out of date, stop rolling" clusterResourcePlacement="crp-3"
I0404 21:22:48.073359       1 rollout/controller.go:61] "Rollout reconciliation loop ends" clusterResourcePlacement="crp-3" latency=10
