### PR TITLE
fix: forget the item on scheduling success

### DIFF
--- a/pkg/controllers/clusterresourceplacement/placement_status.go
+++ b/pkg/controllers/clusterresourceplacement/placement_status.go
@@ -33,13 +33,6 @@ const (
 	// SchedulingUnknownReason is the reason string of placement condition when the schedule status is unknown.
 	SchedulingUnknownReason = "SchedulePending"
 
-	// SynchronizePendingReason is the reason string of placement condition when the selected resources have not synchronized
-	// under the per-cluster namespaces (i.e., fleet-member-<member-name>) on the hub cluster yet.
-	SynchronizePendingReason = "SynchronizePending"
-	// SynchronizeSucceededReason is the reason string of placement condition when the selected resources are
-	// successfully synchronized under the per-cluster namespaces (i.e., fleet-member-<member-name>) on the hub cluster.
-	SynchronizeSucceededReason = "SynchronizeSucceeded"
-
 	// ApplyFailedReason is the reason string of placement condition when the selected resources fail to apply.
 	ApplyFailedReason = "ApplyFailed"
 	// ApplyPendingReason is the reason string of placement condition when the selected resources are pending to apply.
@@ -50,20 +43,6 @@ const (
 
 // ResourcePlacementStatus condition reasons and message formats
 const (
-	// ResourceApplyFailedReason is the reason string of placement condition when the selected resources fail to apply.
-	ResourceApplyFailedReason = "ApplyFailed"
-	// ResourceApplyPendingReason is the reason string of placement condition when the selected resources are pending to apply.
-	ResourceApplyPendingReason = "ApplyPending"
-	// ResourceApplySucceededReason is the reason string of placement condition when the selected resources are applied successfully.
-	ResourceApplySucceededReason = "ApplySucceeded"
-
-	// WorkSynchronizePendingReason is the reason string of placement condition when the work(s) are pending to synchronize.
-	WorkSynchronizePendingReason = "WorkSynchronizePending"
-	// WorkSynchronizeFailedReason is the reason string of placement condition when the work(s) failed to synchronize.
-	WorkSynchronizeFailedReason = "WorkSynchronizeFailed"
-	// WorkSynchronizeSucceededReason is the reason string of placement condition when the work(s) are synchronized successfully.
-	WorkSynchronizeSucceededReason = "WorkSynchronizeSucceeded"
-
 	// ResourceScheduleSucceededReason is the reason string of placement condition when the selected resources are scheduled.
 	ResourceScheduleSucceededReason = "ScheduleSucceeded"
 	// ResourceScheduleFailedReason is the reason string of placement condition when the scheduler failed to schedule the selected resources.

--- a/pkg/scheduler/queue/queue.go
+++ b/pkg/scheduler/queue/queue.go
@@ -166,6 +166,8 @@ func NewSimpleClusterResourcePlacementSchedulingQueue(opts ...Option) ClusterRes
 	}
 
 	return &simpleClusterResourcePlacementSchedulingQueue{
-		active: workqueue.NewNamedRateLimitingQueue(options.rateLimiter, options.name),
+		active: workqueue.NewRateLimitingQueueWithConfig(options.rateLimiter, workqueue.RateLimitingQueueConfig{
+			Name: options.name,
+		}),
 	}
 }

--- a/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/watcher.go
+++ b/pkg/scheduler/watchers/clusterschedulingpolicysnapshot/watcher.go
@@ -98,7 +98,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Enqueue the CRP name for scheduler processing.
-	r.SchedulerWorkQueue.AddRateLimited(queue.ClusterResourcePlacementKey(crpName))
+	r.SchedulerWorkQueue.Add(queue.ClusterResourcePlacementKey(crpName))
 
 	// The reconciliation loop ends.
 	return ctrl.Result{}, nil

--- a/pkg/scheduler/watchers/membercluster/watcher.go
+++ b/pkg/scheduler/watchers/membercluster/watcher.go
@@ -151,7 +151,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			"Enqueueing CRP for scheduler processing",
 			"memberCluster", memberClusterRef,
 			"clusterResourcePlacement", klog.KObj(crp))
-		r.SchedulerWorkQueue.AddRateLimited(queue.ClusterResourcePlacementKey(crp.Name))
+		r.SchedulerWorkQueue.Add(queue.ClusterResourcePlacementKey(crp.Name))
 	}
 
 	// The reconciliation loop completes.
@@ -170,13 +170,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// CRPs anyway, which will account for any missing updates on the cluster side
 			// during the downtime; in other words, notifications from this controller is not
 			// necessary.
-			klog.V(2).InfoS("Ignoring create events for member cluster objects", "eventObject", klog.KObj(e.Object))
+			klog.V(3).InfoS("Ignoring create events for member cluster objects", "eventObject", klog.KObj(e.Object))
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Ignore deletion events; the removal of a cluster is first signaled by adding a deleteTimeStamp,
 			// which is an update event
-			klog.V(2).InfoS("Ignoring delete events for member cluster objects", "eventObject", klog.KObj(e.Object))
+			klog.V(3).InfoS("Ignoring delete events for member cluster objects", "eventObject", klog.KObj(e.Object))
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
@@ -263,7 +263,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			}
 
 			// All the other changes are ignored.
-			klog.V(2).InfoS("Ignoring update events that are irrelevant to the scheduler", "memberCluster", clusterKObj)
+			klog.V(3).InfoS("Ignoring update events that are irrelevant to the scheduler", "memberCluster", clusterKObj)
 			return false
 		},
 	}


### PR DESCRIPTION
### Description of your changes

1. Fix a bug that the scheduler forget to forget an item when there is no error. 
2. Adjust some logs

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
