### PR TITLE
feat: support kubectl -o wide

### DIFF
--- a/apis/placement/v1/clusterresourceplacement_types.go
+++ b/apis/placement/v1/clusterresourceplacement_types.go
@@ -28,10 +28,13 @@ const (
 // +kubebuilder:resource:scope="Cluster",shortName=crp,categories={fleet,fleet-placement}
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=`.metadata.generation`,name="Gen",type=string
+// +kubebuilder:printcolumn:JSONPath=`.spec.policy.placementType`,name="Type",priority=1,type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].status`,name="Scheduled",type=string
-// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].observedGeneration`,name="ScheduledGen",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].observedGeneration`,name="Scheduled-Gen",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementWorkSynchronized")].status`,name="Work-Synchronized",priority=1,type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementWorkSynchronized")].observedGeneration`,name="Work-Synchronized-Gen",priority=1,type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].status`,name="Available",type=string
-// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].observedGeneration`,name="AvailableGen",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].observedGeneration`,name="Available-Gen",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -704,17 +707,6 @@ const (
 	// - "False" means we didn't fully satisfy the placement requirement. We will fill the Reason field.
 	// - "Unknown" means we don't have a scheduling decision yet.
 	ClusterResourcePlacementScheduledConditionType ClusterResourcePlacementConditionType = "ClusterResourcePlacementScheduled"
-
-	// ClusterResourcePlacementSynchronizedConditionType indicates whether the selected resources are synchronized under
-	// the per-cluster namespaces (i.e., fleet-member-<member-name>) on the hub cluster.
-	// Its condition status can be one of the following:
-	// - "True" means all the selected resources are successfully synchronized under the per-cluster namespaces
-	// (i.e., fleet-member-<member-name>) on the hub cluster.
-	// - "False" means all the selected resources have not been synchronized under the per-cluster namespaces
-	// (i.e., fleet-member-<member-name>) on the hub cluster yet.
-	// To be deprecated, it will be replaced by ClusterResourcePlacementRolloutStarted and ClusterResourcePlacementWorkSynchronized
-	// conditions.
-	ClusterResourcePlacementSynchronizedConditionType ClusterResourcePlacementConditionType = "ClusterResourcePlacementSynchronized"
 
 	// ClusterResourcePlacementRolloutStartedConditionType indicates whether the selected resources start rolling out or
 	// not.

--- a/apis/placement/v1beta1/clusterresourceplacement_types.go
+++ b/apis/placement/v1beta1/clusterresourceplacement_types.go
@@ -29,10 +29,13 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:JSONPath=`.metadata.generation`,name="Gen",type=string
+// +kubebuilder:printcolumn:JSONPath=`.spec.policy.placementType`,name="Type",priority=1,type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].status`,name="Scheduled",type=string
-// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].observedGeneration`,name="ScheduledGen",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].observedGeneration`,name="Scheduled-Gen",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementWorkSynchronized")].status`,name="Work-Synchronized",priority=1,type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementWorkSynchronized")].observedGeneration`,name="Work-Synchronized-Gen",priority=1,type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].status`,name="Available",type=string
-// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].observedGeneration`,name="AvailableGen",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].observedGeneration`,name="Available-Gen",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -704,17 +707,6 @@ const (
 	// - "False" means we didn't fully satisfy the placement requirement. We will fill the Reason field.
 	// - "Unknown" means we don't have a scheduling decision yet.
 	ClusterResourcePlacementScheduledConditionType ClusterResourcePlacementConditionType = "ClusterResourcePlacementScheduled"
-
-	// ClusterResourcePlacementSynchronizedConditionType indicates whether the selected resources are synchronized under
-	// the per-cluster namespaces (i.e., fleet-member-<member-name>) on the hub cluster.
-	// Its condition status can be one of the following:
-	// - "True" means all the selected resources are successfully synchronized under the per-cluster namespaces
-	// (i.e., fleet-member-<member-name>) on the hub cluster.
-	// - "False" means all the selected resources have not been synchronized under the per-cluster namespaces
-	// (i.e., fleet-member-<member-name>) on the hub cluster yet.
-	// To be deprecated, it will be replaced by ClusterResourcePlacementRolloutStarted and ClusterResourcePlacementWorkSynchronized
-	// conditions.
-	ClusterResourcePlacementSynchronizedConditionType ClusterResourcePlacementConditionType = "ClusterResourcePlacementSynchronized"
 
 	// ClusterResourcePlacementRolloutStartedConditionType indicates whether the selected resources start rolling out or
 	// not.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourceplacements.yaml
@@ -23,17 +23,29 @@ spec:
     - jsonPath: .metadata.generation
       name: Gen
       type: string
+    - jsonPath: .spec.policy.placementType
+      name: Type
+      priority: 1
+      type: string
     - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].status
       name: Scheduled
       type: string
     - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].observedGeneration
-      name: ScheduledGen
+      name: Scheduled-Gen
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementWorkSynchronized")].status
+      name: Work-Synchronized
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementWorkSynchronized")].observedGeneration
+      name: Work-Synchronized-Gen
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].status
       name: Available
       type: string
     - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].observedGeneration
-      name: AvailableGen
+      name: Available-Gen
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -1129,17 +1141,29 @@ spec:
     - jsonPath: .metadata.generation
       name: Gen
       type: string
+    - jsonPath: .spec.policy.placementType
+      name: Type
+      priority: 1
+      type: string
     - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].status
       name: Scheduled
       type: string
     - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementScheduled")].observedGeneration
-      name: ScheduledGen
+      name: Scheduled-Gen
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementWorkSynchronized")].status
+      name: Work-Synchronized
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementWorkSynchronized")].observedGeneration
+      name: Work-Synchronized-Gen
+      priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].status
       name: Available
       type: string
     - jsonPath: .status.conditions[?(@.type=="ClusterResourcePlacementAvailable")].observedGeneration
-      name: AvailableGen
+      name: Available-Gen
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/hack/loadtest/util/placement.go
+++ b/hack/loadtest/util/placement.go
@@ -253,7 +253,7 @@ func waitForCrpToComplete(ctx context.Context, hubClient client.Client, deadline
 			klog.ErrorS(err, "failed to get crp", "crp", crpName)
 		}
 		appliedCond := crp.GetCondition(string(v1beta1.ClusterResourcePlacementAppliedConditionType))
-		synchronizedCond := crp.GetCondition(string(v1beta1.ClusterResourcePlacementSynchronizedConditionType))
+		synchronizedCond := crp.GetCondition(string(v1beta1.ClusterResourcePlacementWorkSynchronizedConditionType))
 		scheduledCond := crp.GetCondition(string(v1beta1.ClusterResourcePlacementScheduledConditionType))
 		select {
 		case <-timer.C:


### PR DESCRIPTION
### Description of your changes

```
$kubectl get crp
NAME    GEN   SCHEDULED   SCHEDULED-GEN   AVAILABLE   AVAILABLE-GEN   AGE
crp-1   1     True        1               True        1               173m
$ kubectl get crp -o wide
NAME    GEN   TYPE      SCHEDULED   SCHEDULED-GEN   WORK-SYNCHRONIZED   WORK-SYNCHRONIZED-GEN   AVAILABLE   AVAILABLE-GEN   AGE
crp-1   1     PickAll   True        1               True                1                       True        1               173m
```

Fixes # 793

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

local test

### Special notes for your reviewer

use "-" to split the column name to make it consistent with k8 deployment output,
```
kubectl get deployment coredns -n kube-system -o wide
NAME      READY   UP-TO-DATE   AVAILABLE   AGE    CONTAINERS   IMAGES                                    SELECTOR
coredns   2/2     2            2           162m   coredns      registry.k8s.io/coredns/coredns:v1.10.1   k8s-app=kube-dns
```