### PR TITLE
fix: only mark a binding apply failed if there are failed manifest

### DIFF
--- a/pkg/controllers/rollout/controller.go
+++ b/pkg/controllers/rollout/controller.go
@@ -343,8 +343,9 @@ func (r *Reconciler) pickBindingsToRoll(ctx context.Context, allBindings []*flee
 		case fleetv1beta1.BindingStateUnscheduled:
 			appliedCondition := binding.GetCondition(string(fleetv1beta1.ResourceBindingApplied))
 			availableCondition := binding.GetCondition(string(fleetv1beta1.ResourceBindingAvailable))
-			if condition.IsConditionStatusFalse(appliedCondition, binding.Generation) || condition.IsConditionStatusFalse(availableCondition, binding.Generation) {
-				klog.V(3).InfoS("Found a failed to be ready unscheduled binding", "clusterResourcePlacement", crpKObj, "binding", bindingKObj)
+			if !condition.IsConditionStatusTrue(appliedCondition, binding.Generation) || !condition.IsConditionStatusTrue(availableCondition, binding.Generation) {
+				klog.V(3).InfoS("Found a failed to be ready unscheduled binding", "clusterResourcePlacement", crpKObj,
+					"binding", bindingKObj, "appliedCondition", appliedCondition, "availableCondition", availableCondition)
 			} else {
 				canBeReadyBindings = append(canBeReadyBindings, binding)
 			}
@@ -384,7 +385,7 @@ func (r *Reconciler) pickBindingsToRoll(ctx context.Context, allBindings []*flee
 			// check if the binding is failed or still on going
 			appliedCondition := binding.GetCondition(string(fleetv1beta1.ResourceBindingApplied))
 			availableCondition := binding.GetCondition(string(fleetv1beta1.ResourceBindingAvailable))
-			if condition.IsConditionStatusFalse(appliedCondition, binding.Generation) || condition.IsConditionStatusFalse(availableCondition, binding.Generation) {
+			if !condition.IsConditionStatusTrue(appliedCondition, binding.Generation) || !condition.IsConditionStatusTrue(availableCondition, binding.Generation) {
 				klog.V(3).InfoS("Found a failed to be ready bound binding", "clusterResourcePlacement", crpKObj, "binding", bindingKObj)
 				bindingFailed = true
 			} else {

--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -638,7 +638,7 @@ func buildAllWorkAppliedCondition(works map[string]*fleetv1beta1.Work, binding *
 		return metav1.Condition{
 			Status:             metav1.ConditionFalse,
 			Type:               string(fleetv1beta1.ResourceBindingApplied),
-			Reason:             condition.WorkNotAppliedReason,
+			Reason:             condition.WorkFailedToApplyReason,
 			Message:            fmt.Sprintf("Work object %s is not applied", notAppliedWork),
 			ObservedGeneration: binding.GetGeneration(),
 		}

--- a/pkg/controllers/workgenerator/controller_test.go
+++ b/pkg/controllers/workgenerator/controller_test.go
@@ -170,7 +170,7 @@ func TestBuildAllWorkAppliedCondition(t *testing.T) {
 				ObservedGeneration: 1,
 			},
 		},
-		"applied should be false if not all work applied to the latest generation": {
+		"applied should be known if not all work applied to the latest generation": {
 			works: map[string]*fleetv1beta1.Work{
 				"notAppliedWork1": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -205,13 +205,38 @@ func TestBuildAllWorkAppliedCondition(t *testing.T) {
 			},
 			generation: 1,
 			want: metav1.Condition{
-				Status:             metav1.ConditionFalse,
+				Status:             metav1.ConditionUnknown,
 				Type:               string(fleetv1beta1.ResourceBindingApplied),
 				Reason:             condition.WorkNotAppliedReason,
 				ObservedGeneration: 1,
 			},
 		},
-		"applied should be false if not all work has applied": {
+		"applied should be unknown if all work has no applied condition": {
+			works: map[string]*fleetv1beta1.Work{
+				"notappliedWork1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "work1",
+						Generation: 123,
+					},
+					Status: fleetv1beta1.WorkStatus{},
+				},
+				"notAppliedWork2": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "work2",
+						Generation: 12,
+					},
+					Status: fleetv1beta1.WorkStatus{},
+				},
+			},
+			generation: 1,
+			want: metav1.Condition{
+				Status:             metav1.ConditionUnknown,
+				Type:               string(fleetv1beta1.ResourceBindingApplied),
+				Reason:             condition.WorkNotAppliedReason,
+				ObservedGeneration: 1,
+			},
+		},
+		"applied should be unknown if not all work has applied": {
 			works: map[string]*fleetv1beta1.Work{
 				"appliedWork1": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -237,13 +262,45 @@ func TestBuildAllWorkAppliedCondition(t *testing.T) {
 			},
 			generation: 1,
 			want: metav1.Condition{
+				Status:             metav1.ConditionUnknown,
+				Type:               string(fleetv1beta1.ResourceBindingApplied),
+				Reason:             condition.WorkNotAppliedReason,
+				ObservedGeneration: 1,
+			},
+		},
+		"applied should be false if there is one work has failed applied": {
+			works: map[string]*fleetv1beta1.Work{
+				"appliedWork1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "work1",
+						Generation: 123,
+					},
+					Status: fleetv1beta1.WorkStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
+								Status:             metav1.ConditionFalse,
+								ObservedGeneration: 123,
+							},
+						},
+					},
+				},
+				"notAppliedWork2": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "work2",
+						Generation: 12,
+					},
+				},
+			},
+			generation: 1,
+			want: metav1.Condition{
 				Status:             metav1.ConditionFalse,
 				Type:               string(fleetv1beta1.ResourceBindingApplied),
 				Reason:             condition.WorkNotAppliedReason,
 				ObservedGeneration: 1,
 			},
 		},
-		"applied should be false if some work applied condition is unknown": {
+		"applied should be unknown if some work applied condition is unknown": {
 			works: map[string]*fleetv1beta1.Work{
 				"appliedWork1": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -255,6 +312,47 @@ func TestBuildAllWorkAppliedCondition(t *testing.T) {
 							{
 								Type:               fleetv1beta1.WorkConditionTypeApplied,
 								Status:             metav1.ConditionUnknown,
+								ObservedGeneration: 123,
+							},
+						},
+					},
+				},
+				"appliedWork2": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "work2",
+						Generation: 12,
+					},
+					Status: fleetv1beta1.WorkStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
+								Status:             metav1.ConditionTrue,
+								ObservedGeneration: 12,
+							},
+						},
+					},
+				},
+			},
+			generation: 1,
+			want: metav1.Condition{
+				Status:             metav1.ConditionUnknown,
+				Type:               string(fleetv1beta1.ResourceBindingApplied),
+				Reason:             condition.WorkNotAppliedReason,
+				ObservedGeneration: 1,
+			},
+		},
+		"applied should be false if some work applied condition is false": {
+			works: map[string]*fleetv1beta1.Work{
+				"appliedWork1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "work1",
+						Generation: 123,
+					},
+					Status: fleetv1beta1.WorkStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               fleetv1beta1.WorkConditionTypeApplied,
+								Status:             metav1.ConditionFalse,
 								ObservedGeneration: 123,
 							},
 						},

--- a/pkg/utils/condition/condition.go
+++ b/pkg/utils/condition/condition.go
@@ -87,6 +87,9 @@ const (
 	// WorkNotAppliedReason is the reason string of placement condition if some works are not applied.
 	WorkNotAppliedReason = "NotAllWorkHaveBeenApplied"
 
+	// WorkFailedToApplyReason is the reason string of placement condition if some works failed to apply.
+	WorkFailedToApplyReason = "SomeWorkFailedToApply"
+
 	// AllWorkAppliedReason is the reason string of placement condition if all works are applied.
 	AllWorkAppliedReason = "AllWorkHaveBeenApplied"
 


### PR DESCRIPTION
### Description of your changes

Currently, we mark a binding failed if not all work are applied. This causes the CRP controller to try to fill in failed placement from work. So we only mark a binding apply failed if there are failed manifest, CRP condition won't change. This is probably also useful when we start to copy failed manifest to the binding.

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
