### PR TITLE
fix: check the deployment  available replica count instead

### DIFF
--- a/pkg/controllers/work/apply_controller_test.go
+++ b/pkg/controllers/work/apply_controller_test.go
@@ -939,14 +939,33 @@ func TestTrackResourceAvailability(t *testing.T) {
 						"generation": 1,
 						"name":       "test-deployment",
 					},
+					"spec": map[string]interface{}{
+						"replicas": 3,
+					},
 					"status": map[string]interface{}{
 						"observedGeneration": 1,
-						"conditions": []interface{}{
-							map[string]interface{}{
-								"type":   "Available",
-								"status": "True",
-							},
-						},
+						"availableReplicas":  3,
+						"updatedReplicas":    3,
+					},
+				},
+			},
+			expected: manifestAvailableAction,
+			err:      nil,
+		},
+		"Test Deployment available with default replica": {
+			gvr: utils.DeploymentGVR,
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"generation": 1,
+						"name":       "test-deployment",
+					},
+					"status": map[string]interface{}{
+						"observedGeneration": 1,
+						"availableReplicas":  1,
+						"updatedReplicas":    1,
 					},
 				},
 			},
@@ -963,38 +982,59 @@ func TestTrackResourceAvailability(t *testing.T) {
 						"generation": 2,
 						"name":       "test-deployment",
 					},
+					"spec": map[string]interface{}{
+						"replicas": 3,
+					},
 					"status": map[string]interface{}{
 						"observedGeneration": 1,
-						"conditions": []interface{}{
-							map[string]interface{}{
-								"type":   "Available",
-								"status": "True",
-							},
-						},
+						"availableReplicas":  3,
+						"updatedReplicas":    3,
 					},
 				},
 			},
 			expected: manifestNotAvailableYetAction,
 			err:      nil,
 		},
-		"Test Deployment not available": {
+		"Test Deployment not available as not enough available": {
 			gvr: utils.DeploymentGVR,
 			obj: &unstructured.Unstructured{
 				Object: map[string]interface{}{
 					"apiVersion": "apps/v1",
 					"kind":       "Deployment",
 					"metadata": map[string]interface{}{
-						"generation": 1,
+						"generation": 2,
 						"name":       "test-deployment",
 					},
+					"spec": map[string]interface{}{
+						"replicas": 3,
+					},
 					"status": map[string]interface{}{
-						"observedGeneration": 1,
-						"conditions": []interface{}{
-							map[string]interface{}{
-								"type":   "Available",
-								"status": "False",
-							},
-						},
+						"observedGeneration": 2,
+						"availableReplicas":  2,
+						"updatedReplicas":    3,
+					},
+				},
+			},
+			expected: manifestNotAvailableYetAction,
+			err:      nil,
+		},
+		"Test Deployment not available as not enough updated": {
+			gvr: utils.DeploymentGVR,
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata": map[string]interface{}{
+						"generation": 2,
+						"name":       "test-deployment",
+					},
+					"spec": map[string]interface{}{
+						"replicas": 3,
+					},
+					"status": map[string]interface{}{
+						"observedGeneration": 2,
+						"availableReplicas":  3,
+						"updatedReplicas":    2,
 					},
 				},
 			},


### PR DESCRIPTION
### Description of your changes

The "Available" condition of a deployment is not sufficient to indicate that a deployment is updated correctly so we need
to tighten up the standard.

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
