### PR TITLE
fix: own the resource when the existing resource is not owned by other applier

### DIFF
--- a/pkg/controllers/work/applier.go
+++ b/pkg/controllers/work/applier.go
@@ -83,6 +83,13 @@ func findConflictedWork(ctx context.Context, hubClient client.Client, namespace 
 }
 
 func validateOwnerReference(ctx context.Context, hubClient client.Client, namespace string, strategy *fleetv1beta1.ApplyStrategy, ownerRefs []metav1.OwnerReference) (ApplyAction, error) {
+	// If no owner reference is found, the resource could be managed by the work.
+	// There is a corner case that the resource is already managed by the work but the owner reference could be removed
+	// by other controllers later.
+	if len(ownerRefs) == 0 {
+		return "", nil
+	}
+
 	conflictedWork, err := findConflictedWork(ctx, hubClient, namespace, strategy, ownerRefs)
 	if err != nil {
 		return errorApplyAction, err

--- a/pkg/controllers/work/applier_test.go
+++ b/pkg/controllers/work/applier_test.go
@@ -392,6 +392,16 @@ func TestValidateOwnerReference(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "empty owner reference which is removed by other controllers",
+			ownerRefs: []metav1.OwnerReference{},
+			want:      "",
+		},
+		{
+			name:      "nil owner reference which is removed by other controllers",
+			ownerRefs: nil,
+			want:      "",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/e2e/placement_selecting_resources_test.go
+++ b/test/e2e/placement_selecting_resources_test.go
@@ -702,6 +702,14 @@ var _ = Describe("validating CRP when failed to apply resources", Ordered, func(
 		createWorkResources()
 
 		ns := appNamespace()
+		ns.SetOwnerReferences([]metav1.OwnerReference{
+			{
+				APIVersion: "another-api-version",
+				Kind:       "another-kind",
+				Name:       "another-owner",
+				UID:        "another-uid",
+			},
+		})
 		By(fmt.Sprintf("creating namespace %s on member cluster", ns.Name))
 		Expect(allMemberClusters[0].KubeClient.Create(ctx, &ns)).Should(Succeed(), "Failed to create namespace %s", ns.Name)
 


### PR DESCRIPTION
### Description of your changes

Allow agent to take over the resource if it has no owner reference.

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

UT and e2e

### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
