### PR TITLE
fix: address a minor issue that might cause duplicate entries in cluster decisions (status)

### DIFF
--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -3594,6 +3594,89 @@ func TestNewSchedulingDecisionsFromBindings(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                              "duplicate entries",
+			maxUnselectedClusterDecisionCount: 0,
+			notPicked: ScoredClusters{
+				{
+					Cluster: &clusterv1beta1.MemberCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: clusterName,
+						},
+					},
+					Score: &ClusterScore{
+						AffinityScore:       int(affinityScore3),
+						TopologySpreadScore: int(topologySpreadScore3),
+					},
+				},
+			},
+			filtered: []*filteredClusterWithStatus{
+				{
+					cluster: &clusterv1beta1.MemberCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: altClusterName,
+						},
+					},
+					status: filteredStatus,
+				},
+			},
+			existing: [][]*placementv1beta1.ClusterResourceBinding{
+				{
+					&placementv1beta1.ClusterResourceBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: bindingName,
+						},
+						Spec: placementv1beta1.ResourceBindingSpec{
+							ClusterDecision: placementv1beta1.ClusterDecision{
+								ClusterName: clusterName,
+								Selected:    true,
+								ClusterScore: &placementv1beta1.ClusterScore{
+									TopologySpreadScore: &topologySpreadScore1,
+									AffinityScore:       &affinityScore1,
+								},
+								Reason: fmt.Sprintf(resourceScheduleSucceededWithScoreMessageFormat, clusterName, affinityScore1, topologySpreadScore1),
+							},
+						},
+					},
+					&placementv1beta1.ClusterResourceBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: altBindingName,
+						},
+						Spec: placementv1beta1.ResourceBindingSpec{
+							ClusterDecision: placementv1beta1.ClusterDecision{
+								ClusterName: altClusterName,
+								Selected:    true,
+								ClusterScore: &placementv1beta1.ClusterScore{
+									TopologySpreadScore: &topologySpreadScore2,
+									AffinityScore:       &affinityScore2,
+								},
+								Reason: fmt.Sprintf(resourceScheduleSucceededWithScoreMessageFormat, altClusterName, affinityScore2, topologySpreadScore2),
+							},
+						},
+					},
+				},
+			},
+			want: []placementv1beta1.ClusterDecision{
+				{
+					ClusterName: clusterName,
+					Selected:    true,
+					ClusterScore: &placementv1beta1.ClusterScore{
+						TopologySpreadScore: &topologySpreadScore1,
+						AffinityScore:       &affinityScore1,
+					},
+					Reason: fmt.Sprintf(resourceScheduleSucceededWithScoreMessageFormat, clusterName, affinityScore1, topologySpreadScore1),
+				},
+				{
+					ClusterName: altClusterName,
+					Selected:    true,
+					ClusterScore: &placementv1beta1.ClusterScore{
+						TopologySpreadScore: &topologySpreadScore2,
+						AffinityScore:       &affinityScore2,
+					},
+					Reason: fmt.Sprintf(resourceScheduleSucceededWithScoreMessageFormat, altClusterName, affinityScore2, topologySpreadScore2),
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/scheduler/framework/frameworkutils.go
+++ b/pkg/scheduler/framework/frameworkutils.go
@@ -283,7 +283,7 @@ func newSchedulingDecisionsFromBindings(
 	//
 	// Note that for such occurrences, we will honor the previously made decisions in an attempt
 	// to reduce fluctations.
-	seenClusters := map[string]bool{}
+	seenClusters := make(map[string]bool)
 
 	// Build new scheduling decisions.
 	slotsLeft := clustersDecisionArrayLengthLimitInAPI
@@ -308,7 +308,7 @@ func newSchedulingDecisionsFromBindings(
 			break
 		}
 
-		if _, ok := seenClusters[sc.Cluster.Name]; ok {
+		if seenClusters[sc.Cluster.Name] {
 			// Skip clusters that have been added to the decision list.
 			continue
 		}

--- a/pkg/scheduler/framework/frameworkutils.go
+++ b/pkg/scheduler/framework/frameworkutils.go
@@ -274,12 +274,24 @@ func newSchedulingDecisionsFromBindings(
 	// Pre-allocate with a reasonable capacity.
 	newDecisions := make([]placementv1beta1.ClusterDecision, 0, maxUnselectedClusterDecisionCount)
 
+	// Track clusters that have been added to the decision list.
+	//
+	// This is to avoid duplicate entries in the decision list, caused by a rare occurrence
+	// where a cluster is picked before, but later loses its status as a matching (or most
+	// preferable) cluster (e.g., a label/cluster property change) under the evaluation
+	// of **the same** scheduling policy.
+	//
+	// Note that for such occurrences, we will honor the previously made decisions in an attempt
+	// to reduce fluctations.
+	seenClusters := map[string]bool{}
+
 	// Build new scheduling decisions.
 	slotsLeft := clustersDecisionArrayLengthLimitInAPI
 	for _, bindingSet := range existing {
 		setLength := len(bindingSet)
 		for i := 0; i < setLength && i < slotsLeft; i++ {
 			newDecisions = append(newDecisions, bindingSet[i].Spec.ClusterDecision)
+			seenClusters[bindingSet[i].Spec.TargetCluster] = true
 		}
 
 		slotsLeft -= setLength
@@ -294,6 +306,11 @@ func newSchedulingDecisionsFromBindings(
 	for _, sc := range notPicked {
 		if slotsLeft == 0 || maxUnselectedClusterDecisionCount == 0 {
 			break
+		}
+
+		if _, ok := seenClusters[sc.Cluster.Name]; ok {
+			// Skip clusters that have been added to the decision list.
+			continue
 		}
 
 		newDecisions = append(newDecisions, placementv1beta1.ClusterDecision{
@@ -313,6 +330,11 @@ func newSchedulingDecisionsFromBindings(
 	// Move some decisions from unbound clusters, if there are still enough room.
 	for i := 0; i < maxUnselectedClusterDecisionCount && i < len(filtered) && i < slotsLeft; i++ {
 		clusterWithStatus := filtered[i]
+		if _, ok := seenClusters[clusterWithStatus.cluster.Name]; ok {
+			// Skip clusters that have been added to the decision list.
+			continue
+		}
+
 		newDecisions = append(newDecisions, placementv1beta1.ClusterDecision{
 			ClusterName: clusterWithStatus.cluster.Name,
 			Selected:    false,


### PR DESCRIPTION
### Description of your changes

This PR fixes a minor issue where duplicate entries might occur in cluster decisions when a cluster is picked and then unpicked without having a scheduling policy change.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests

### Special notes for your reviewer


