### PR TITLE
fix:  enhance the member cluster leave flow

### DIFF
--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller.go
@@ -145,7 +145,6 @@ func (r *Reconciler) handleDelete(ctx context.Context, mc *clusterv1beta1.Member
 		}
 		return runtime.Result{RequeueAfter: time.Second}, stuckErr
 	}
-	mcJoinedCondition := meta.FindStatusCondition(mc.Status.Conditions, string(clusterv1beta1.ConditionTypeMemberClusterJoined))
 	currentImc := &clusterv1beta1.InternalMemberCluster{}
 	imcNamespacedName := types.NamespacedName{Namespace: namespaceName, Name: mc.Name}
 	if err := r.Client.Get(ctx, imcNamespacedName, currentImc); err != nil {
@@ -153,13 +152,8 @@ func (r *Reconciler) handleDelete(ctx context.Context, mc *clusterv1beta1.Member
 			klog.ErrorS(err, "Failed to get internal member cluster", "internalMemberCluster", imcNamespacedName)
 			return runtime.Result{}, controller.NewAPIServerError(true, err)
 		}
-		// we don't need to wait for the agent to leave if the internal member cluster is not found
-		if condition.IsConditionStatusTrue(mcJoinedCondition, mc.GetGeneration()) {
-			// alert if the MC status is joined but imc is missing
-			klog.ErrorS(controller.NewUnexpectedBehaviorError(fmt.Errorf("internalMemberCluster %s not found", namespaceName)), "The member cluster is joined but its internalMemberCluster is missing", "memberCluster", mcObjRef)
-		} else {
-			klog.V(2).Info("InternalMemberCluster not found, start garbage collecting", "memberCluster", mcObjRef)
-		}
+		// this is possible since we garbage collect the internal member cluster first before deleting the MC
+		klog.V(2).Info("InternalMemberCluster not found, start garbage collecting", "memberCluster", mcObjRef)
 		return runtime.Result{Requeue: true}, r.garbageCollect(ctx, mc)
 	}
 	// calculate the current status of the member cluster from imc status
@@ -167,7 +161,7 @@ func (r *Reconciler) handleDelete(ctx context.Context, mc *clusterv1beta1.Member
 	// TODO: check the last heartbeat time from all agents and assume the member cluster is left if they haven't sent heartbeat
 	//       beyond a pre-agreed threshold.
 	// check if the cluster is already left
-	mcJoinedCondition = meta.FindStatusCondition(mc.Status.Conditions, string(clusterv1beta1.ConditionTypeMemberClusterJoined))
+	mcJoinedCondition := meta.FindStatusCondition(mc.Status.Conditions, string(clusterv1beta1.ConditionTypeMemberClusterJoined))
 	if condition.IsConditionStatusFalse(mcJoinedCondition, mc.GetGeneration()) {
 		klog.V(2).InfoS("Agent already left, start garbage collecting", "memberCluster", mcObjRef)
 		if gcErr := r.garbageCollect(ctx, mc); gcErr != nil {
@@ -175,7 +169,7 @@ func (r *Reconciler) handleDelete(ctx context.Context, mc *clusterv1beta1.Member
 		}
 		return runtime.Result{Requeue: true}, controller.NewUpdateIgnoreConflictError(r.updateMemberClusterStatus(ctx, mc))
 	}
-	klog.V(2).InfoS("Need to wait for the agent to leave", "memberCluster", mcObjRef, "agentJoinedCondition", mcJoinedCondition)
+	klog.V(2).InfoS("Need to wait for the agent to leave", "memberCluster", mcObjRef, "joinedCondition", mcJoinedCondition)
 	// mark the imc as left to make sure the agent is leaving the fleet
 	if err := r.leave(ctx, mc, currentImc); err != nil {
 		klog.ErrorS(err, "Failed to mark the imc as leave", "memberCluster", mcObjRef)

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller_integration_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller_integration_test.go
@@ -228,7 +228,7 @@ var _ = Describe("Test MemberCluster Controller", func() {
 			result, err := r.Reconcile(ctx, ctrl.Request{
 				NamespacedName: memberClusterNamespacedName,
 			})
-			Expect(result).Should(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).Should(Equal(ctrl.Result{}))
 
 			Expect(err).Should(Succeed())
 
@@ -284,7 +284,7 @@ var _ = Describe("Test MemberCluster Controller", func() {
 
 			By("trigger reconcile again to initiate leave workflow")
 			result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: memberClusterNamespacedName})
-			Expect(result).Should(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).Should(Equal(ctrl.Result{}))
 			Expect(err).Should(Succeed())
 
 			var imc clusterv1beta1.InternalMemberCluster
@@ -680,7 +680,7 @@ var _ = Describe("Test MemberCluster Controller", func() {
 			result, err := r.Reconcile(ctx, ctrl.Request{
 				NamespacedName: memberClusterNamespacedName,
 			})
-			Expect(result).Should(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).Should(Equal(ctrl.Result{}))
 			Expect(err).Should(Succeed())
 
 			By("getting imc status")
@@ -702,7 +702,7 @@ var _ = Describe("Test MemberCluster Controller", func() {
 			result, err = r.Reconcile(ctx, ctrl.Request{
 				NamespacedName: memberClusterNamespacedName,
 			})
-			Expect(result).Should(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).Should(Equal(ctrl.Result{}))
 			Expect(err).Should(Succeed())
 
 			By("checking mc status")
@@ -757,7 +757,7 @@ var _ = Describe("Test MemberCluster Controller", func() {
 			result, err = r.Reconcile(ctx, ctrl.Request{
 				NamespacedName: memberClusterNamespacedName,
 			})
-			Expect(result).Should(Equal(ctrl.Result{Requeue: true}))
+			Expect(result).Should(Equal(ctrl.Result{}))
 			Expect(err).Should(Succeed())
 
 			By("checking mc status")

--- a/pkg/controllers/membercluster/v1beta1/membercluster_controller_integration_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_controller_integration_test.go
@@ -830,5 +830,4 @@ var _ = Describe("Test MemberCluster Controller", func() {
 			Expect(ns.DeletionTimestamp != nil).Should(BeTrue())
 		})
 	})
-
 })

--- a/pkg/controllers/membercluster/v1beta1/membercluster_suite_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_suite_test.go
@@ -41,7 +41,6 @@ func TestMemberCluster(t *testing.T) {
 var _ = BeforeSuite(func() {
 	done := make(chan interface{})
 	go func() {
-
 		By("Setup klog")
 		fs := flag.NewFlagSet("klog", flag.ContinueOnError)
 		klog.InitFlags(fs)

--- a/pkg/controllers/membercluster/v1beta1/membercluster_suite_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_suite_test.go
@@ -41,6 +41,7 @@ func TestMemberCluster(t *testing.T) {
 var _ = BeforeSuite(func() {
 	done := make(chan interface{})
 	go func() {
+		defer GinkgoRecover()
 		By("Setup klog")
 		fs := flag.NewFlagSet("klog", flag.ContinueOnError)
 		klog.InitFlags(fs)

--- a/pkg/controllers/membercluster/v1beta1/membercluster_suite_test.go
+++ b/pkg/controllers/membercluster/v1beta1/membercluster_suite_test.go
@@ -41,7 +41,6 @@ func TestMemberCluster(t *testing.T) {
 var _ = BeforeSuite(func() {
 	done := make(chan interface{})
 	go func() {
-		defer GinkgoRecover()
 		By("Setup klog")
 		fs := flag.NewFlagSet("klog", flag.ContinueOnError)
 		klog.InitFlags(fs)

--- a/test/e2e/enveloped_object_placement_test.go
+++ b/test/e2e/enveloped_object_placement_test.go
@@ -162,11 +162,8 @@ var _ = Describe("placing wrapped resources using a CRP", Ordered, func() {
 	})
 
 	AfterAll(func() {
-		// Remove the custom deletion blocker finalizer from the CRP.
-		cleanupCRP(crpName)
-
-		// Delete the created resources.
-		cleanupWorkResources()
+		By(fmt.Sprintf("deleting placement %s and related resources", crpName))
+		ensureCRPAndRelatedResourcesDeletion(crpName, allMemberClusters)
 	})
 })
 

--- a/test/e2e/enveloped_object_placement_test.go
+++ b/test/e2e/enveloped_object_placement_test.go
@@ -178,10 +178,11 @@ func checkEnvelopQuotaAndMutationWebhookPlacement(memberCluster *framework.Clust
 		if err := memberCluster.KubeClient.Get(ctx, types.NamespacedName{Namespace: workNamespaceName, Name: testConfigMap.Name}, placedConfigMap); err != nil {
 			return err
 		}
-		if err := hubCluster.KubeClient.Get(ctx, types.NamespacedName{Namespace: workNamespaceName, Name: testConfigMap.Name}, &testConfigMap); err != nil {
+		hubConfigMap := &corev1.ConfigMap{}
+		if err := hubCluster.KubeClient.Get(ctx, types.NamespacedName{Namespace: workNamespaceName, Name: testConfigMap.Name}, hubConfigMap); err != nil {
 			return err
 		}
-		if diff := cmp.Diff(placedConfigMap.Data, testConfigMap.Data); diff != "" {
+		if diff := cmp.Diff(placedConfigMap.Data, hubConfigMap.Data); diff != "" {
 			return fmt.Errorf("configmap diff (-got, +want): %s", diff)
 		}
 		By("check the namespaced envelope objects")

--- a/test/e2e/enveloped_object_placement_test.go
+++ b/test/e2e/enveloped_object_placement_test.go
@@ -293,18 +293,22 @@ func checkForRolloutStuckOnOneFailedClusterStatus(wantSelectedResources []placem
 
 func readEnvelopTestManifests() {
 	By("Read the testConfigMap resources")
+	testConfigMap = corev1.ConfigMap{}
 	err := utils.GetObjectFromManifest("resources/test-configmap.yaml", &testConfigMap)
 	Expect(err).Should(Succeed())
 
 	By("Read testEnvelopConfigMap resource")
+	testEnvelopConfigMap = corev1.ConfigMap{}
 	err = utils.GetObjectFromManifest("resources/test-envelop-configmap.yaml", &testEnvelopConfigMap)
 	Expect(err).Should(Succeed())
 
 	By("Read EnvelopeWebhook")
+	testEnvelopeWebhook = admv1.MutatingWebhookConfiguration{}
 	err = utils.GetObjectFromManifest("resources/webhook.yaml", &testEnvelopeWebhook)
 	Expect(err).Should(Succeed())
 
 	By("Read ResourceQuota")
+	testEnvelopeResourceQuota = corev1.ResourceQuota{}
 	err = utils.GetObjectFromManifest("resources/resourcequota.yaml", &testEnvelopeResourceQuota)
 	Expect(err).Should(Succeed())
 }

--- a/test/e2e/join_and_leave_test.go
+++ b/test/e2e/join_and_leave_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Test member cluster join and leave flow", Ordered, Serial, fun
 		}
 	})
 
-	Context("Test cluster join and leave flow with CRP not deleted", func() {
+	Context("Test cluster join and leave flow with CRP not deleted", Ordered, Serial, func() {
 		It("Create the test resources in the namespace", createWrappedResourcesForEnvelopTest)
 
 		It("Create the CRP that select the name space and place it to all clusters", func() {

--- a/test/e2e/join_and_leave_test.go
+++ b/test/e2e/join_and_leave_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+// Note that this container will run in parallel with other containers.
+var _ = Describe("placing wrapped resources using a CRP", Ordered, Serial, func() {
+	crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+	workNamespaceName := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+	var wantSelectedResources []placementv1beta1.ResourceIdentifier
+	BeforeAll(func() {
+		// Create the test resources.
+		readEnvelopTestManifests()
+		wantSelectedResources = []placementv1beta1.ResourceIdentifier{
+			{
+				Kind:    "Namespace",
+				Name:    workNamespaceName,
+				Version: "v1",
+			},
+			{
+				Kind:      "ConfigMap",
+				Name:      testConfigMap.Name,
+				Version:   "v1",
+				Namespace: workNamespaceName,
+			},
+			{
+				Kind:      "ConfigMap",
+				Name:      testEnvelopConfigMap.Name,
+				Version:   "v1",
+				Namespace: workNamespaceName,
+			},
+		}
+	})
+
+	Context("Test cluster join and leave flow with CRP not deleted", Ordered, Serial, func() {
+		It("Create the test resources in the namespace", createWrappedResourcesForEnvelopTest)
+
+		It("Create the CRP that select the name space and place it to all clusters", func() {
+			crp := &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crpName,
+					// Add a custom finalizer; this would allow us to better observe
+					// the behavior of the controllers.
+					Finalizers: []string{customDeletionBlockerFinalizer},
+				},
+				Spec: placementv1beta1.ClusterResourcePlacementSpec{
+					ResourceSelectors: workResourceSelector(),
+					Strategy: placementv1beta1.RolloutStrategy{
+						Type: placementv1beta1.RollingUpdateRolloutStrategyType,
+						RollingUpdate: &placementv1beta1.RollingUpdateConfig{
+							UnavailablePeriodSeconds: ptr.To(2),
+						},
+					},
+				},
+			}
+			Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP")
+		})
+
+		It("should update CRP status as expected", func() {
+			// resourceQuota is enveloped so it's not trackable yet
+			crpStatusUpdatedActual := customizedCRPStatusUpdatedActual(crpName, wantSelectedResources, allMemberClusterNames, nil, "0", false)
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+		})
+
+		It("should place the resources on all member clusters", func() {
+			for idx := range allMemberClusters {
+				memberCluster := allMemberClusters[idx]
+				workResourcesPlacedActual := checkEnvelopQuotaAndMutationWebhookPlacement(memberCluster)
+				Eventually(workResourcesPlacedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to place work resources on member cluster %s", memberCluster.ClusterName)
+			}
+		})
+
+		It("Should be able to unjoin a cluster with crp still running", func() {
+			By("remove all the clusters without deleting the CRP")
+			setAllMemberClustersToLeave()
+			checkIfAllMemberClustersHaveLeft()
+		})
+
+		It("should update CRP status as expected", func() {
+			// resourceQuota is enveloped so it's not trackable yet
+			crpStatusUpdatedActual := customizedCRPStatusUpdatedActual(crpName, wantSelectedResources, nil, nil, "0", false)
+			Eventually(crpStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+		})
+
+		It("Should be able to rejoin the cluster", func() {
+			By("rejoin all the clusters without deleting the CRP")
+			setAllMemberClustersToJoin()
+			checkIfAllMemberClustersHaveJoined()
+			checkIfAzurePropertyProviderIsWorking()
+		})
+	})
+
+	AfterAll(func() {
+		// Remove the custom deletion blocker finalizer from the CRP.
+		cleanupCRP(crpName)
+
+		// Delete the created resources.
+		cleanupWorkResources()
+	})
+})


### PR DESCRIPTION
### Description of your changes

1.  fix the immediate bug by just listing all the work in the cluster namespace.
2. issue the work finalizer removal in parallel.
3. issue a foreground delete namespace before removing the finalizer on the MC object.
4. handle the edge case that the imc does not exist.

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
