### PR TITLE
fix: fix flaky ro webhook e2e test

### DIFF
--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -1076,10 +1076,10 @@ var _ = Describe("webhook tests for ResourceOverride CREATE operations resource 
 
 	It("should deny create RO with invalid resource override", func() {
 		Consistently(func(g Gomega) error {
-			By("create 2nd resourceOverride with same resource selection")
+			By("deny create 2nd resourceOverride with same resource selection")
 			ro1 := &placementv1alpha1.ResourceOverride{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-ro-%d", GinkgoParallelProcess()),
+					Name:      fmt.Sprintf("test-create-ro-%d", GinkgoParallelProcess()),
 					Namespace: roNamespace,
 				},
 				Spec: placementv1alpha1.ResourceOverrideSpec{
@@ -1126,7 +1126,7 @@ var _ = Describe("webhook tests for ResourceOverride CREATE operations resource 
 
 var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered, func() {
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
-	ro1Name := fmt.Sprintf("test-ro-%d", GinkgoParallelProcess())
+	ro1Name := fmt.Sprintf("test-update-ro-%d", GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
 	selector := placementv1alpha1.ResourceSelector{
 		Group:   "apps",

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -1236,7 +1236,7 @@ var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered
 				Group:   "apps",
 				Kind:    "Deployment",
 				Version: "v1",
-				Name:    "test-deployment-%d",
+				Name:    "test-deployment",
 			}
 			ro.Spec.ResourceSelectors = append(ro.Spec.ResourceSelectors, newSelector)
 			clusterSelectorTerm := placementv1beta1.ClusterSelectorTerm{

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -631,7 +631,7 @@ var _ = Describe("webhook tests for ClusterResourceOverride CREATE operations re
 		Consistently(func(g Gomega) error {
 			cro1 := &placementv1alpha1.ClusterResourceOverride{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("test-create-cro-%d", GinkgoParallelProcess()),
+					Name: fmt.Sprintf("test-cro-%d", GinkgoParallelProcess()),
 				},
 				Spec: placementv1alpha1.ClusterResourceOverrideSpec{
 					ClusterResourceSelectors: []placementv1beta1.ClusterResourceSelector{
@@ -697,7 +697,7 @@ var _ = Describe("webhook tests for ClusterResourceOverride CREATE operations re
 
 var _ = Describe("webhook tests for ClusterResourceOverride UPDATE operations", Ordered, func() {
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
-	cro1Name := fmt.Sprintf("test-update-cro-%d", GinkgoParallelProcess())
+	cro1Name := fmt.Sprintf("test-cro-%d", GinkgoParallelProcess())
 	cro := &placementv1alpha1.ClusterResourceOverride{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: croName,
@@ -1079,7 +1079,7 @@ var _ = Describe("webhook tests for ResourceOverride CREATE operations resource 
 			By("create 2nd resourceOverride with same resource selection")
 			ro1 := &placementv1alpha1.ResourceOverride{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-create-ro-%d", GinkgoParallelProcess()),
+					Name:      fmt.Sprintf("test-ro-%d", GinkgoParallelProcess()),
 					Namespace: roNamespace,
 				},
 				Spec: placementv1alpha1.ResourceOverrideSpec{
@@ -1126,7 +1126,7 @@ var _ = Describe("webhook tests for ResourceOverride CREATE operations resource 
 
 var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered, func() {
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
-	ro1Name := fmt.Sprintf("test-update-ro-%d", GinkgoParallelProcess())
+	ro1Name := fmt.Sprintf("test-ro-%d", GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
 	selector := placementv1alpha1.ResourceSelector{
 		Group:   "apps",
@@ -1210,7 +1210,7 @@ var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered
 							Group:   "apps",
 							Kind:    "Deployment",
 							Version: "v1",
-							Name:    "test-deployment-1",
+							Name:    "test-deployment",
 						},
 					},
 					Policy: &placementv1alpha1.OverridePolicy{
@@ -1236,7 +1236,7 @@ var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered
 				Group:   "apps",
 				Kind:    "Deployment",
 				Version: "v1",
-				Name:    fmt.Sprintf("test-deployment-%d", 1),
+				Name:    "test-deployment-%d",
 			}
 			ro.Spec.ResourceSelectors = append(ro.Spec.ResourceSelectors, newSelector)
 			clusterSelectorTerm := placementv1beta1.ClusterSelectorTerm{

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -631,7 +631,7 @@ var _ = Describe("webhook tests for ClusterResourceOverride CREATE operations re
 		Consistently(func(g Gomega) error {
 			cro1 := &placementv1alpha1.ClusterResourceOverride{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: fmt.Sprintf("test-cro-%d", GinkgoParallelProcess()),
+					Name: fmt.Sprintf("test-create-cro-%d", GinkgoParallelProcess()),
 				},
 				Spec: placementv1alpha1.ClusterResourceOverrideSpec{
 					ClusterResourceSelectors: []placementv1beta1.ClusterResourceSelector{
@@ -695,9 +695,9 @@ var _ = Describe("webhook tests for ClusterResourceOverride CREATE operations re
 	})
 })
 
-var _ = Describe("webhook tests for CRO UPDATE operations", Ordered, func() {
+var _ = Describe("webhook tests for ClusterResourceOverride UPDATE operations", Ordered, func() {
 	croName := fmt.Sprintf(croNameTemplate, GinkgoParallelProcess())
-	cro1Name := fmt.Sprintf("test-cro-%d", GinkgoParallelProcess())
+	cro1Name := fmt.Sprintf("test-update-cro-%d", GinkgoParallelProcess())
 	cro := &placementv1alpha1.ClusterResourceOverride{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: croName,
@@ -1079,7 +1079,7 @@ var _ = Describe("webhook tests for ResourceOverride CREATE operations resource 
 			By("create 2nd resourceOverride with same resource selection")
 			ro1 := &placementv1alpha1.ResourceOverride{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-ro-%d", GinkgoParallelProcess()),
+					Name:      fmt.Sprintf("test-create-ro-%d", GinkgoParallelProcess()),
 					Namespace: roNamespace,
 				},
 				Spec: placementv1alpha1.ResourceOverrideSpec{
@@ -1126,7 +1126,7 @@ var _ = Describe("webhook tests for ResourceOverride CREATE operations resource 
 
 var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered, func() {
 	roName := fmt.Sprintf(roNameTemplate, GinkgoParallelProcess())
-	ro1Name := fmt.Sprintf("test-ro-%d", GinkgoParallelProcess())
+	ro1Name := fmt.Sprintf("test-update-ro-%d", GinkgoParallelProcess())
 	roNamespace := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
 	selector := placementv1alpha1.ResourceSelector{
 		Group:   "apps",
@@ -1201,7 +1201,7 @@ var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered
 			By("creating a new resource override")
 			ro1 := &placementv1alpha1.ResourceOverride{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-ro-%d", GinkgoParallelProcess()),
+					Name:      ro1Name,
 					Namespace: roNamespace,
 				},
 				Spec: placementv1alpha1.ResourceOverrideSpec{


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:
- For [webhook failure](https://github.com/Azure/fleet/actions/runs/9805690990/job/27075899440), ensure both are selecting the same resource.
- For [already exists failure](https://github.com/Azure/fleet/actions/runs/9756434642/job/26928197484), there are only two places that use "test-ro" so differentiated the names so that they don't overlap. In one instance it should get denied when trying to create, while in the other it gets created and then deleted.

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
