### PR TITLE
feat: handle fleet/upstream MC resources differently in fleet guard rail

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -90,6 +90,9 @@ const (
 
 	// ResourceIdentifierWithEnvelopeIdentifierStringFormat is the format of the resource identifier string with envelope identifier.
 	ResourceIdentifierWithEnvelopeIdentifierStringFormat = "%s/%s/%s/%s/%s/%s/%s/%s"
+
+	// FleetClusterResourceIsAnnotationKey is used to mark the cluster resource is created by fleet.
+	FleetClusterResourceIsAnnotationKey = "fleet.azure.com/cluster-resource-id"
 )
 
 var (

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -91,8 +91,8 @@ const (
 	// ResourceIdentifierWithEnvelopeIdentifierStringFormat is the format of the resource identifier string with envelope identifier.
 	ResourceIdentifierWithEnvelopeIdentifierStringFormat = "%s/%s/%s/%s/%s/%s/%s/%s"
 
-	// FleetClusterResourceIsAnnotationKey is used to mark the cluster resource is created by fleet.
-	FleetClusterResourceIsAnnotationKey = "fleet.azure.com/cluster-resource-id"
+	// FleetAnnotationPrefix is the prefix used to annotate fleet member cluster resources.
+	FleetAnnotationPrefix = "fleet.azure.com"
 )
 
 var (
@@ -553,4 +553,14 @@ func IsFailedResourcePlacementsEqual(oldFailedResourcePlacements, newFailedResou
 		}
 	}
 	return true
+}
+
+// IsFleetAnnotationPresent returns true if a key with fleet prefix is present in the annotations map.
+func IsFleetAnnotationPresent(annotations map[string]string) bool {
+	for k, _ := range annotations {
+		if strings.HasPrefix(k, FleetAnnotationPrefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -557,7 +557,7 @@ func IsFailedResourcePlacementsEqual(oldFailedResourcePlacements, newFailedResou
 
 // IsFleetAnnotationPresent returns true if a key with fleet prefix is present in the annotations map.
 func IsFleetAnnotationPresent(annotations map[string]string) bool {
-	for k, _ := range annotations {
+	for k := range annotations {
 		if strings.HasPrefix(k, FleetAnnotationPrefix) {
 			return true
 		}

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -209,6 +209,7 @@ func parseMemberClusterNameFromNamespace(namespace string) string {
 	return mcName
 }
 
+// isAnnotationPresent returns true if the key is present in the annotations map.
 func isAnnotationPresent(annotations map[string]string, key string) bool {
 	_, exists := annotations[key]
 	return exists

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook.go
@@ -128,13 +128,13 @@ func (v *fleetResourceValidator) handleMemberCluster(req admission.Request) admi
 		if err := v.decoder.DecodeRaw(req.OldObject, &oldMC); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		isFleetMC := isAnnotationPresent(oldMC.Annotations, utils.FleetClusterResourceIsAnnotationKey)
+		isFleetMC := utils.IsFleetAnnotationPresent(oldMC.Annotations)
 		if isFleetMC {
 			return validation.ValidateFleetMemberClusterUpdate(currentMC, oldMC, req, v.whiteListedUsers)
 		}
 		return validation.ValidatedUpstreamMemberClusterUpdate(currentMC, oldMC, req, v.whiteListedUsers)
 	}
-	isFleetMC := isAnnotationPresent(currentMC.Annotations, utils.FleetClusterResourceIsAnnotationKey)
+	isFleetMC := utils.IsFleetAnnotationPresent(currentMC.Annotations)
 	if isFleetMC {
 		return validation.ValidateUserForResource(req, v.whiteListedUsers)
 	}
@@ -207,10 +207,4 @@ func parseMemberClusterNameFromNamespace(namespace string) string {
 		mcName = namespace[startIndex:]
 	}
 	return mcName
-}
-
-// isAnnotationPresent returns true if the key is present in the annotations map.
-func isAnnotationPresent(annotations map[string]string, key string) bool {
-	_, exists := annotations[key]
-	return exists
 }

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
@@ -981,7 +981,7 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow any user to modify upstream MC annotations, without adding fleet cluster resource ID annotation": {
+		"allow any user to modify upstream MC annotations, without adding fleet pre-fixed annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
@@ -1004,7 +1004,7 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"deny user in system:masters group to modify upstream MC annotations, by adding fleet cluster resource ID annotation": {
+		"deny user in system:masters group to modify upstream MC annotations, by adding fleet pre-fixed annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
@@ -1096,7 +1096,7 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"deny update of fleet MC spec by non whitelisted user ": {
+		"deny update of fleet MC spec by non whitelisted user": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
@@ -1120,7 +1120,7 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow update of MC spec by any user": {
+		"allow update of upstream MC spec by any user": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 const (
-	mcName = "test-mc"
+	mcName                 = "test-mc"
+	testClusterResourceID1 = "test-cluster-resource-id-1"
+	testClusterResourceID2 = "test-cluster-resource-id-2"
 )
 
 func TestHandleCRD(t *testing.T) {
@@ -394,12 +396,64 @@ func TestHandleV1Alpha1MemberCluster(t *testing.T) {
 }
 
 func TestHandleMemberCluster(t *testing.T) {
-	MCObject := &clusterv1beta1.MemberCluster{
+	fleetMCObject := &clusterv1beta1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MemberCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-mc",
+			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+		},
+	}
+	updateClusterResourceIDAnnotationFleetMCObject := &clusterv1beta1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MemberCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-mc",
+			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID2},
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+		},
+	}
+	mcObject := &clusterv1beta1.MemberCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-mc",
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+		},
+	}
+	labelUpdatedFleetMCObject := &clusterv1beta1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MemberCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-mc",
+			Labels:      map[string]string{"test-key": "test-value"},
+			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
 		},
 	}
 	labelUpdatedMCObject := &clusterv1beta1.MemberCluster{
@@ -410,24 +464,61 @@ func TestHandleMemberCluster(t *testing.T) {
 			Name:   "test-mc",
 			Labels: map[string]string{"test-key": "test-value"},
 		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+		},
+	}
+	annotationUpdatedFleetMCObject := &clusterv1beta1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MemberCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mc",
+			Annotations: map[string]string{
+				utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1,
+				"test-key": "test-value",
+			},
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+		},
 	}
 	annotationUpdatedMCObject := &clusterv1beta1.MemberCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-mc",
-			Annotations: map[string]string{"test-key": "test-value"},
+			Name: "test-mc",
+			Annotations: map[string]string{
+				"test-key": "test-value",
+			},
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
 		},
 	}
-	taintUpdatedMCObject := &clusterv1beta1.MemberCluster{
+	taintUpdatedFleetMCObject := &clusterv1beta1.MemberCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-mc",
+			Name:        "test-mc",
+			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
 			Taints: []clusterv1beta1.Taint{
 				{
 					Key:    "key1",
@@ -435,6 +526,22 @@ func TestHandleMemberCluster(t *testing.T) {
 					Effect: corev1.TaintEffectNoSchedule,
 				},
 			},
+		},
+	}
+	specUpdatedFleetMCObject := &clusterv1beta1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MemberCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-mc",
+			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+			HeartbeatPeriodSeconds: 30,
 		},
 	}
 	specUpdatedMCObject := &clusterv1beta1.MemberCluster{
@@ -445,15 +552,33 @@ func TestHandleMemberCluster(t *testing.T) {
 			Name: "test-mc",
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+			Taints: []clusterv1beta1.Taint{
+				{
+					Key:    "key1",
+					Value:  "value1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+			},
 			HeartbeatPeriodSeconds: 30,
 		},
 	}
-	statusUpdatedMCObject := &clusterv1beta1.MemberCluster{
+	statusUpdatedFleetMCObject := &clusterv1beta1.MemberCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-mc",
+			Name:        "test-mc",
+			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
 		},
 		Status: clusterv1beta1.MemberClusterStatus{
 			Conditions: []metav1.Condition{
@@ -465,15 +590,50 @@ func TestHandleMemberCluster(t *testing.T) {
 		},
 	}
 
-	MCObjectBytes, err := json.Marshal(MCObject)
+	statusUpdatedMCObject := &clusterv1beta1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MemberCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mc",
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+		},
+		Status: clusterv1beta1.MemberClusterStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(fleetv1alpha1.ConditionTypeMemberClusterReadyToJoin),
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	fleetMCObjectBytes, err := json.Marshal(fleetMCObject)
+	assert.Nil(t, err)
+	updateClusterResourceIDAnnotationFleetMCObjectBytes, err := json.Marshal(updateClusterResourceIDAnnotationFleetMCObject)
+	assert.Nil(t, err)
+	mcObjectBytes, err := json.Marshal(mcObject)
+	assert.Nil(t, err)
+	labelUpdatedFleetMCObjectBytes, err := json.Marshal(labelUpdatedFleetMCObject)
 	assert.Nil(t, err)
 	labelUpdatedMCObjectBytes, err := json.Marshal(labelUpdatedMCObject)
 	assert.Nil(t, err)
+	annotationUpdatedFleetMCObjectBytes, err := json.Marshal(annotationUpdatedFleetMCObject)
+	assert.Nil(t, err)
 	annotationUpdatedMCObjectBytes, err := json.Marshal(annotationUpdatedMCObject)
 	assert.Nil(t, err)
-	taintUpdatedMCObjectBytes, err := json.Marshal(taintUpdatedMCObject)
+	taintUpdatedFleetMCObjectBytes, err := json.Marshal(taintUpdatedFleetMCObject)
+	assert.Nil(t, err)
+	specUpdatedFleetMCObjectBytes, err := json.Marshal(specUpdatedFleetMCObject)
 	assert.Nil(t, err)
 	specUpdatedMCObjectBytes, err := json.Marshal(specUpdatedMCObject)
+	assert.Nil(t, err)
+	statusUpdatedFleetMCObjectBytes, err := json.Marshal(statusUpdatedFleetMCObject)
 	assert.Nil(t, err)
 	statusUpdatedMCObjectBytes, err := json.Marshal(statusUpdatedMCObject)
 	assert.Nil(t, err)
@@ -489,13 +649,13 @@ func TestHandleMemberCluster(t *testing.T) {
 		resourceValidator fleetResourceValidator
 		wantResponse      admission.Response
 	}{
-		"allow create MC for user in system:masters group": {
+		"allow create fleet MC for user in system:masters group": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    labelUpdatedMCObjectBytes,
-						Object: labelUpdatedMCObject,
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -510,7 +670,53 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Create, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow any user to modify MC labels": {
+		"allow create upstream MC for any user": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    mcObjectBytes,
+						Object: mcObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"system:masters"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Create,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Create, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow any user to modify fleet MC labels": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    labelUpdatedFleetMCObjectBytes,
+						Object: labelUpdatedFleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow any user to modify upstream MC labels": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
@@ -519,8 +725,8 @@ func TestHandleMemberCluster(t *testing.T) {
 						Object: labelUpdatedMCObject,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    MCObjectBytes,
-						Object: MCObject,
+						Raw:    mcObjectBytes,
+						Object: mcObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -535,17 +741,17 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow any user to modify MC annotations": {
+		"allow any user to modify fleet MC annotations other than fleet cluster resource ID annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    annotationUpdatedMCObjectBytes,
-						Object: annotationUpdatedMCObject,
+						Raw:    annotationUpdatedFleetMCObjectBytes,
+						Object: annotationUpdatedFleetMCObject,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    MCObjectBytes,
-						Object: MCObject,
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -560,17 +766,17 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow any user to modify MC taints": {
+		"deny any user to modify fleet MC annotations, update fleet cluster resource ID annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    taintUpdatedMCObjectBytes,
-						Object: taintUpdatedMCObject,
+						Raw:    updateClusterResourceIDAnnotationFleetMCObjectBytes,
+						Object: updateClusterResourceIDAnnotationFleetMCObject,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    MCObjectBytes,
-						Object: MCObject,
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -583,19 +789,44 @@ func TestHandleMemberCluster(t *testing.T) {
 			resourceValidator: fleetResourceValidator{
 				decoder: decoder,
 			},
-			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow system:masters group user to modify MC spec": {
+		"deny any user to modify fleet MC annotations, remove fleet cluster resource ID annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    specUpdatedMCObjectBytes,
-						Object: specUpdatedMCObject,
+						Raw:    mcObjectBytes,
+						Object: mcObject,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    MCObjectBytes,
-						Object: MCObject,
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow user in system:masters group to modify fleet MC annotations, update fleet cluster resource ID annotation": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    updateClusterResourceIDAnnotationFleetMCObjectBytes,
+						Object: updateClusterResourceIDAnnotationFleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -610,17 +841,268 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow system:masters group user to modify MC status": {
+		"allow user in system:masters group to modify fleet MC annotations, remove fleet cluster resource ID annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    statusUpdatedMCObjectBytes,
-						Object: statusUpdatedMCObject,
+						Raw:    mcObjectBytes,
+						Object: mcObject,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    MCObjectBytes,
-						Object: MCObject,
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"system:masters"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow any user to modify upstream MC annotations, without adding fleet cluster resource ID annotation": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    annotationUpdatedMCObjectBytes,
+						Object: annotationUpdatedMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    mcObjectBytes,
+						Object: mcObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"deny any user to modify upstream MC annotations, by adding fleet cluster resource ID annotation": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    mcObjectBytes,
+						Object: mcObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow user in system:masters group to modify upstream MC annotations, by adding fleet cluster resource ID annotation": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    mcObjectBytes,
+						Object: mcObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"system:masters"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow any user to modify fleet MC taints": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    taintUpdatedFleetMCObjectBytes,
+						Object: taintUpdatedFleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow system:masters group user to modify fleet MC spec": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    specUpdatedFleetMCObjectBytes,
+						Object: specUpdatedFleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"system:masters"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"deny update of fleet MC spec by non system:masters group": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    specUpdatedFleetMCObjectBytes,
+						Object: specUpdatedFleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"deny update of fleet MC spec by non whitelisted user ": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    specUpdatedFleetMCObjectBytes,
+						Object: specUpdatedFleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder:          decoder,
+				whiteListedUsers: []string{"test-user1"},
+			},
+			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"deny update of fleet MC spec apart from taints by any user": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    specUpdatedFleetMCObjectBytes,
+						Object: specUpdatedFleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow update of MC spec by any user": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    specUpdatedMCObjectBytes,
+						Object: specUpdatedMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    mcObjectBytes,
+						Object: mcObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow system:masters group user to modify fleet MC status": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    statusUpdatedFleetMCObjectBytes,
+						Object: statusUpdatedFleetMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -636,17 +1118,17 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "status", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow whitelisted user to modify MC status": {
+		"allow whitelisted user to modify fleet MC status": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    statusUpdatedMCObjectBytes,
-						Object: statusUpdatedMCObject,
+						Raw:    statusUpdatedFleetMCObjectBytes,
+						Object: statusUpdatedFleetMCObject,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    MCObjectBytes,
-						Object: MCObject,
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -663,17 +1145,17 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "status", types.NamespacedName{Name: "test-mc"})),
 		},
-		"deny update of member cluster spec by non system:masters group": {
+		"deny user not in system:masters group to modify fleet MC status": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    specUpdatedMCObjectBytes,
-						Object: specUpdatedMCObject,
+						Raw:    statusUpdatedFleetMCObjectBytes,
+						Object: statusUpdatedFleetMCObject,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    MCObjectBytes,
-						Object: MCObject,
+						Raw:    fleetMCObjectBytes,
+						Object: fleetMCObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -681,24 +1163,51 @@ func TestHandleMemberCluster(t *testing.T) {
 					},
 					RequestKind: &utils.MCMetaGVK,
 					Operation:   admissionv1.Update,
+					SubResource: "status",
 				},
 			},
 			resourceValidator: fleetResourceValidator{
 				decoder: decoder,
 			},
-			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "status", types.NamespacedName{Name: "test-mc"})),
 		},
-		"deny update of member cluster spec by non whitelisted user ": {
+		"allow system:masters group user to modify upstream MC status": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    specUpdatedMCObjectBytes,
-						Object: specUpdatedMCObject,
+						Raw:    statusUpdatedMCObjectBytes,
+						Object: statusUpdatedMCObject,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    MCObjectBytes,
-						Object: MCObject,
+						Raw:    mcObjectBytes,
+						Object: mcObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"system:masters"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+					SubResource: "status",
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "status", types.NamespacedName{Name: "test-mc"})),
+		},
+		"allow whitelisted user to modify upstream MC status": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    statusUpdatedMCObjectBytes,
+						Object: statusUpdatedMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    mcObjectBytes,
+						Object: mcObject,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -706,13 +1215,40 @@ func TestHandleMemberCluster(t *testing.T) {
 					},
 					RequestKind: &utils.MCMetaGVK,
 					Operation:   admissionv1.Update,
+					SubResource: "status",
 				},
 			},
 			resourceValidator: fleetResourceValidator{
 				decoder:          decoder,
-				whiteListedUsers: []string{"test-user1"},
+				whiteListedUsers: []string{"test-user"},
 			},
-			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "status", types.NamespacedName{Name: "test-mc"})),
+		},
+		"deny user not in system:masters group to modify upstream MC status": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name: "test-mc",
+					Object: runtime.RawExtension{
+						Raw:    statusUpdatedMCObjectBytes,
+						Object: statusUpdatedMCObject,
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    mcObjectBytes,
+						Object: mcObject,
+					},
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{"test-group"},
+					},
+					RequestKind: &utils.MCMetaGVK,
+					Operation:   admissionv1.Update,
+					SubResource: "status",
+				},
+			},
+			resourceValidator: fleetResourceValidator{
+				decoder: decoder,
+			},
+			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "status", types.NamespacedName{Name: "test-mc"})),
 		},
 	}
 

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
@@ -933,7 +933,7 @@ func TestHandleMemberCluster(t *testing.T) {
 			resourceValidator: fleetResourceValidator{
 				decoder: decoder,
 			},
-			wantResponse: admission.Denied("no user is allowed to remove all fleet pre-fixed annotation from a fleet member cluster"),
+			wantResponse: admission.Denied("no user is allowed to remove all fleet pre-fixed annotations from a fleet member cluster"),
 		},
 		"allow user in system:masters group to modify fleet MC annotations, update one fleet pre-fixed annotation": {
 			req: admission.Request{

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
@@ -1138,31 +1138,6 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"deny update of fleet MC spec apart from taints by any user": {
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Name: "test-mc",
-					Object: runtime.RawExtension{
-						Raw:    specUpdatedFleetMCObjectBytes,
-						Object: specUpdatedFleetMCObject,
-					},
-					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
-					},
-					UserInfo: authenticationv1.UserInfo{
-						Username: "test-user",
-						Groups:   []string{"test-group"},
-					},
-					RequestKind: &utils.MCMetaGVK,
-					Operation:   admissionv1.Update,
-				},
-			},
-			resourceValidator: fleetResourceValidator{
-				decoder: decoder,
-			},
-			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
-		},
 		"allow update of MC spec by any user": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{

--- a/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
+++ b/pkg/webhook/fleetresourcehandler/fleetresourcehandler_webhook_test.go
@@ -29,6 +29,10 @@ const (
 	mcName                 = "test-mc"
 	testClusterResourceID1 = "test-cluster-resource-id-1"
 	testClusterResourceID2 = "test-cluster-resource-id-2"
+	testLocation           = "test-location"
+
+	fleetClusterResourceIsAnnotationKey = "fleet.azure.com/cluster-resource-id"
+	fleetLocationAnnotationKey          = "fleet.azure.com/location"
 )
 
 func TestHandleCRD(t *testing.T) {
@@ -401,8 +405,11 @@ func TestHandleMemberCluster(t *testing.T) {
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-mc",
-			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+			Name: "test-mc",
+			Annotations: map[string]string{
+				fleetClusterResourceIsAnnotationKey: testClusterResourceID1,
+				fleetLocationAnnotationKey:          testLocation,
+			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
 			Identity: rbacv1.Subject{
@@ -411,13 +418,33 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 		},
 	}
-	updateClusterResourceIDAnnotationFleetMCObject := &clusterv1beta1.MemberCluster{
+	updateClusterResourceIDAnnotationFleetMCObject1 := &clusterv1beta1.MemberCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-mc",
-			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID2},
+			Name: "test-mc",
+			Annotations: map[string]string{
+				fleetClusterResourceIsAnnotationKey: testClusterResourceID2,
+				fleetLocationAnnotationKey:          testLocation,
+			},
+		},
+		Spec: clusterv1beta1.MemberClusterSpec{
+			Identity: rbacv1.Subject{
+				Kind: "User",
+				Name: "test-user",
+			},
+		},
+	}
+	updateClusterResourceIDAnnotationFleetMCObject2 := &clusterv1beta1.MemberCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MemberCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-mc",
+			Annotations: map[string]string{
+				fleetClusterResourceIsAnnotationKey: testClusterResourceID2,
+			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
 			Identity: rbacv1.Subject{
@@ -445,9 +472,12 @@ func TestHandleMemberCluster(t *testing.T) {
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-mc",
-			Labels:      map[string]string{"test-key": "test-value"},
-			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+			Name:   "test-mc",
+			Labels: map[string]string{"test-key": "test-value"},
+			Annotations: map[string]string{
+				fleetClusterResourceIsAnnotationKey: testClusterResourceID1,
+				fleetLocationAnnotationKey:          testLocation,
+			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
 			Identity: rbacv1.Subject{
@@ -478,8 +508,9 @@ func TestHandleMemberCluster(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-mc",
 			Annotations: map[string]string{
-				utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1,
-				"test-key": "test-value",
+				fleetClusterResourceIsAnnotationKey: testClusterResourceID1,
+				fleetLocationAnnotationKey:          testLocation,
+				"test-key":                          "test-value",
 			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
@@ -511,8 +542,11 @@ func TestHandleMemberCluster(t *testing.T) {
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-mc",
-			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+			Name: "test-mc",
+			Annotations: map[string]string{
+				fleetClusterResourceIsAnnotationKey: testClusterResourceID1,
+				fleetLocationAnnotationKey:          testLocation,
+			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
 			Identity: rbacv1.Subject{
@@ -533,8 +567,11 @@ func TestHandleMemberCluster(t *testing.T) {
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-mc",
-			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+			Name: "test-mc",
+			Annotations: map[string]string{
+				fleetClusterResourceIsAnnotationKey: testClusterResourceID1,
+				fleetLocationAnnotationKey:          testLocation,
+			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
 			Identity: rbacv1.Subject{
@@ -571,8 +608,11 @@ func TestHandleMemberCluster(t *testing.T) {
 			Kind: "MemberCluster",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-mc",
-			Annotations: map[string]string{utils.FleetClusterResourceIsAnnotationKey: testClusterResourceID1},
+			Name: "test-mc",
+			Annotations: map[string]string{
+				fleetClusterResourceIsAnnotationKey: testClusterResourceID1,
+				fleetLocationAnnotationKey:          testLocation,
+			},
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
 			Identity: rbacv1.Subject{
@@ -615,7 +655,9 @@ func TestHandleMemberCluster(t *testing.T) {
 
 	fleetMCObjectBytes, err := json.Marshal(fleetMCObject)
 	assert.Nil(t, err)
-	updateClusterResourceIDAnnotationFleetMCObjectBytes, err := json.Marshal(updateClusterResourceIDAnnotationFleetMCObject)
+	updateClusterResourceIDAnnotationFleetMCObjectBytes1, err := json.Marshal(updateClusterResourceIDAnnotationFleetMCObject1)
+	assert.Nil(t, err)
+	updateClusterResourceIDAnnotationFleetMCObjectBytes2, err := json.Marshal(updateClusterResourceIDAnnotationFleetMCObject2)
 	assert.Nil(t, err)
 	mcObjectBytes, err := json.Marshal(mcObject)
 	assert.Nil(t, err)
@@ -654,8 +696,7 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -675,8 +716,7 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -696,8 +736,7 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -717,12 +756,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -742,12 +779,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -767,12 +802,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -792,12 +825,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    labelUpdatedFleetMCObjectBytes,
-						Object: labelUpdatedFleetMCObject,
+						Raw: labelUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -817,12 +848,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    labelUpdatedMCObjectBytes,
-						Object: labelUpdatedMCObject,
+						Raw: labelUpdatedMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -837,17 +866,15 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow any user to modify fleet MC annotations other than fleet cluster resource ID annotation": {
+		"allow any user to modify fleet MC annotations other than fleet pre-fixed annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    annotationUpdatedFleetMCObjectBytes,
-						Object: annotationUpdatedFleetMCObject,
+						Raw: annotationUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -862,17 +889,15 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"deny any user to modify fleet MC annotations, update fleet cluster resource ID annotation": {
+		"deny any user to modify fleet MC annotations, update fleet pre-fixed annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    updateClusterResourceIDAnnotationFleetMCObjectBytes,
-						Object: updateClusterResourceIDAnnotationFleetMCObject,
+						Raw: updateClusterResourceIDAnnotationFleetMCObjectBytes1,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -887,17 +912,15 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"deny any user to modify fleet MC annotations, remove fleet cluster resource ID annotation": {
+		"deny user in system:masters group to modify fleet MC annotations, remove all fleet pre-fixed annotations": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -910,19 +933,17 @@ func TestHandleMemberCluster(t *testing.T) {
 			resourceValidator: fleetResourceValidator{
 				decoder: decoder,
 			},
-			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+			wantResponse: admission.Denied("no user is allowed to remove all fleet pre-fixed annotation from a fleet member cluster"),
 		},
-		"allow user in system:masters group to modify fleet MC annotations, update fleet cluster resource ID annotation": {
+		"allow user in system:masters group to modify fleet MC annotations, update one fleet pre-fixed annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    updateClusterResourceIDAnnotationFleetMCObjectBytes,
-						Object: updateClusterResourceIDAnnotationFleetMCObject,
+						Raw: updateClusterResourceIDAnnotationFleetMCObjectBytes1,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -937,17 +958,15 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"allow user in system:masters group to modify fleet MC annotations, remove fleet cluster resource ID annotation": {
+		"allow user in system:masters group to modify fleet MC annotations, update one fleet pre-fixed annotation and remove another fleet pre-fixed annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: updateClusterResourceIDAnnotationFleetMCObjectBytes2,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -967,12 +986,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    annotationUpdatedMCObjectBytes,
-						Object: annotationUpdatedMCObject,
+						Raw: annotationUpdatedMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -987,42 +1004,15 @@ func TestHandleMemberCluster(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
 		},
-		"deny any user to modify upstream MC annotations, by adding fleet cluster resource ID annotation": {
+		"deny user in system:masters group to modify upstream MC annotations, by adding fleet cluster resource ID annotation": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
-					},
-					UserInfo: authenticationv1.UserInfo{
-						Username: "test-user",
-						Groups:   []string{"test-group"},
-					},
-					RequestKind: &utils.MCMetaGVK,
-					Operation:   admissionv1.Update,
-				},
-			},
-			resourceValidator: fleetResourceValidator{
-				decoder: decoder,
-			},
-			wantResponse: admission.Denied(fmt.Sprintf(validation.ResourceDeniedFormat, "test-user", utils.GenerateGroupString([]string{"test-group"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
-		},
-		"allow user in system:masters group to modify upstream MC annotations, by adding fleet cluster resource ID annotation": {
-			req: admission.Request{
-				AdmissionRequest: admissionv1.AdmissionRequest{
-					Name: "test-mc",
-					Object: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
-					},
-					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1035,19 +1025,17 @@ func TestHandleMemberCluster(t *testing.T) {
 			resourceValidator: fleetResourceValidator{
 				decoder: decoder,
 			},
-			wantResponse: admission.Allowed(fmt.Sprintf(validation.ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{"system:masters"}), admissionv1.Update, &utils.MCMetaGVK, "", types.NamespacedName{Name: "test-mc"})),
+			wantResponse: admission.Denied("no user is allowed to add a fleet pre-fixed annotation to an upstream member cluster"),
 		},
 		"allow any user to modify fleet MC taints": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    taintUpdatedFleetMCObjectBytes,
-						Object: taintUpdatedFleetMCObject,
+						Raw: taintUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1067,12 +1055,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    specUpdatedFleetMCObjectBytes,
-						Object: specUpdatedFleetMCObject,
+						Raw: specUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1092,12 +1078,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    specUpdatedFleetMCObjectBytes,
-						Object: specUpdatedFleetMCObject,
+						Raw: specUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1117,12 +1101,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    specUpdatedFleetMCObjectBytes,
-						Object: specUpdatedFleetMCObject,
+						Raw: specUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1143,12 +1125,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    specUpdatedMCObjectBytes,
-						Object: specUpdatedMCObject,
+						Raw: specUpdatedMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1168,12 +1148,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    statusUpdatedFleetMCObjectBytes,
-						Object: statusUpdatedFleetMCObject,
+						Raw: statusUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1194,12 +1172,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    statusUpdatedFleetMCObjectBytes,
-						Object: statusUpdatedFleetMCObject,
+						Raw: statusUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1221,12 +1197,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    statusUpdatedFleetMCObjectBytes,
-						Object: statusUpdatedFleetMCObject,
+						Raw: statusUpdatedFleetMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    fleetMCObjectBytes,
-						Object: fleetMCObject,
+						Raw: fleetMCObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1247,12 +1221,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    statusUpdatedMCObjectBytes,
-						Object: statusUpdatedMCObject,
+						Raw: statusUpdatedMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1273,12 +1245,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    statusUpdatedMCObjectBytes,
-						Object: statusUpdatedMCObject,
+						Raw: statusUpdatedMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",
@@ -1300,12 +1270,10 @@ func TestHandleMemberCluster(t *testing.T) {
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: "test-mc",
 					Object: runtime.RawExtension{
-						Raw:    statusUpdatedMCObjectBytes,
-						Object: statusUpdatedMCObject,
+						Raw: statusUpdatedMCObjectBytes,
 					},
 					OldObject: runtime.RawExtension{
-						Raw:    mcObjectBytes,
-						Object: mcObject,
+						Raw: mcObjectBytes,
 					},
 					UserInfo: authenticationv1.UserInfo{
 						Username: "test-user",

--- a/pkg/webhook/validation/uservalidation.go
+++ b/pkg/webhook/validation/uservalidation.go
@@ -150,18 +150,21 @@ func isMapFieldUpdated(currentMap, oldMap map[string]string) bool {
 	return !reflect.DeepEqual(currentMap, oldMap)
 }
 
+// isFleetClusterResourceIDAnnotationUpdated returns true if fleet cluster resource ID annotation is updated/removed.
 func isFleetClusterResourceIDAnnotationUpdated(currentMap, oldMap map[string]string) bool {
 	currentVal, currentExists := currentMap[utils.FleetClusterResourceIsAnnotationKey]
 	oldVal, oldExists := oldMap[utils.FleetClusterResourceIsAnnotationKey]
 	return oldExists && !currentExists || oldVal != currentVal
 }
 
+// isFleetClusterResourceIDAnnotationAdded returns true if fleet cluster resource ID annotation is added.
 func isFleetClusterResourceIDAnnotationAdded(currentMap, oldMap map[string]string) bool {
 	_, currentExists := currentMap[utils.FleetClusterResourceIsAnnotationKey]
 	_, oldExists := oldMap[utils.FleetClusterResourceIsAnnotationKey]
 	return !oldExists && currentExists
 }
 
+// isMemberClusterStatusUpdated returns true if member cluster status is updated.
 func isMemberClusterStatusUpdated(currentMCStatus, oldMCStatus clusterv1beta1.MemberClusterStatus) bool {
 	return !equality.Semantic.DeepEqual(currentMCStatus, oldMCStatus)
 }

--- a/pkg/webhook/validation/uservalidation.go
+++ b/pkg/webhook/validation/uservalidation.go
@@ -91,10 +91,10 @@ func ValidateV1Alpha1MemberClusterUpdate(currentMC, oldMC fleetv1alpha1.MemberCl
 func ValidateFleetMemberClusterUpdate(currentMC, oldMC clusterv1beta1.MemberCluster, req admission.Request, whiteListedUsers []string) admission.Response {
 	namespacedName := types.NamespacedName{Name: currentMC.GetName()}
 	userInfo := req.UserInfo
-	// any user is allowed to modify labels, annotations, taints on fleet MC.
 	// set taints field to nil.
 	currentMC.Spec.Taints = nil
 	oldMC.Spec.Taints = nil
+	// any user is allowed to modify labels, annotations, taints on fleet MC.
 	isObjUpdated, err := isMemberClusterUpdated(currentMC.DeepCopy(), oldMC.DeepCopy())
 	if err != nil {
 		return admission.Denied(err.Error())
@@ -111,8 +111,7 @@ func ValidatedUpstreamMemberClusterUpdate(currentMC, oldMC clusterv1beta1.Member
 	namespacedName := types.NamespacedName{Name: currentMC.GetName()}
 	userInfo := req.UserInfo
 	// any user is allowed to modify MC spec for upstream MC.
-	isStatusUpdated := isMemberClusterStatusUpdated(currentMC.Status, oldMC.Status)
-	if isStatusUpdated || isFleetClusterResourceIDAnnotationAdded(currentMC.Annotations, oldMC.Annotations) {
+	if isMemberClusterStatusUpdated(currentMC.Status, oldMC.Status) || isFleetClusterResourceIDAnnotationAdded(currentMC.Annotations, oldMC.Annotations) {
 		return ValidateUserForResource(req, whiteListedUsers)
 	}
 	klog.V(3).InfoS(allowedModifyResource, "user", userInfo.Username, "groups", userInfo.Groups, "operation", req.Operation, "GVK", req.RequestKind, "subResource", req.SubResource, "namespacedName", namespacedName)

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -116,7 +116,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should deny update operation on fleet member cluster CR, fleet prefixed annotation for user in system:masters group", func() {
+	It("should deny update operation on fleet member cluster CR remove fleet prefixed annotation for user in system:masters group", func() {
 		Eventually(func(g Gomega) error {
 			var mc clusterv1beta1.MemberCluster
 			err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)
@@ -194,7 +194,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should allow update operation on fleet member cluster CR annotations for any user", func() {
+	It("should allow update operation on fleet member cluster CR annotations except fleet pre-fixed annotation for any user", func() {
 		var mc clusterv1beta1.MemberCluster
 		By(fmt.Sprintf("update annotations in fleet member cluster %s, expecting successful UPDATE of fleet member cluster", mcName))
 		Eventually(func(g Gomega) error {
@@ -212,7 +212,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should allow update operation on fleet member cluster CR to modify fleet pre-fixed annotation for user in system:masters group", func() {
+	It("should allow update operation on fleet member cluster CR to modify fleet pre-fixed annotation value for user in system:masters group", func() {
 		var mc clusterv1beta1.MemberCluster
 		By(fmt.Sprintf("update fleet member cluster, remove cluster id annotation %s", mcName))
 		Eventually(func(g Gomega) error {
@@ -314,7 +314,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 		ensureMemberClusterAndRelatedResourcesDeletion(mcName)
 	})
 
-	It("should deny update operation on upstream member cluster CR fleet pre-fixed annotation for user not in system:masters group", func() {
+	It("should deny update operation on upstream member cluster CR add fleet pre-fixed annotation for user not in system:masters group", func() {
 		Eventually(func(g Gomega) error {
 			var mc clusterv1beta1.MemberCluster
 			err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)
@@ -331,7 +331,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should deny update operation on upstream member cluster CR fleet pre-fixed annotation for user in system:masters group", func() {
+	It("should deny update operation on upstream member cluster CR add fleet pre-fixed annotation for user in system:masters group", func() {
 		Eventually(func(g Gomega) error {
 			var mc clusterv1beta1.MemberCluster
 			err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -89,6 +89,9 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 				return err
 			}
 			By(fmt.Sprintf("update fleet member cluster, cluster id annotation %s", mc.Name))
+			if len(mc.Annotations) == 0 {
+				return errors.New("annotations are empty")
+			}
 			mc.Annotations[utils.FleetClusterResourceIsAnnotationKey] = clusterID2
 			err = impersonateHubClient.Update(ctx, &mc)
 			if k8sErrors.IsConflict(err) {
@@ -253,7 +256,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 	})
 })
 
-var _ = Describe("fleet guard rail tests for allow upstream MC CREATE operations", func() {
+var _ = Describe("fleet guard rail tests for allow upstream MC CREATE, DELETE operations", func() {
 	mcName := fmt.Sprintf(mcNameTemplate, GinkgoParallelProcess())
 
 	It("should allow CREATE, DELETE operation on upstream member cluster CR for user not in system:masters group", func() {
@@ -413,7 +416,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 				return err
 			}
 			By(fmt.Sprintf("update upstream member cluster spec for MC %s", mc.Name))
-			mc.Spec.HeartbeatPeriodSeconds = 30
+			mc.Spec.HeartbeatPeriodSeconds = 32
 			By(fmt.Sprintf("expecting denial of operation UPDATE of upstream member cluster %s", mc.Name))
 			return impersonateHubClient.Update(ctx, &mc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -112,7 +112,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 			if k8sErrors.IsConflict(err) {
 				return err
 			}
-			return checkIfStatusErrorWithMessage(err, "no user is allowed to remove all fleet pre-fixed annotation from a fleet member cluster")
+			return checkIfStatusErrorWithMessage(err, "no user is allowed to remove all fleet pre-fixed annotations from a fleet member cluster")
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
@@ -129,7 +129,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 			if k8sErrors.IsConflict(err) {
 				return err
 			}
-			return checkIfStatusErrorWithMessage(err, "no user is allowed to remove all fleet pre-fixed annotation from a fleet member cluster")
+			return checkIfStatusErrorWithMessage(err, "no user is allowed to remove all fleet pre-fixed annotations from a fleet member cluster")
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -44,7 +44,7 @@ var (
 	testGroups = []string{"system:authenticated"}
 )
 
-var _ = Describe("fleet guard rail tests for deny MC CREATE operations", func() {
+var _ = Describe("fleet guard rail tests for deny fleet MC CREATE operations", func() {
 	mcName := fmt.Sprintf(mcNameTemplate, GinkgoParallelProcess())
 
 	It("should deny CREATE operation on member cluster CR for user not in system:masters group", func() {
@@ -81,7 +81,7 @@ var _ = Describe("fleet guard rail tests for allow/deny MC UPDATE, DELETE operat
 		ensureMemberClusterAndRelatedResourcesDeletion(mcName)
 	})
 
-	It("should deny UPDATE operation on member cluster CR for user not in MC identity", func() {
+	It("should deny UPDATE operation on member cluster CR for user not in systems:masters group", func() {
 		Eventually(func(g Gomega) error {
 			var mc clusterv1beta1.MemberCluster
 			g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)).Should(Succeed())

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -314,8 +314,6 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 			if err != nil {
 				return err
 			}
-			labels := make(map[string]string)
-			labels[testKey] = testValue
 			mc.SetLabels(map[string]string{testKey: testValue})
 			return impersonateHubClient.Update(ctx, &mc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -33,6 +33,9 @@ import (
 const (
 	testUser     = "test-user"
 	testIdentity = "test-identity"
+	testReason   = "test-reason"
+	testKey      = "test-key"
+	testValue    = "test-value"
 )
 
 var (
@@ -114,6 +117,9 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 		Eventually(func(g Gomega) error {
 			var mc clusterv1beta1.MemberCluster
 			err := hubClient.Get(ctx, types.NamespacedName{Name: mcName}, &mc)
+			if err != nil {
+				return err
+			}
 			By(fmt.Sprintf("update fleet member cluster spec for MC %s", mc.Name))
 			mc.Spec.HeartbeatPeriodSeconds = 30
 			By(fmt.Sprintf("expecting denial of operation UPDATE of fleet member cluster %s", mc.Name))
@@ -136,7 +142,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 			if len(mc.Status.Conditions) == 0 {
 				return errors.New("status conditions are empty")
 			}
-			mc.Status.Conditions[0].Reason = "update"
+			mc.Status.Conditions[0].Reason = testReason
 			err = impersonateHubClient.Status().Update(ctx, &mc)
 			if k8sErrors.IsConflict(err) {
 				return err
@@ -163,9 +169,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 			if err != nil {
 				return err
 			}
-			labels := make(map[string]string)
-			labels["test-key"] = "test-value"
-			mc.SetLabels(labels)
+			mc.SetLabels(map[string]string{testKey: testValue})
 			return impersonateHubClient.Update(ctx, &mc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
@@ -178,9 +182,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 			if err != nil {
 				return err
 			}
-			annotations := make(map[string]string)
-			annotations["test-key"] = "test-value"
-			mc.SetLabels(annotations)
+			mc.SetAnnotations(map[string]string{testKey: testValue})
 			return impersonateHubClient.Update(ctx, &mc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
@@ -227,7 +229,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 			if len(mc.Status.Conditions) == 0 {
 				return errors.New("status conditions are empty")
 			}
-			mc.Status.Conditions[0].Reason = "update"
+			mc.Status.Conditions[0].Reason = testReason
 			return hubClient.Status().Update(ctx, &mc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
@@ -295,7 +297,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 			if len(mc.Status.Conditions) == 0 {
 				return errors.New("status conditions are empty")
 			}
-			mc.Status.Conditions[0].Reason = "update"
+			mc.Status.Conditions[0].Reason = testReason
 			err = impersonateHubClient.Status().Update(ctx, &mc)
 			if k8sErrors.IsConflict(err) {
 				return err
@@ -313,8 +315,8 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 				return err
 			}
 			labels := make(map[string]string)
-			labels["test-key"] = "test-value"
-			mc.SetLabels(labels)
+			labels[testKey] = testValue
+			mc.SetLabels(map[string]string{testKey: testValue})
 			return impersonateHubClient.Update(ctx, &mc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
@@ -327,9 +329,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 			if err != nil {
 				return err
 			}
-			annotations := make(map[string]string)
-			annotations["test-key"] = "test-value"
-			mc.SetLabels(annotations)
+			mc.SetAnnotations(map[string]string{testKey: testValue})
 			return impersonateHubClient.Update(ctx, &mc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
@@ -390,7 +390,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 			if len(mc.Status.Conditions) == 0 {
 				return errors.New("status conditions are empty")
 			}
-			mc.Status.Conditions[0].Reason = "update"
+			mc.Status.Conditions[0].Reason = testReason
 			return hubClient.Status().Update(ctx, &mc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
@@ -517,7 +517,7 @@ var _ = Describe("fleet guard rail tests for IMC UPDATE operation, in fleet-memb
 			if err != nil {
 				return err
 			}
-			imc.Labels = map[string]string{"test-key": "test-value"}
+			imc.Labels = map[string]string{testKey: testValue}
 			By("expecting successful UPDATE of Internal Member Cluster Status")
 			return impersonateHubClient.Update(ctx, &imc)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
@@ -650,7 +650,7 @@ var _ = Describe("fleet guard rail for UPDATE work operations, in fleet prefixed
 			if err != nil {
 				return err
 			}
-			w.SetLabels(map[string]string{"test-key": "test-value"})
+			w.SetLabels(map[string]string{testKey: testValue})
 			By("expecting successful UPDATE of work")
 			return impersonateHubClient.Update(ctx, &w)
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
@@ -720,7 +720,7 @@ var _ = Describe("fleet guard rail networking E2Es", Serial, Ordered, func() {
 				if err != nil {
 					return err
 				}
-				ise.SetLabels(map[string]string{"test-key": "test-value"})
+				ise.SetLabels(map[string]string{testKey: testValue})
 				By("expecting denial of operation UPDATE of Internal Service Export")
 				err = impersonateHubClient.Update(ctx, &ise)
 				if k8sErrors.IsConflict(err) {
@@ -791,7 +791,7 @@ var _ = Describe("fleet guard rail networking E2Es", Serial, Ordered, func() {
 				if err != nil {
 					return err
 				}
-				ise.SetLabels(map[string]string{"test-key": "test-value"})
+				ise.SetLabels(map[string]string{testKey: testValue})
 				By("expecting denial of operation UPDATE of Internal Service Export")
 				return impersonateHubClient.Update(ctx, &ise)
 			}, eventuallyDuration, eventuallyInterval).Should(Succeed())

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -181,7 +181,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 		Expect(checkIfStatusErrorWithMessage(impersonateHubClient.Delete(ctx, &mc), fmt.Sprintf(validation.ResourceDeniedFormat, testUser, utils.GenerateGroupString(testGroups), admissionv1.Delete, &mcGVK, "", types.NamespacedName{Name: mc.Name}))).Should(Succeed())
 	})
 
-	It("should allow update operation on fleet member cluster CR labels for any user", func() {
+	It("should allow update operation on fleet member cluster CR labels for non system user", func() {
 		var mc clusterv1beta1.MemberCluster
 		By(fmt.Sprintf("update labels in fleet member cluster %s, expecting successful UPDATE of fleet member cluster", mcName))
 		Eventually(func(g Gomega) error {
@@ -194,7 +194,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should allow update operation on fleet member cluster CR annotations except fleet pre-fixed annotation for any user", func() {
+	It("should allow update operation on fleet member cluster CR annotations except fleet pre-fixed annotation for non system user", func() {
 		var mc clusterv1beta1.MemberCluster
 		By(fmt.Sprintf("update annotations in fleet member cluster %s, expecting successful UPDATE of fleet member cluster", mcName))
 		Eventually(func(g Gomega) error {
@@ -231,7 +231,7 @@ var _ = Describe("fleet guard rail tests for allow/deny fleet MC UPDATE, DELETE 
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should allow update operation on fleet member cluster CR taints for any user", func() {
+	It("should allow update operation on fleet member cluster CR taints for non system user", func() {
 		var mc clusterv1beta1.MemberCluster
 		By(fmt.Sprintf("update taints in fleet member cluster %s, expecting successful UPDATE of fleet member cluster", mcName))
 		Eventually(func(g Gomega) error {
@@ -368,7 +368,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should allow update operation on upstream member cluster CR labels for any user", func() {
+	It("should allow update operation on upstream member cluster CR labels for non system user", func() {
 		var mc clusterv1beta1.MemberCluster
 		By(fmt.Sprintf("update labels in upstream member cluster %s, expecting successful UPDATE of upstream member cluster", mcName))
 		Eventually(func(g Gomega) error {
@@ -381,7 +381,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should allow update operation on upstream member cluster CR annotations for any user", func() {
+	It("should allow update operation on upstream member cluster CR annotations for non system user", func() {
 		var mc clusterv1beta1.MemberCluster
 		By(fmt.Sprintf("update annotations in upstream member cluster %s, expecting successful UPDATE of upstream member cluster", mcName))
 		Eventually(func(g Gomega) error {
@@ -394,7 +394,7 @@ var _ = Describe("fleet guard rail tests for allow/deny upstream MC UPDATE opera
 		}, eventuallyDuration, eventuallyInterval).Should(Succeed())
 	})
 
-	It("should allow update operation on upstream member cluster CR taints for any user", func() {
+	It("should allow update operation on upstream member cluster CR taints for non system user", func() {
 		var mc clusterv1beta1.MemberCluster
 		By(fmt.Sprintf("update taints in upstream member cluster %s, expecting successful UPDATE of upstream member cluster", mcName))
 		Eventually(func(g Gomega) error {

--- a/test/e2e/scheduler_watchers_test.go
+++ b/test/e2e/scheduler_watchers_test.go
@@ -90,7 +90,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 		})
 
 		It("can add a new member cluster", func() {
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
@@ -122,7 +122,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -315,7 +315,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 			// Mark the newly created member cluster as unhealthy.
 			markMemberClusterAsUnhealthy(fakeClusterName1ForWatcherTests)
 
@@ -384,7 +384,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			labels := map[string]string{
 				labelNameForWatcherTests: labelValueForWatcherTests,
 			}
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, labels)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, labels, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -473,7 +473,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			labels := map[string]string{
 				labelNameForWatcherTests: labelValueForWatcherTests,
 			}
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, labels)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, labels, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -538,7 +538,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -738,7 +738,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 		})
 
 		It("can add a new member cluster", func() {
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
@@ -769,7 +769,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 			// Mark the newly created member cluster as unhealthy.
 			markMemberClusterAsUnhealthy(fakeClusterName1ForWatcherTests)
 
@@ -833,7 +833,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -898,7 +898,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -995,7 +995,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 		})
 
 		It("can add a new member cluster", func() {
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
@@ -1028,7 +1028,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil)
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, nil, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -1117,7 +1117,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{labelNameForWatcherTests: labelValueForWatcherTests})
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{labelNameForWatcherTests: labelValueForWatcherTests}, nil)
 			// Mark the newly created member cluster as unhealthy.
 			markMemberClusterAsUnhealthy(fakeClusterName1ForWatcherTests)
 
@@ -1236,7 +1236,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 		})
 
 		It("can add a new member cluster in a region which would violate the topology spread constraint", func() {
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue1})
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue1}, nil)
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 		})
 
@@ -1247,7 +1247,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 		})
 
 		It("can add a new member cluster in a region which would re-balance the topology spread", func() {
-			createMemberCluster(fakeClusterName2ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue2})
+			createMemberCluster(fakeClusterName2ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue2}, nil)
 			markMemberClusterAsHealthy(fakeClusterName2ForWatcherTests)
 		})
 
@@ -1439,7 +1439,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 		})
 
 		It("can add a new member cluster in a region which would violate the topology spread constraint", func() {
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue1})
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue1}, nil)
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 		})
 
@@ -1463,7 +1463,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{labelNameForWatcherTests: labelValueForWatcherTests})
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{labelNameForWatcherTests: labelValueForWatcherTests}, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -1528,7 +1528,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{labelNameForWatcherTests: labelValueForWatcherTests})
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{labelNameForWatcherTests: labelValueForWatcherTests}, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -1615,7 +1615,7 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create a new member cluster.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{labelNameForWatcherTests: labelValueForWatcherTests})
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{labelNameForWatcherTests: labelValueForWatcherTests}, nil)
 			// Mark the newly created member cluster as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 
@@ -1694,8 +1694,8 @@ var _ = Describe("responding to specific member cluster changes", func() {
 			createWorkResources()
 
 			// Create new member clusters.
-			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue1})
-			createMemberCluster(fakeClusterName2ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue2})
+			createMemberCluster(fakeClusterName1ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue1}, nil)
+			createMemberCluster(fakeClusterName2ForWatcherTests, hubClusterSAName, map[string]string{regionLabelName: regionLabelValue2}, nil)
 			// Mark the newly created member clusters as healthy.
 			markMemberClusterAsHealthy(fakeClusterName1ForWatcherTests)
 			markMemberClusterAsHealthy(fakeClusterName2ForWatcherTests)

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -100,6 +100,9 @@ var (
 	envLabelName      = "env"
 	envLabelValue1    = "prod"
 	envLabelValue2    = "canary"
+	clusterID1        = "test-cluster-id-1"
+	clusterID2        = "test-cluster-id-2"
+	clusterID3        = "test-cluster-id-3"
 
 	labelsByClusterName = map[string]map[string]string{
 		memberCluster1EastProdName: {
@@ -113,6 +116,17 @@ var (
 		memberCluster3WestProdName: {
 			regionLabelName: regionLabelValue2,
 			envLabelName:    envLabelValue1,
+		},
+	}
+	annotationsByClusterName = map[string]map[string]string{
+		memberCluster1EastProdName: {
+			utils.FleetClusterResourceIsAnnotationKey: clusterID1,
+		},
+		memberCluster2EastCanaryName: {
+			utils.FleetClusterResourceIsAnnotationKey: clusterID2,
+		},
+		memberCluster3WestProdName: {
+			utils.FleetClusterResourceIsAnnotationKey: clusterID3,
 		},
 	}
 

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -60,9 +60,10 @@ const (
 	hubClusterSAName = "fleet-hub-agent"
 	fleetSystemNS    = "fleet-system"
 
-	kubeConfigPathEnvVarName         = "KUBECONFIG"
-	propertyProviderEnvVarName       = "PROPERTY_PROVIDER"
-	azurePropertyProviderEnvVarValue = "azure"
+	kubeConfigPathEnvVarName            = "KUBECONFIG"
+	propertyProviderEnvVarName          = "PROPERTY_PROVIDER"
+	azurePropertyProviderEnvVarValue    = "azure"
+	fleetClusterResourceIsAnnotationKey = "fleet.azure.com/cluster-resource-id"
 )
 
 const (
@@ -120,13 +121,13 @@ var (
 	}
 	annotationsByClusterName = map[string]map[string]string{
 		memberCluster1EastProdName: {
-			utils.FleetClusterResourceIsAnnotationKey: clusterID1,
+			fleetClusterResourceIsAnnotationKey: clusterID1,
 		},
 		memberCluster2EastCanaryName: {
-			utils.FleetClusterResourceIsAnnotationKey: clusterID2,
+			fleetClusterResourceIsAnnotationKey: clusterID2,
 		},
 		memberCluster3WestProdName: {
-			utils.FleetClusterResourceIsAnnotationKey: clusterID3,
+			fleetClusterResourceIsAnnotationKey: clusterID3,
 		},
 	}
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -52,11 +52,12 @@ var (
 )
 
 // createMemberCluster creates a MemberCluster object.
-func createMemberCluster(name, svcAccountName string, labels map[string]string) {
+func createMemberCluster(name, svcAccountName string, labels, annotations map[string]string) {
 	mcObj := &clusterv1beta1.MemberCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
+			Name:        name,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Spec: clusterv1beta1.MemberClusterSpec{
 			Identity: rbacv1.Subject{
@@ -169,7 +170,7 @@ func markMemberClusterAsLeft(name string) {
 func setAllMemberClustersToJoin() {
 	for idx := range allMemberClusters {
 		memberCluster := allMemberClusters[idx]
-		createMemberCluster(memberCluster.ClusterName, memberCluster.PresentingServiceAccountInHubClusterName, labelsByClusterName[memberCluster.ClusterName])
+		createMemberCluster(memberCluster.ClusterName, memberCluster.PresentingServiceAccountInHubClusterName, labelsByClusterName[memberCluster.ClusterName], annotationsByClusterName[memberCluster.ClusterName])
 	}
 }
 
@@ -397,7 +398,7 @@ func summarizeAKSClusterProperties(memberCluster *framework.Cluster, mcObj *clus
 // have left the fleet.
 func setupInvalidClusters() {
 	// Create a member cluster object that represents the unhealthy cluster.
-	createMemberCluster(memberCluster4UnhealthyName, hubClusterSAName, nil)
+	createMemberCluster(memberCluster4UnhealthyName, hubClusterSAName, nil, nil)
 
 	// Mark the member cluster as unhealthy.
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -1167,8 +1167,8 @@ func constructWrappedResources(testEnvelopeObj *corev1.ConfigMap, workloadObj me
 	}
 }
 
-// checkIfStatusError checks if the error is a status error and if error contains the error message.
-func checkIfStatusError(err error, errorMsg string) error {
+// checkIfStatusErrorWithMessage checks if the error is a status error and if error contains the error message.
+func checkIfStatusErrorWithMessage(err error, errorMsg string) error {
 	var statusErr *k8serrors.StatusError
 	if errors.As(err, &statusErr) {
 		if strings.Contains(statusErr.ErrStatus.Message, errorMsg) {

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -392,7 +392,7 @@ var _ = Describe("webhook tests for MC taints", Ordered, func() {
 	mcName := fmt.Sprintf(mcNameTemplate, GinkgoParallelProcess())
 
 	BeforeAll(func() {
-		createMemberCluster(mcName, testUser, nil)
+		createMemberCluster(mcName, testUser, nil, nil)
 	})
 
 	AfterAll(func() {


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

UTs and upstream E2E tests

### Special notes for your reviewer

Handle fleet/upstream MC resources differently,

For fleet MC:

- Deny normal users from modifying the fleet cluster resource ID annotation (update, delete)
- Allow special authenticated users to update all fleet pre-fixed annotations values and delete some fleet pre-fixed annotations (update)
- Deny special authenticated users to delete all fleet pre-fixed annotations (we have a hard requirement that at least one annotation should have pre-fix fleet.azure.com)
- Only special authenticated users can update ownerReferences, finalizers, spec, status (taints are ignored)
- All other changes to objectMeta are allowed for all users

For upstream MC:

Allow all users to CREATE/DELETE upstream MC resource without cluster resource id annotation

- Deny normal users from adding the fleet pre-fixed annotation on update
- Deny special authenticated users to add the fleet pre-fixed annotation on update
- All other changes to objectMeta are allowed for all users
- Any user can update spec
- Only special authenticated users can update status

Glossary special authenticated users - users in,

- system:master group user
- whitelistested user (can be provided when installing hub agent on cluster)
- authenticated service account
- kube-scheduler
- kube-controller-manager
- node group user


