### PR TITLE
fix: fix the order between namespace and crd resources in the resource snapshots

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,6 @@ github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/crossplane/crossplane-runtime v0.20.1 h1:xEYNL65wq3IA4NloSknH/n7F/GVKQd3QDpNWB4dFRks=
-github.com/crossplane/crossplane-runtime v0.20.1/go.mod h1:FuKIC8Mg8hE2gIAMyf2wCPkxkFPz+VnMQiYWBq1/p5A=
 github.com/crossplane/crossplane-runtime v1.16.0 h1:lz+l0wEB3qowdTmN7t0PZkfuNSvfOoEhQrEYFbYqMow=
 github.com/crossplane/crossplane-runtime v1.16.0/go.mod h1:Pz2tdGVMF6KDGzHZOkvKro0nKc8EzK0sb/nSA7pH4Dc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/controllers/clusterresourceplacement/controller.go
+++ b/pkg/controllers/clusterresourceplacement/controller.go
@@ -182,10 +182,9 @@ func (r *Reconciler) handleUpdate(ctx context.Context, crp *fleetv1beta1.Cluster
 		klog.ErrorS(err, "Failed to select resources for placement", "clusterResourcePlacement", crpKObj)
 		return ctrl.Result{}, err
 	}
-	resourceSnapshotSpec := fleetv1beta1.ResourceSnapshotSpec{
-		SelectedResources: selectedResources,
-	}
-	latestResourceSnapshot, err := r.getOrCreateClusterResourceSnapshot(ctx, crp, envelopeObjCount, &resourceSnapshotSpec, int(revisionLimit))
+
+	latestResourceSnapshot, err := r.getOrCreateClusterResourceSnapshot(ctx, crp, envelopeObjCount,
+		&fleetv1beta1.ResourceSnapshotSpec{SelectedResources: selectedResources}, int(revisionLimit))
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controllers/clusterresourceplacement/resource_selector.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector.go
@@ -122,7 +122,7 @@ func sortResources(resources []runtime.Object) {
 		if gvkComp == 0 {
 			// same gvk, compare namespace/name
 			return strings.Compare(fmt.Sprintf("%s/%s", obj1.GetNamespace(), obj1.GetName()),
-				fmt.Sprintf("%s/%s", obj2.GetNamespace(), obj2.GetName())) < 0
+				fmt.Sprintf("%s/%s", obj2.GetNamespace(), obj2.GetName())) > 0
 		}
 		return gvkComp > 0
 	})

--- a/pkg/controllers/clusterresourceplacement/resource_selector_test.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector_test.go
@@ -868,20 +868,20 @@ func TestSortResource(t *testing.T) {
 		want      []runtime.Object
 	}{
 		"should gather selected resources with Namespace in front with order": {
-			resources: []runtime.Object{deployment, namespace2, namespace1},
-			want:      []runtime.Object{namespace1, namespace2, deployment},
+			resources: []runtime.Object{deployment, namespace1, namespace2},
+			want:      []runtime.Object{namespace2, namespace1, deployment},
 		},
 		"should gather selected resources with CRD in front with order": {
-			resources: []runtime.Object{clusterRole, crd2, crd1},
-			want:      []runtime.Object{crd1, crd2, clusterRole},
+			resources: []runtime.Object{clusterRole, crd1, crd2},
+			want:      []runtime.Object{crd2, crd1, clusterRole},
 		},
 		"should gather selected resources with CRD or Namespace in front  with order": {
-			resources: []runtime.Object{deployment, crd2, namespace2, clusterRole, crd1, namespace1},
-			want:      []runtime.Object{namespace1, namespace2, crd1, crd2, clusterRole, deployment},
+			resources: []runtime.Object{deployment, namespace1, namespace2, clusterRole, crd1, crd2},
+			want:      []runtime.Object{namespace2, namespace1, crd2, crd1, clusterRole, deployment},
 		},
 		"should gather selected resources with CRD or Namespace in front  with order, second case": {
-			resources: []runtime.Object{crd2, crd1, deployment, namespace2, clusterRole},
-			want:      []runtime.Object{namespace2, crd1, crd2, clusterRole, deployment},
+			resources: []runtime.Object{crd1, crd2, deployment, namespace2, clusterRole},
+			want:      []runtime.Object{namespace2, crd2, crd1, clusterRole, deployment},
 		},
 	}
 

--- a/pkg/controllers/clusterresourceplacement/resource_selector_test.go
+++ b/pkg/controllers/clusterresourceplacement/resource_selector_test.go
@@ -796,13 +796,24 @@ func createResourceContentForTest(t *testing.T, obj interface{}) *fleetv1beta1.R
 }
 
 func TestSortResource(t *testing.T) {
-	// Create the Namespace object
-	namespace := &unstructured.Unstructured{
+	// Create the first Namespace object
+	namespace1 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
 			"kind":       "Namespace",
 			"metadata": map[string]interface{}{
-				"name": "test",
+				"name": "test1",
+			},
+		},
+	}
+
+	// Create the second Namespace object
+	namespace2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "test2",
 			},
 		},
 	}
@@ -819,13 +830,24 @@ func TestSortResource(t *testing.T) {
 		},
 	}
 
-	// Create the CustomResourceDefinition object
-	crd := &unstructured.Unstructured{
+	// Create the first CustomResourceDefinition object
+	crd1 := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "apiextensions.k8s.io/v1",
 			"kind":       "CustomResourceDefinition",
 			"metadata": map[string]interface{}{
-				"name": "test-crd",
+				"name": "test-crd1",
+			},
+		},
+	}
+
+	// Create the second CustomResourceDefinition object
+	crd2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]interface{}{
+				"name": "test-crd2",
 			},
 		},
 	}
@@ -845,17 +867,21 @@ func TestSortResource(t *testing.T) {
 		resources []runtime.Object
 		want      []runtime.Object
 	}{
-		"should gather selected resources with Namespace in front": {
-			resources: []runtime.Object{deployment, namespace},
-			want:      []runtime.Object{namespace, deployment},
+		"should gather selected resources with Namespace in front with order": {
+			resources: []runtime.Object{deployment, namespace2, namespace1},
+			want:      []runtime.Object{namespace1, namespace2, deployment},
 		},
-		"should gather selected resources with CRD in front": {
-			resources: []runtime.Object{clusterRole, crd},
-			want:      []runtime.Object{crd, clusterRole},
+		"should gather selected resources with CRD in front with order": {
+			resources: []runtime.Object{clusterRole, crd2, crd1},
+			want:      []runtime.Object{crd1, crd2, clusterRole},
 		},
-		"should gather selected resources with CRD or Namespace in front": {
-			resources: []runtime.Object{deployment, clusterRole, crd, namespace},
-			want:      []runtime.Object{namespace, crd, clusterRole, deployment},
+		"should gather selected resources with CRD or Namespace in front  with order": {
+			resources: []runtime.Object{deployment, crd2, namespace2, clusterRole, crd1, namespace1},
+			want:      []runtime.Object{namespace1, namespace2, crd1, crd2, clusterRole, deployment},
+		},
+		"should gather selected resources with CRD or Namespace in front  with order, second case": {
+			resources: []runtime.Object{crd2, crd1, deployment, namespace2, clusterRole},
+			want:      []runtime.Object{namespace2, crd1, crd2, clusterRole, deployment},
 		},
 	}
 


### PR DESCRIPTION
### Description of your changes

fix the order between namespace and crd resources in the resource snapshots so that the snapshot doesn't change when there is no resource changes

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
