### PR TITLE
fix: update updateBindingStatusWithRetry and corresponding UT

### DIFF
--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -224,44 +224,44 @@ func (r *Reconciler) Reconcile(ctx context.Context, req controllerruntime.Reques
 // updateBindingStatusWithRetry sends the update request to API server with retry.
 func (r *Reconciler) updateBindingStatusWithRetry(ctx context.Context, resourceBinding *fleetv1beta1.ClusterResourceBinding) error {
 	// Retry only for specific errors or conditions
-	//err := r.Client.Status().Update(ctx, resourceBinding)
-	//if err != nil {
-	//	klog.ErrorS(err, "Failed to update the resourceBinding status, will retry", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
-	errAfterRetries := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		var latestBinding fleetv1beta1.ClusterResourceBinding
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(resourceBinding), &latestBinding); err != nil {
-			return err
-		}
-		// Work generator is the only controller that updates conditions excluding rollout started which is updated by rollout controller.
-		if rolloutCond := latestBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted)); rolloutCond != nil {
-			found := false
-			for i := range resourceBinding.Status.Conditions {
-				if resourceBinding.Status.Conditions[i].Type == rolloutCond.Type {
-					// Replace the existing condition
-					resourceBinding.Status.Conditions[i] = *rolloutCond
-					found = true
-					break
+	err := r.Client.Status().Update(ctx, resourceBinding)
+	if err != nil {
+		klog.ErrorS(err, "Failed to update the resourceBinding status, will retry", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
+		errAfterRetries := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			var latestBinding fleetv1beta1.ClusterResourceBinding
+			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(resourceBinding), &latestBinding); err != nil {
+				return err
+			}
+			// Work generator is the only controller that updates conditions excluding rollout started which is updated by rollout controller.
+			if rolloutCond := latestBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted)); rolloutCond != nil {
+				found := false
+				for i := range resourceBinding.Status.Conditions {
+					if resourceBinding.Status.Conditions[i].Type == rolloutCond.Type {
+						// Replace the existing condition
+						resourceBinding.Status.Conditions[i] = *rolloutCond
+						found = true
+						break
+					}
+				}
+				if !found {
+					return controller.NewUnexpectedBehaviorError(fmt.Errorf("found a resourceBinding %v without RolloutStarted condition", klog.KObj(resourceBinding)))
 				}
 			}
-			if !found {
-				return controller.NewUnexpectedBehaviorError(fmt.Errorf("found a resourceBinding %v without RolloutStarted condition", klog.KObj(resourceBinding)))
-			}
-		}
 
-		if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
-			klog.ErrorS(err, "Failed to update the resourceBinding status", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
-			return err
+			if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
+				klog.ErrorS(err, "Failed to update the resourceBinding status", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
+				return err
+			}
+			klog.V(2).InfoS("Successfully updated the resourceBinding status", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
+			return nil
+		})
+		if errAfterRetries != nil {
+			klog.ErrorS(errAfterRetries, "Failed to update resourceBinding status after retries", "resourceBinding", klog.KObj(resourceBinding))
+			return errAfterRetries
 		}
-		klog.V(2).InfoS("Successfully updated the resourceBinding status", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
 		return nil
-	})
-	if errAfterRetries != nil {
-		klog.ErrorS(errAfterRetries, "Failed to update resourceBinding status after retries", "resourceBinding", klog.KObj(resourceBinding))
-		return errAfterRetries
 	}
-	return nil
-	//}
-	//return err
+	return err
 }
 
 // handleDelete handle a deleting binding

--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -224,43 +224,44 @@ func (r *Reconciler) Reconcile(ctx context.Context, req controllerruntime.Reques
 // updateBindingStatusWithRetry sends the update request to API server with retry.
 func (r *Reconciler) updateBindingStatusWithRetry(ctx context.Context, resourceBinding *fleetv1beta1.ClusterResourceBinding) error {
 	// Retry only for specific errors or conditions
-	err := r.Client.Status().Update(ctx, resourceBinding)
-	if err != nil {
-		klog.ErrorS(err, "Failed to update the resourceBinding status, will retry", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
-		errAfterRetries := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			var latestBinding fleetv1beta1.ClusterResourceBinding
-			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(resourceBinding), &latestBinding); err != nil {
-				return err
-			}
-			// Work generator is the only controller that updates conditions excluding rollout started which is updated by rollout controller.
-			if rolloutCond := latestBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted)); rolloutCond != nil {
-				found := false
-				for i := range resourceBinding.Status.Conditions {
-					if resourceBinding.Status.Conditions[i].Type == rolloutCond.Type {
-						// Replace the existing condition
-						resourceBinding.Status.Conditions[i] = *rolloutCond
-						found = true
-						break
-					}
-				}
-				if !found {
-					return controller.NewUnexpectedBehaviorError(fmt.Errorf("found a resourceBinding %v without RolloutStarted condition", klog.KObj(resourceBinding)))
-				}
-			}
-
-			if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
-				klog.ErrorS(err, "Failed to update the resourceBinding status", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
-				return err
-			}
-			klog.V(2).InfoS("Successfully updated the resourceBinding status", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
-			return nil
-		})
-		if errAfterRetries != nil {
-			klog.ErrorS(errAfterRetries, "Failed to update resourceBinding status after retries", "resourceBinding", klog.KObj(resourceBinding))
-			return errAfterRetries
+	//err := r.Client.Status().Update(ctx, resourceBinding)
+	//if err != nil {
+	//	klog.ErrorS(err, "Failed to update the resourceBinding status, will retry", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
+	errAfterRetries := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var latestBinding fleetv1beta1.ClusterResourceBinding
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(resourceBinding), &latestBinding); err != nil {
+			return err
 		}
+		// Work generator is the only controller that updates conditions excluding rollout started which is updated by rollout controller.
+		if rolloutCond := latestBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted)); rolloutCond != nil {
+			found := false
+			for i := range resourceBinding.Status.Conditions {
+				if resourceBinding.Status.Conditions[i].Type == rolloutCond.Type {
+					// Replace the existing condition
+					resourceBinding.Status.Conditions[i] = *rolloutCond
+					found = true
+					break
+				}
+			}
+			if !found {
+				return controller.NewUnexpectedBehaviorError(fmt.Errorf("found a resourceBinding %v without RolloutStarted condition", klog.KObj(resourceBinding)))
+			}
+		}
+
+		if err := r.Client.Status().Update(ctx, resourceBinding); err != nil {
+			klog.ErrorS(err, "Failed to update the resourceBinding status", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
+			return err
+		}
+		klog.V(2).InfoS("Successfully updated the resourceBinding status", "resourceBinding", klog.KObj(resourceBinding), "resourceBindingStatus", resourceBinding.Status)
+		return nil
+	})
+	if errAfterRetries != nil {
+		klog.ErrorS(errAfterRetries, "Failed to update resourceBinding status after retries", "resourceBinding", klog.KObj(resourceBinding))
+		return errAfterRetries
 	}
 	return nil
+	//}
+	//return err
 }
 
 // handleDelete handle a deleting binding

--- a/pkg/controllers/workgenerator/controller.go
+++ b/pkg/controllers/workgenerator/controller.go
@@ -232,7 +232,6 @@ func (r *Reconciler) updateBindingStatusWithRetry(ctx context.Context, resourceB
 			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(resourceBinding), &latestBinding); err != nil {
 				return err
 			}
-
 			// Work generator is the only controller that updates conditions excluding rollout started which is updated by rollout controller.
 			if rolloutCond := latestBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted)); rolloutCond != nil {
 				found := false

--- a/pkg/controllers/workgenerator/controller_test.go
+++ b/pkg/controllers/workgenerator/controller_test.go
@@ -1496,7 +1496,7 @@ func TestExtractFailedResourcePlacementsFromWork(t *testing.T) {
 	}
 }
 
-func TestUpdateBindingStatusWithRetry(t *testing.T) {
+func TestPatchBindingStatusWithRetry(t *testing.T) {
 	bindingName := "test-binding"
 	lastTransitionTime := metav1.NewTime(time.Now())
 	tests := []struct {
@@ -1507,11 +1507,11 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 		expectError     bool
 	}{
 		{
-			name: "updates status successfully",
+			name: "patch status successfully with no conflict",
 			latestBinding: &fleetv1beta1.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       bindingName,
-					Generation: 1,
+					Generation: 4,
 				},
 				Spec: fleetv1beta1.ResourceBindingSpec{
 					State:                fleetv1beta1.BindingStateBound,
@@ -1523,7 +1523,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 						{
 							Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 4,
 							Reason:             condition.RolloutStartedReason,
 							LastTransitionTime: lastTransitionTime,
 						},
@@ -1533,7 +1533,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 			resourceBinding: &fleetv1beta1.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       bindingName,
-					Generation: 1,
+					Generation: 4,
 				},
 				Spec: fleetv1beta1.ResourceBindingSpec{
 					State:                fleetv1beta1.BindingStateBound,
@@ -1545,25 +1545,25 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 						{
 							Type:               string(fleetv1beta1.ResourceBindingOverridden),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 4,
 							Reason:             condition.OverriddenSucceededReason,
 						},
 						{
 							Type:               string(fleetv1beta1.ResourceBindingWorkSynchronized),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 4,
 							Reason:             condition.AllWorkSyncedReason,
 						},
 						{
 							Type:               string(fleetv1beta1.ResourceBindingApplied),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 4,
 							Reason:             condition.AllWorkAppliedReason,
 						},
 						{
 							Type:               string(fleetv1beta1.ResourceBindingAvailable),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 4,
 							Reason:             condition.AllWorkAvailableReason,
 						},
 					},
@@ -1573,11 +1573,11 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name: "updates status after conflict",
+			name: "patch status after conflict",
 			latestBinding: &fleetv1beta1.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       bindingName,
-					Generation: 1,
+					Generation: 3,
 				},
 				Spec: fleetv1beta1.ResourceBindingSpec{
 					State:                fleetv1beta1.BindingStateBound,
@@ -1589,7 +1589,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 						{
 							Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 3,
 							Reason:             condition.RolloutStartedReason,
 							LastTransitionTime: lastTransitionTime,
 						},
@@ -1599,7 +1599,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 			resourceBinding: &fleetv1beta1.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       bindingName,
-					Generation: 1,
+					Generation: 3,
 				},
 				Spec: fleetv1beta1.ResourceBindingSpec{
 					State:                fleetv1beta1.BindingStateBound,
@@ -1611,25 +1611,25 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 						{
 							Type:               string(fleetv1beta1.ResourceBindingOverridden),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 3,
 							Reason:             condition.OverriddenSucceededReason,
 						},
 						{
 							Type:               string(fleetv1beta1.ResourceBindingWorkSynchronized),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 3,
 							Reason:             condition.AllWorkSyncedReason,
 						},
 						{
 							Type:               string(fleetv1beta1.ResourceBindingApplied),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 3,
 							Reason:             condition.AllWorkAppliedReason,
 						},
 						{
 							Type:               string(fleetv1beta1.ResourceBindingAvailable),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 3,
 							Reason:             condition.AllWorkAvailableReason,
 						},
 					},
@@ -1639,11 +1639,11 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			name: "does not update status",
+			name: "does not patch status because of conflict",
 			latestBinding: &fleetv1beta1.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       bindingName,
-					Generation: 1,
+					Generation: 2,
 				},
 				Spec: fleetv1beta1.ResourceBindingSpec{
 					State:                fleetv1beta1.BindingStateBound,
@@ -1655,7 +1655,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 						{
 							Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 2,
 							Reason:             condition.RolloutStartedReason,
 							LastTransitionTime: lastTransitionTime,
 						},
@@ -1665,7 +1665,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 			resourceBinding: &fleetv1beta1.ClusterResourceBinding{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       bindingName,
-					Generation: 1,
+					Generation: 2,
 				},
 				Spec: fleetv1beta1.ResourceBindingSpec{
 					State:                fleetv1beta1.BindingStateBound,
@@ -1677,26 +1677,20 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 						{
 							Type:               string(fleetv1beta1.ResourceBindingOverridden),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 2,
 							Reason:             condition.OverriddenSucceededReason,
 						},
 						{
 							Type:               string(fleetv1beta1.ResourceBindingWorkSynchronized),
 							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
+							ObservedGeneration: 2,
 							Reason:             condition.AllWorkSyncedReason,
 						},
 						{
 							Type:               string(fleetv1beta1.ResourceBindingApplied),
-							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
-							Reason:             condition.AllWorkAppliedReason,
-						},
-						{
-							Type:               string(fleetv1beta1.ResourceBindingAvailable),
-							Status:             metav1.ConditionTrue,
-							ObservedGeneration: 1,
-							Reason:             condition.AllWorkAvailableReason,
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 2,
+							Reason:             condition.WorkNeedSyncedReason,
 						},
 					},
 				},
@@ -1727,7 +1721,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 				recorder:        record.NewFakeRecorder(10),
 				InformerManager: &informer.FakeManager{},
 			}
-			err := r.updateBindingStatusWithRetry(ctx, tt.resourceBinding)
+			err := r.patchBindingStatusWithRetry(ctx, tt.resourceBinding)
 			if (err != nil) != tt.expectError {
 				t.Errorf("updateBindingStatusWithRetry() error = %v, wantErr %v", err, tt.expectError)
 			}
@@ -1736,16 +1730,29 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(tt.resourceBinding), binding); err != nil {
 				t.Errorf("updateBindingStatusWithRetry() error = %v, wantErr %v", err, nil)
 			}
-
-			if tt.conflictCount > 0 {
-				latestRollout := tt.latestBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted))
-				rollout := tt.resourceBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted))
-				if diff := cmp.Diff(latestRollout, rollout, ignoreOption); diff != "" {
-					t.Errorf("updateBindingStatusWithRetry() ResourceBindingRolloutStarted Condition got = %v, want %v", rollout, latestRollout)
+			latestRollout := tt.latestBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted))
+			rollout := binding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted))
+			if diff := cmp.Diff(latestRollout, rollout, ignoreOption); diff != "" {
+				t.Errorf("updateBindingStatusWithRetry() ResourceBindingRolloutStarted Condition got = %v, want %v", rollout, latestRollout)
+			} else {
+				// A tolerance is used when comparing timestamps to account for precision differences
+				if !CompareTimeWithTolerance(rollout.LastTransitionTime, latestRollout.LastTransitionTime, 1*time.Second) {
+					t.Errorf("updateBindingStatusWithRetry() ResourceBindingRolloutStarted LastTransitionTime got = %v, want %v", rollout.LastTransitionTime, latestRollout.LastTransitionTime)
 				}
 			}
 		})
 	}
+}
+
+func CompareTimeWithTolerance(t1, t2 metav1.Time, tolerance time.Duration) bool {
+	t1Time := t1.Time
+	t2Time := t2.Time
+	// Ensure the timestamps are rounded to seconds for comparison
+	t1Rounded := t1Time.Round(time.Second)
+	t2Rounded := t2Time.Round(time.Second)
+
+	// Compare the timestamps with a tolerance
+	return t2Rounded.Sub(t1Rounded) <= tolerance
 }
 
 type conflictClient struct {
@@ -1765,10 +1772,11 @@ type conflictStatusWriter struct {
 	conflictClient *conflictClient
 }
 
-func (s *conflictStatusWriter) Update(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
+func (s *conflictStatusWriter) Patch(_ context.Context, obj client.Object, patch client.Patch, opt ...client.SubResourcePatchOption) error {
 	if s.conflictClient.conflictCount > 0 {
 		s.conflictClient.conflictCount--
-		return k8serrors.NewConflict(schema.GroupResource{Resource: "ClusterResourceBinding"}, "test-binding", errors.New("conflict"))
+		// Simulate conflict error
+		return k8serrors.NewConflict(schema.GroupResource{Resource: "ClusterResourceBinding"}, obj.GetName(), errors.New("the object has been modified; please apply your changes to the latest version and try again"))
 	}
-	return nil
+	return s.StatusWriter.Patch(context.Background(), obj, patch, opt...)
 }

--- a/pkg/controllers/workgenerator/controller_test.go
+++ b/pkg/controllers/workgenerator/controller_test.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1654,7 +1653,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 					},
 				},
 			},
-			conflictCount: 1,
+			conflictCount: 2,
 			expectError:   false,
 		},
 		{
@@ -1781,7 +1780,7 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 					},
 				},
 			},
-			conflictCount: 0,
+			conflictCount: 1,
 			expectError:   true,
 		},
 	}
@@ -1815,7 +1814,6 @@ func TestUpdateBindingStatusWithRetry(t *testing.T) {
 				latestRollout := tt.latestBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted))
 				rollout := tt.resourceBinding.GetCondition(string(fleetv1beta1.ResourceBindingRolloutStarted))
 				// Check that the rolloutStarted condition is updated with the same values from tt.latestBinding
-				klog.Info("conditions: ", tt.resourceBinding.Status.Conditions)
 				if diff := cmp.Diff(latestRollout, rollout, statusCmpOptions...); diff != "" {
 					t.Errorf("updateBindingStatusWithRetry() ResourceBindingRolloutStarted Condition got = %v, want %v", rollout, latestRollout)
 				}


### PR DESCRIPTION
### Description of your changes

I have:
- Add unexpected error for when rolloutStarted condition is not found.
- Fixed corresponding UT: Compares RolloutStarted Condition is the same as tt.latestBinding after conflict. 

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
