### PR TITLE
fix: bump go build version to 1.22.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore: [docs/**, "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: '1.22.4'
+  GO_VERSION: '1.22.7'
 
 jobs:
   detect-noop:

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.22.4'
+  GO_VERSION: '1.22.7'
 
 jobs:
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,7 +17,7 @@ env:
   MEMBER_AGENT_IMAGE_NAME: member-agent
   REFRESH_TOKEN_IMAGE_NAME: refresh-token
 
-  GO_VERSION: '1.22.4'
+  GO_VERSION: '1.22.7'
 
 jobs:
   export-registry:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   deadline: 10m
-  go: '1.22.4'
+  go: '1.22.7'
 
 linters:
   disable-all: true

--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the hubagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22.4 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22.7 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/member-agent.Dockerfile
+++ b/docker/member-agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the memberagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22.4 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22.7 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -1,5 +1,5 @@
 # Build the hubagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22.4 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22.7 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
### Description of your changes
Fix the CVE

hubagent (gobinary)
===================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬───────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                           Title                           │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼───────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-34156 │ HIGH     │ fixed  │ 1.22.4            │ 1.22.7, 1.23.1 │ encoding/gob: golang: Calling Decoder.Decode on a message │
│         │                │          │        │                   │                │ which contains deeply nested structures...                │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2024-34156                │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴───────────────────────────────────────────────────────────┘
https://github.com/Azure/fleet/actions/runs/10964922001/job/30449604649

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
