### PR TITLE
feat: add, remove finalizer for CRB in Scheduler and scheduler watcher for CRB

### DIFF
--- a/apis/placement/v1beta1/binding_types.go
+++ b/apis/placement/v1beta1/binding_types.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	// SchedulerCRBReconcileFinalizer is a finalizer added to ClusterResourceBindings to ensure we can look up the
-	// corresponding CRP for deleting ClusterResourceBindings to start another scheduling cycle.
-	SchedulerCRBReconcileFinalizer = fleetPrefix + "scheduler-reconcile"
+	// SchedulerCRBCleanupFinalizer is a finalizer added to ClusterResourceBindings to ensure we can look up the
+	// corresponding CRP for deleting ClusterResourceBindings in a scheduling cycle.
+	SchedulerCRBCleanupFinalizer = fleetPrefix + "scheduler-crb-cleanup"
 )
 
 // +kubebuilder:object:root=true

--- a/apis/placement/v1beta1/binding_types.go
+++ b/apis/placement/v1beta1/binding_types.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// SchedulerCRBCleanupFinalizer is a finalizer added to ClusterResourceBindings to ensure we can look up the
-	// corresponding CRP for deleting ClusterResourceBindings in a scheduling cycle.
+	// corresponding CRP name for deleting ClusterResourceBindings to trigger a new scheduling cycle.
 	SchedulerCRBCleanupFinalizer = fleetPrefix + "scheduler-crb-cleanup"
 )
 

--- a/apis/placement/v1beta1/binding_types.go
+++ b/apis/placement/v1beta1/binding_types.go
@@ -10,6 +10,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// SchedulerCRBReconcileFinalizer is a finalizer added to ClusterResourceBindings to ensure we can look up the
+	// corresponding CRP for deleting ClusterResourceBindings to start another scheduling cycle.
+	SchedulerCRBReconcileFinalizer = fleetPrefix + "scheduler-reconcile"
+)
+
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,categories={fleet,fleet-placement},shortName=rb
 // +kubebuilder:subresource:status

--- a/cmd/hubagent/workload/setup.go
+++ b/cmd/hubagent/workload/setup.go
@@ -39,6 +39,7 @@ import (
 	"go.goms.io/fleet/pkg/scheduler/framework"
 	"go.goms.io/fleet/pkg/scheduler/profile"
 	"go.goms.io/fleet/pkg/scheduler/queue"
+	schedulercrbwatcher "go.goms.io/fleet/pkg/scheduler/watchers/clusterresourcebinding"
 	schedulercrpwatcher "go.goms.io/fleet/pkg/scheduler/watchers/clusterresourceplacement"
 	schedulercspswatcher "go.goms.io/fleet/pkg/scheduler/watchers/clusterschedulingpolicysnapshot"
 	"go.goms.io/fleet/pkg/scheduler/watchers/membercluster"
@@ -275,6 +276,15 @@ func SetupControllers(ctx context.Context, wg *sync.WaitGroup, mgr ctrl.Manager,
 			SchedulerWorkQueue: defaultSchedulingQueue,
 		}).SetupWithManager(mgr); err != nil {
 			klog.ErrorS(err, "Unable to set up clusterSchedulingPolicySnapshot watcher for scheduler")
+			return err
+		}
+
+		klog.Info("Setting up the clusterResourceBinding watcher for scheduler")
+		if err := (&schedulercrbwatcher.Reconciler{
+			Client:             mgr.GetClient(),
+			SchedulerWorkQueue: defaultSchedulingQueue,
+		}).SetupWithManager(mgr); err != nil {
+			klog.ErrorS(err, "Unable to set up clusterResourceBinding watcher for scheduler")
 			return err
 		}
 

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -366,7 +366,9 @@ var markUnscheduledForAndUpdate = func(ctx context.Context, hubClient client.Cli
 	// unscheduledBinding from "scheduled" to "bound".
 	binding.Spec.State = placementv1beta1.BindingStateUnscheduled
 	err := hubClient.Update(ctx, binding, &client.UpdateOptions{})
-	klog.V(2).InfoS("Marking binding as unscheduled", "clusterResourceBinding", klog.KObj(binding), "error", err)
+	if err == nil {
+		klog.V(2).InfoS("Marked binding as unscheduled", "clusterResourceBinding", klog.KObj(binding))
+	}
 	return err
 }
 
@@ -374,10 +376,13 @@ var markUnscheduledForAndUpdate = func(ctx context.Context, hubClient client.Cli
 var removeFinalizerAndUpdate = func(ctx context.Context, hubClient client.Client, binding *placementv1beta1.ClusterResourceBinding) error {
 	controllerutil.RemoveFinalizer(binding, placementv1beta1.SchedulerCRBCleanupFinalizer)
 	err := hubClient.Update(ctx, binding, &client.UpdateOptions{})
-	klog.V(2).InfoS("Remove scheduler CRB cleanup finalizer", "clusterResourceBinding", klog.KObj(binding), "error", err)
+	if err == nil {
+		klog.V(2).InfoS("Removed scheduler CRB cleanup finalizer", "clusterResourceBinding", klog.KObj(binding))
+	}
 	return err
 }
 
+// updateBindings iterates over bindings and updates them using the update function provided.
 func (f *framework) updateBindings(ctx context.Context, bindings []*placementv1beta1.ClusterResourceBinding, updateFn func(ctx context.Context, client client.Client, binding *placementv1beta1.ClusterResourceBinding) error) error {
 	// issue all the update requests in parallel
 	errs, cctx := errgroup.WithContext(ctx)

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -295,7 +295,7 @@ func (f *framework) RunSchedulingCycleFor(ctx context.Context, crpName string, p
 	// result so that we won't have a ever increasing chain of flip flop bindings.
 	bound, scheduled, obsolete, unscheduled, dangling, deleting := classifyBindings(policy, bindings, clusters)
 
-	// Remove finalizers on all deleting bindings.
+	// Remove scheduler CRB cleanup finalizer on all deleting bindings.
 	if err := f.removeFinalizer(ctx, deleting); err != nil {
 		klog.ErrorS(err, "Failed to remove finalizers from deleting bindings", "clusterSchedulingPolicySnapshot", policyRef)
 		return ctrl.Result{}, err
@@ -392,7 +392,7 @@ func (f *framework) markAsUnscheduledFor(ctx context.Context, bindings []*placem
 	return errs.Wait()
 }
 
-// removeFinalizer removes all finalizers from ClusterResourceBinding.
+// removeFinalizer removes scheduler CRB cleanup finalizer from ClusterResourceBindings.
 func (f *framework) removeFinalizer(ctx context.Context, bindings []*placementv1beta1.ClusterResourceBinding) error {
 	// issue all the update requests in parallel
 	errs, cctx := errgroup.WithContext(ctx)

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -406,7 +406,10 @@ func (f *framework) removeFinalizer(ctx context.Context, bindings []*placementv1
 					// We will retry on conflicts.
 					if apierrors.IsConflict(err) {
 						// get the binding again to make sure we have the latest version to update again.
-						return f.client.Get(cctx, client.ObjectKeyFromObject(deletingBinding), deletingBinding)
+						getErr := f.client.Get(cctx, client.ObjectKeyFromObject(deletingBinding), deletingBinding)
+						if getErr != nil {
+							return getErr
+						}
 					}
 					return err
 				})

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -401,7 +401,7 @@ func (f *framework) removeFinalizer(ctx context.Context, bindings []*placementv1
 					return apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err) || apierrors.IsConflict(err)
 				},
 				func() error {
-					controllerutil.RemoveFinalizer(deletingBinding, placementv1beta1.SchedulerCRBReconcileFinalizer)
+					controllerutil.RemoveFinalizer(deletingBinding, placementv1beta1.SchedulerCRBCleanupFinalizer)
 					err := f.client.Update(cctx, deletingBinding, &client.UpdateOptions{})
 					// We will retry on conflicts.
 					if apierrors.IsConflict(err) {

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -380,8 +380,7 @@ func (f *framework) markAsUnscheduledFor(ctx context.Context, bindings []*placem
 					// We will just retry for conflict errors since the scheduler holds the truth here.
 					if apierrors.IsConflict(err) {
 						// get the binding again to make sure we have the latest version to update again.
-						getErr := f.client.Get(cctx, client.ObjectKeyFromObject(unscheduledBinding), unscheduledBinding)
-						if getErr != nil {
+						if getErr := f.client.Get(cctx, client.ObjectKeyFromObject(unscheduledBinding), unscheduledBinding); getErr != nil {
 							return getErr
 						}
 					}
@@ -409,8 +408,7 @@ func (f *framework) removeFinalizer(ctx context.Context, bindings []*placementv1
 					// We will retry on conflicts.
 					if apierrors.IsConflict(err) {
 						// get the binding again to make sure we have the latest version to update again.
-						getErr := f.client.Get(cctx, client.ObjectKeyFromObject(deletingBinding), deletingBinding)
-						if getErr != nil {
+						if getErr := f.client.Get(cctx, client.ObjectKeyFromObject(deletingBinding), deletingBinding); getErr != nil {
 							return getErr
 						}
 					}

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -380,7 +380,10 @@ func (f *framework) markAsUnscheduledFor(ctx context.Context, bindings []*placem
 					// We will just retry for conflict errors since the scheduler holds the truth here.
 					if apierrors.IsConflict(err) {
 						// get the binding again to make sure we have the latest version to update again.
-						return f.client.Get(cctx, client.ObjectKeyFromObject(unscheduledBinding), unscheduledBinding)
+						getErr := f.client.Get(cctx, client.ObjectKeyFromObject(unscheduledBinding), unscheduledBinding)
+						if getErr != nil {
+							return getErr
+						}
 					}
 					return err
 				})

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -1279,6 +1279,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1301,6 +1302,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1323,6 +1325,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1515,6 +1518,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1624,6 +1628,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1646,6 +1651,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1668,6 +1674,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1711,6 +1718,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1733,6 +1741,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1818,6 +1827,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
+						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -505,7 +505,7 @@ func TestUpdateBindingRemoveFinalizerAndUpdate(t *testing.T) {
 
 	got := make([]*placementv1beta1.ClusterResourceBinding, len(clusterResourceBindingList.Items))
 	for i := range clusterResourceBindingList.Items {
-		got = append(got, &clusterResourceBindingList.Items[i])
+		got[i] = &clusterResourceBindingList.Items[i]
 	}
 
 	want := []*placementv1beta1.ClusterResourceBinding{

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -387,7 +387,7 @@ func TestClassifyBindings(t *testing.T) {
 }
 
 func TestUpdateBindingsWithErrors(t *testing.T) {
-	boundBinding := placementv1beta1.ClusterResourceBinding{
+	binding := placementv1beta1.ClusterResourceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: bindingName,
 		},
@@ -411,19 +411,19 @@ func TestUpdateBindingsWithErrors(t *testing.T) {
 		wantErr      error
 	}{
 		{
-			name:     "service unavailable error on update, successful get & return return service unavailable",
-			bindings: []*placementv1beta1.ClusterResourceBinding{&boundBinding},
+			name:     "service unavailable error on update, successful get & retry update keeps returning service unavailable error",
+			bindings: []*placementv1beta1.ClusterResourceBinding{&binding},
 			customClient: &errorClient{
 				Client: fakeClient,
-				// set large error retry count to force the return of update error.
+				// set large error retry count to keep returning of update error.
 				errorForRetryCount: 1000000,
 				returnUpdateErr:    "ServiceUnavailable",
 			},
 			wantErr: k8serrors.NewServiceUnavailable("service is unavailable"),
 		},
 		{
-			name:     "service unavailable error on update, successful get & retry return nil",
-			bindings: []*placementv1beta1.ClusterResourceBinding{&boundBinding},
+			name:     "service unavailable error on update, successful get & retry update returns nil",
+			bindings: []*placementv1beta1.ClusterResourceBinding{&binding},
 			customClient: &errorClient{
 				Client:             fakeClient,
 				errorForRetryCount: 1,
@@ -432,8 +432,8 @@ func TestUpdateBindingsWithErrors(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:     "server timeout error on update, successful get & retry return nil",
-			bindings: []*placementv1beta1.ClusterResourceBinding{&boundBinding},
+			name:     "server timeout error on update, successful get & retry update returns nil",
+			bindings: []*placementv1beta1.ClusterResourceBinding{&binding},
 			customClient: &errorClient{
 				Client:             fakeClient,
 				errorForRetryCount: 1,
@@ -442,8 +442,8 @@ func TestUpdateBindingsWithErrors(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:     "conflict error on update, get failed, return get error",
-			bindings: []*placementv1beta1.ClusterResourceBinding{&boundBinding},
+			name:     "conflict error on update, get failed, retry update returns get error",
+			bindings: []*placementv1beta1.ClusterResourceBinding{&binding},
 			customClient: &errorClient{
 				Client:             fakeClient,
 				errorForRetryCount: 1,

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -1279,7 +1279,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1302,7 +1302,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1325,7 +1325,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1518,7 +1518,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1628,7 +1628,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1651,7 +1651,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1674,7 +1674,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1718,7 +1718,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1741,7 +1741,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,
@@ -1827,7 +1827,7 @@ func TestCrossReferencePickedClustersAndDeDupBindings(t *testing.T) {
 						Labels: map[string]string{
 							placementv1beta1.CRPTrackingLabel: crpName,
 						},
-						Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+						Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 					},
 					Spec: placementv1beta1.ResourceBindingSpec{
 						State:                        placementv1beta1.BindingStateScheduled,

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -65,7 +65,7 @@ var (
 	lessFuncFilteredCluster = func(filtered1, filtered2 *filteredClusterWithStatus) bool {
 		return filtered1.cluster.Name < filtered2.cluster.Name
 	}
-	lessFuncBinding = func(binding1, binding2 *placementv1beta1.ClusterResourceBinding) bool {
+	lessFuncBinding = func(binding1, binding2 placementv1beta1.ClusterResourceBinding) bool {
 		return binding1.Name < binding2.Name
 	}
 )
@@ -503,12 +503,7 @@ func TestUpdateBindingRemoveFinalizerAndUpdate(t *testing.T) {
 		t.Fatalf("List cluster resource boundBindings returned %v, want no error", err)
 	}
 
-	got := make([]*placementv1beta1.ClusterResourceBinding, len(clusterResourceBindingList.Items))
-	for i := range clusterResourceBindingList.Items {
-		got[i] = &clusterResourceBindingList.Items[i]
-	}
-
-	want := []*placementv1beta1.ClusterResourceBinding{
+	want := []placementv1beta1.ClusterResourceBinding{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: bindingName,
@@ -535,7 +530,7 @@ func TestUpdateBindingRemoveFinalizerAndUpdate(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(got, want, ignoreTypeMetaAPIVersionKindFields, ignoreObjectMetaResourceVersionField, cmpopts.SortSlices(lessFuncBinding)); diff != "" {
+	if diff := cmp.Diff(clusterResourceBindingList.Items, want, ignoreTypeMetaAPIVersionKindFields, ignoreObjectMetaResourceVersionField, cmpopts.SortSlices(lessFuncBinding)); diff != "" {
 		t.Errorf("diff (-got, +want): %s", diff)
 	}
 }

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -352,8 +352,9 @@ func TestClassifyBindings(t *testing.T) {
 	wantObsolete := []*placementv1beta1.ClusterResourceBinding{&obsoleteBinding}
 	wantUnscheduled := []*placementv1beta1.ClusterResourceBinding{&unscheduledBinding}
 	wantDangling := []*placementv1beta1.ClusterResourceBinding{&associatedWithLeavingClusterBinding, &assocaitedWithDisappearedClusterBinding}
+	wantDeleting := []*placementv1beta1.ClusterResourceBinding{&deletingBinding}
 
-	bound, scheduled, obsolete, unscheduled, dangling := classifyBindings(policy, bindings, clusters)
+	bound, scheduled, obsolete, unscheduled, dangling, deleting := classifyBindings(policy, bindings, clusters)
 	if diff := cmp.Diff(bound, wantBound); diff != "" {
 		t.Errorf("classifyBindings() bound diff (-got, +want): %s", diff)
 	}
@@ -372,6 +373,10 @@ func TestClassifyBindings(t *testing.T) {
 
 	if diff := cmp.Diff(dangling, wantDangling); diff != "" {
 		t.Errorf("classifyBindings() dangling diff (-got, +want) = %s", diff)
+	}
+
+	if diff := cmp.Diff(deleting, wantDeleting); diff != "" {
+		t.Errorf("classifyBIndings() deleting diff (-got, +want) = %s", diff)
 	}
 }
 

--- a/pkg/scheduler/framework/frameworkutils.go
+++ b/pkg/scheduler/framework/frameworkutils.go
@@ -185,7 +185,7 @@ func crossReferencePickedClustersAndDeDupBindings(
 					Labels: map[string]string{
 						placementv1beta1.CRPTrackingLabel: crpName,
 					},
-					Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+					Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 				},
 				Spec: placementv1beta1.ResourceBindingSpec{
 					State: placementv1beta1.BindingStateScheduled,
@@ -684,7 +684,7 @@ func crossReferenceValidTargetsWithBindings(
 					Labels: map[string]string{
 						placementv1beta1.CRPTrackingLabel: crpName,
 					},
-					Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+					Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 				},
 				Spec: placementv1beta1.ResourceBindingSpec{
 					State: placementv1beta1.BindingStateScheduled,

--- a/pkg/scheduler/framework/frameworkutils.go
+++ b/pkg/scheduler/framework/frameworkutils.go
@@ -54,7 +54,7 @@ func classifyBindings(policy *placementv1beta1.ClusterSchedulingPolicySnapshot, 
 
 		switch {
 		case !binding.DeletionTimestamp.IsZero():
-			// we need remove scheduler reconcile finalizer from deleting ClusterResourceBindings.
+			// we need remove scheduler CRB cleanup finalizer from deleting ClusterResourceBindings.
 			deleting = append(deleting, &binding)
 		case binding.Spec.State == placementv1beta1.BindingStateUnscheduled:
 			// we need to remember those bindings so that we will not create another one.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -282,7 +282,7 @@ func (s *Scheduler) cleanUpAllBindingsFor(ctx context.Context, crp *fleetv1beta1
 		return controller.NewAPIServerError(false, err)
 	}
 
-	// Remove scheduler reconcile finalizer from deleting bindings.
+	// Remove scheduler CRB cleanup finalizer from deleting bindings.
 	for idx := range bindingList.Items {
 		binding := &bindingList.Items[idx]
 		controllerutil.RemoveFinalizer(binding, fleetv1beta1.SchedulerCRBCleanupFinalizer)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -283,15 +283,7 @@ func (s *Scheduler) cleanUpAllBindingsFor(ctx context.Context, crp *fleetv1beta1
 	}
 
 	// Remove scheduler CRB cleanup finalizer from deleting bindings.
-	for idx := range bindingList.Items {
-		binding := &bindingList.Items[idx]
-		controllerutil.RemoveFinalizer(binding, fleetv1beta1.SchedulerCRBCleanupFinalizer)
-		if err := s.client.Update(ctx, binding); err != nil {
-			klog.ErrorS(err, "Failed to remove scheduler reconcile finalizer from cluster resource binding", "clusterResourceBinding", klog.KObj(binding))
-			return controller.NewUpdateIgnoreConflictError(err)
-		}
-	}
-
+	//
 	// Note that once a CRP has been marked for deletion, it will no longer enter the scheduling cycle,
 	// so any cleanup finalizer has to be removed here.
 	//
@@ -300,6 +292,11 @@ func (s *Scheduler) cleanUpAllBindingsFor(ctx context.Context, crp *fleetv1beta1
 	// run the deletion.
 	for idx := range bindingList.Items {
 		binding := &bindingList.Items[idx]
+		controllerutil.RemoveFinalizer(binding, fleetv1beta1.SchedulerCRBCleanupFinalizer)
+		if err := s.client.Update(ctx, binding); err != nil {
+			klog.ErrorS(err, "Failed to remove scheduler reconcile finalizer from cluster resource binding", "clusterResourceBinding", klog.KObj(binding))
+			return controller.NewUpdateIgnoreConflictError(err)
+		}
 		// Delete the binding if it has not been marked for deletion yet.
 		if binding.DeletionTimestamp == nil {
 			if err := s.client.Delete(ctx, binding); err != nil && !errors.IsNotFound(err) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -70,6 +70,7 @@ func TestCleanUpAllBindingsFor(t *testing.T) {
 				Labels: map[string]string{
 					fleetv1beta1.CRPTrackingLabel: crpName,
 				},
+				Finalizers: []string{fleetv1beta1.SchedulerCRBCleanupFinalizer},
 			},
 		},
 		{
@@ -78,6 +79,7 @@ func TestCleanUpAllBindingsFor(t *testing.T) {
 				Labels: map[string]string{
 					fleetv1beta1.CRPTrackingLabel: crpName,
 				},
+				Finalizers: []string{fleetv1beta1.SchedulerCRBCleanupFinalizer},
 			},
 		},
 	}

--- a/pkg/scheduler/watchers/clusterresourcebinding/controller_integration_test.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/controller_integration_test.go
@@ -85,7 +85,7 @@ var _ = Describe("scheduler - cluster resource binding watcher", Ordered, func()
 					},
 				},
 			}
-			// create cluster resource binding.
+			// Create cluster resource binding.
 			Expect(hubClient.Create(ctx, &crb)).Should(Succeed(), "Failed to create cluster resource binding")
 		})
 

--- a/pkg/scheduler/watchers/clusterresourcebinding/controller_integration_test.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/controller_integration_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+package clusterresourcebinding
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+)
+
+const (
+	eventuallyDuration   = time.Second * 5
+	eventuallyInterval   = time.Millisecond * 250
+	consistentlyDuration = time.Second
+	consistentlyInterval = time.Millisecond * 200
+
+	crbName     = "test-crb"
+	crpName     = "test-crp"
+	clusterName = "test-cluster"
+)
+
+var (
+	noKeyEnqueuedActual = func() error {
+		if queueLen := keyCollector.Len(); queueLen != 0 {
+			return fmt.Errorf("work queue is not empty: current len %d, want 0", queueLen)
+		}
+		return nil
+	}
+
+	expectedKeySetEnqueuedActual = func() error {
+		if isAllPresent, absentKeys := keyCollector.IsPresent(crpName); !isAllPresent {
+			return fmt.Errorf("expected key(s) %v is not found", absentKeys)
+		}
+
+		if queueLen := keyCollector.Len(); queueLen != 1 {
+			return fmt.Errorf("more than one key is enqueued: current len %d, want 1", queueLen)
+		}
+
+		return nil
+	}
+)
+
+// This container cannot be run in parallel since we are trying to access a common shared queue.
+var _ = Describe("scheduler - cluster resource binding watcher", Ordered, func() {
+	BeforeAll(func() {
+		Eventually(noKeyEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Workqueue is not empty")
+		Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+	})
+
+	Context("create, update & delete cluster resource binding", func() {
+		BeforeAll(func() {
+			affinityScore := int32(1)
+			topologyScore := int32(1)
+			crb := fleetv1beta1.ClusterResourceBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crbName,
+					Labels: map[string]string{
+						fleetv1beta1.CRPTrackingLabel: crpName,
+					},
+					Finalizers: []string{fleetv1beta1.SchedulerCRBCleanupFinalizer},
+				},
+				Spec: fleetv1beta1.ResourceBindingSpec{
+					State: fleetv1beta1.BindingStateScheduled,
+					// Leave the associated resource snapshot name empty; it is up to another controller
+					// to fulfill this field.
+					SchedulingPolicySnapshotName: "test-policy",
+					TargetCluster:                clusterName,
+					ClusterDecision: fleetv1beta1.ClusterDecision{
+						ClusterName: clusterName,
+						Selected:    true,
+						ClusterScore: &fleetv1beta1.ClusterScore{
+							AffinityScore:       &affinityScore,
+							TopologySpreadScore: &topologyScore,
+						},
+						Reason: "test-reason",
+					},
+				},
+			}
+			// create cluster resource binding.
+			Expect(hubClient.Create(ctx, &crb)).Should(Succeed(), "Failed to create cluster resource binding")
+		})
+
+		It("should not enqueue the CRP name when CRB is created", func() {
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+		})
+
+		It("update cluster resource binding", func() {
+			var crb fleetv1beta1.ClusterResourceBinding
+			Expect(hubClient.Get(ctx, client.ObjectKey{Name: crbName}, &crb)).Should(Succeed())
+			crb.Spec.State = fleetv1beta1.BindingStateBound
+			Expect(hubClient.Update(ctx, &crb)).Should(Succeed())
+		})
+
+		It("should not enqueue the CRP name when it CRB is updated", func() {
+			Consistently(noKeyEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is not empty")
+		})
+
+		It("delete cluster resource binding", func() {
+			var crb fleetv1beta1.ClusterResourceBinding
+			Expect(hubClient.Get(ctx, client.ObjectKey{Name: crbName}, &crb)).Should(Succeed())
+			Expect(hubClient.Delete(ctx, &crb)).Should(Succeed())
+		})
+
+		It("should enqueue CRP name when CRB is deleted", func() {
+			Consistently(expectedKeySetEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is either empty or it contains more than one element")
+		})
+
+		AfterAll(func() {
+			keyCollector.Reset()
+		})
+	})
+})

--- a/pkg/scheduler/watchers/clusterresourcebinding/controller_integration_test.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/controller_integration_test.go
@@ -2,6 +2,7 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
+
 package clusterresourcebinding
 
 import (

--- a/pkg/scheduler/watchers/clusterresourcebinding/controller_integration_test.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/controller_integration_test.go
@@ -110,6 +110,7 @@ var _ = Describe("scheduler - cluster resource binding watcher", Ordered, func()
 		})
 
 		It("should enqueue CRP name when CRB is deleted", func() {
+			Eventually(expectedKeySetEnqueuedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Workqueue is either empty or it contains more than one element")
 			Consistently(expectedKeySetEnqueuedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Workqueue is either empty or it contains more than one element")
 		})
 

--- a/pkg/scheduler/watchers/clusterresourcebinding/suite_test.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/suite_test.go
@@ -1,3 +1,8 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
 package clusterresourcebinding
 
 import (

--- a/pkg/scheduler/watchers/clusterresourcebinding/suite_test.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/suite_test.go
@@ -1,0 +1,100 @@
+package clusterresourcebinding
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/scheduler/queue"
+	"go.goms.io/fleet/test/utils/keycollector"
+)
+
+var (
+	hubTestEnv   *envtest.Environment
+	hubClient    client.Client
+	ctx          context.Context
+	cancel       context.CancelFunc
+	keyCollector *keycollector.SchedulerWorkqueueKeyCollector
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Scheduler Source Cluster Resource Binding Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	klog.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrap the test environment")
+
+	// Start the hub cluster.
+	hubTestEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	hubCfg, err := hubTestEnv.Start()
+	Expect(err).ToNot(HaveOccurred(), "Failed to start test environment")
+	Expect(hubCfg).ToNot(BeNil(), "Hub cluster configuration is nil")
+
+	// Add custom APIs to the runtime scheme.
+	Expect(fleetv1beta1.AddToScheme(scheme.Scheme)).Should(Succeed())
+
+	// Set up a client for the hub cluster.
+	hubClient, err = client.New(hubCfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred(), "Failed to create hub cluster client")
+	Expect(hubClient).ToNot(BeNil(), "Hub cluster client is nil")
+
+	// Set up a controller manager and let it manage the hub cluster controller.
+	ctrlMgr, err := ctrl.NewManager(hubCfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	Expect(err).NotTo(HaveOccurred(), "Failed to create controller manager")
+
+	schedulerWorkQueue := queue.NewSimpleClusterResourcePlacementSchedulingQueue()
+
+	// Create ClusterResourceBinding watcher reconciler.
+	reconciler := &Reconciler{
+		Client:             hubClient,
+		SchedulerWorkQueue: schedulerWorkQueue,
+	}
+	err = reconciler.SetupWithManager(ctrlMgr)
+	Expect(err).ToNot(HaveOccurred(), "Failed to set up controller with controller manager")
+
+	// Start the key collector.
+	keyCollector = keycollector.NewSchedulerWorkqueueKeyCollector(schedulerWorkQueue)
+	go func() {
+		keyCollector.Run(ctx)
+	}()
+
+	// Start the controller manager.
+	go func() {
+		defer GinkgoRecover()
+		err := ctrlMgr.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "Failed to start controller manager")
+	}()
+})
+
+var _ = AfterSuite(func() {
+	defer klog.Flush()
+	cancel()
+
+	By("tearing down the test environment")
+	Expect(hubTestEnv.Stop()).Should(Succeed(), "Failed to stop test environment")
+})

--- a/pkg/scheduler/watchers/clusterresourcebinding/watcher.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/watcher.go
@@ -47,9 +47,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, controller.NewAPIServerError(true, client.IgnoreNotFound(err))
 	}
 
-	// Check if the CRB has been deleted and has the scheduler finalizer.
+	// Check if the CRB has been deleted and has the scheduler CRB cleanup finalizer.
 	if crb.DeletionTimestamp != nil && controllerutil.ContainsFinalizer(crb, fleetv1beta1.SchedulerCRBCleanupFinalizer) {
-		// The CRB has been deleted and still has the scheduler finalizer; enqueue it's corresponding CRP
+		// The CRB has been deleted and still has the scheduler CRB cleanup finalizer; enqueue it's corresponding CRP
 		// for the scheduler to process.
 		crpName, exist := crb.GetLabels()[fleetv1beta1.CRPTrackingLabel]
 		if !exist {

--- a/pkg/scheduler/watchers/clusterresourcebinding/watcher.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/watcher.go
@@ -48,7 +48,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Check if the CRB has been deleted and has the scheduler finalizer.
-	if crb.DeletionTimestamp != nil && controllerutil.ContainsFinalizer(crb, fleetv1beta1.SchedulerCRBReconcileFinalizer) {
+	if crb.DeletionTimestamp != nil && controllerutil.ContainsFinalizer(crb, fleetv1beta1.SchedulerCRBCleanupFinalizer) {
 		// The CRB has been deleted and still has the scheduler finalizer; enqueue it's corresponding CRP
 		// for the scheduler to process.
 		crpName, exist := crb.GetLabels()[fleetv1beta1.CRPTrackingLabel]

--- a/pkg/scheduler/watchers/clusterresourcebinding/watcher.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/watcher.go
@@ -10,15 +10,16 @@ import (
 	"fmt"
 	"time"
 
-	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
-	"go.goms.io/fleet/pkg/scheduler/queue"
-	"go.goms.io/fleet/pkg/utils/controller"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/scheduler/queue"
+	"go.goms.io/fleet/pkg/utils/controller"
 )
 
 // Reconciler reconciles the deletion of a ClusterResourceBinding.

--- a/pkg/scheduler/watchers/clusterresourcebinding/watcher.go
+++ b/pkg/scheduler/watchers/clusterresourcebinding/watcher.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package clusterresourcebinding
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/scheduler/queue"
+	"go.goms.io/fleet/pkg/utils/controller"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Reconciler reconciles the deletion of a ClusterResourceBinding.
+type Reconciler struct {
+	// Client is the client the controller uses to access the hub cluster.
+	client.Client
+	// SchedulerWorkQueue is the workqueue in use by the scheduler.
+	SchedulerWorkQueue queue.ClusterResourcePlacementSchedulingQueueWriter
+}
+
+// Reconcile reconciles the CRB.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	crbRef := klog.KRef("", req.Name)
+	startTime := time.Now()
+	klog.V(2).InfoS("Scheduler source reconciliation starts", "clusterResourceBinding", crbRef)
+	defer func() {
+		latency := time.Since(startTime).Milliseconds()
+		klog.V(2).InfoS("Scheduler source reconciliation ends", "clusterResourceBinding", crbRef, "latency", latency)
+	}()
+
+	// Retrieve the CRB.
+	crb := &fleetv1beta1.ClusterResourceBinding{}
+	if err := r.Client.Get(ctx, req.NamespacedName, crb); err != nil {
+		klog.ErrorS(err, "Failed to get cluster resource binding", "clusterResourceBinding", crbRef)
+		return ctrl.Result{}, controller.NewAPIServerError(true, client.IgnoreNotFound(err))
+	}
+
+	// Check if the CRB has been deleted and has the scheduler finalizer.
+	if crb.DeletionTimestamp != nil && controllerutil.ContainsFinalizer(crb, fleetv1beta1.SchedulerCRBReconcileFinalizer) {
+		// The CRB has been deleted and still has the scheduler finalizer; enqueue it's corresponding CRP
+		// for the scheduler to process.
+		crpName, exist := crb.GetLabels()[fleetv1beta1.CRPTrackingLabel]
+		if !exist {
+			err := controller.NewUnexpectedBehaviorError(fmt.Errorf("clusterResourceBinding %s doesn't have CRP tracking label", crb.Name))
+			klog.ErrorS(err, "Failed to enqueue CRP name for CRB")
+			// error cannot be retried.
+			return ctrl.Result{}, nil
+		}
+		r.SchedulerWorkQueue.AddRateLimited(queue.ClusterResourcePlacementKey(crpName))
+	}
+
+	// No action is needed for the scheduler to take in other cases.
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	customPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// Ignore creation events.
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// Ignore deletion events (events emitted when the object is actually removed
+			// from storage).
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Check if the update event is valid.
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				err := controller.NewUnexpectedBehaviorError(fmt.Errorf("update event is invalid"))
+				klog.ErrorS(err, "Failed to process update event")
+				return false
+			}
+
+			// Check if the deletion timestamp has been set.
+			oldDeletionTimestamp := e.ObjectOld.GetDeletionTimestamp()
+			newDeletionTimestamp := e.ObjectNew.GetDeletionTimestamp()
+			if oldDeletionTimestamp == nil && newDeletionTimestamp != nil {
+				return true
+			}
+
+			return false
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&fleetv1beta1.ClusterResourceBinding{}).
+		WithEventFilter(customPredicate).
+		Complete(r)
+}

--- a/test/scheduler/actuals_test.go
+++ b/test/scheduler/actuals_test.go
@@ -109,6 +109,7 @@ func scheduledBindingsCreatedOrUpdatedForClustersActual(clusters []string, score
 					Labels: map[string]string{
 						placementv1beta1.CRPTrackingLabel: crpName,
 					},
+					Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 				},
 				Spec: placementv1beta1.ResourceBindingSpec{
 					State:                        placementv1beta1.BindingStateScheduled,

--- a/test/scheduler/actuals_test.go
+++ b/test/scheduler/actuals_test.go
@@ -170,6 +170,7 @@ func boundBindingsCreatedOrUpdatedForClustersActual(clusters []string, scoreByCl
 					Labels: map[string]string{
 						placementv1beta1.CRPTrackingLabel: crpName,
 					},
+					Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 				},
 				Spec: placementv1beta1.ResourceBindingSpec{
 					State:                        placementv1beta1.BindingStateBound,
@@ -230,6 +231,7 @@ func unscheduledBindingsCreatedOrUpdatedForClustersActual(clusters []string, sco
 					Labels: map[string]string{
 						placementv1beta1.CRPTrackingLabel: crpName,
 					},
+					Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
 				},
 				Spec: placementv1beta1.ResourceBindingSpec{
 					State:                        placementv1beta1.BindingStateUnscheduled,

--- a/test/scheduler/actuals_test.go
+++ b/test/scheduler/actuals_test.go
@@ -109,7 +109,7 @@ func scheduledBindingsCreatedOrUpdatedForClustersActual(clusters []string, score
 					Labels: map[string]string{
 						placementv1beta1.CRPTrackingLabel: crpName,
 					},
-					Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+					Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 				},
 				Spec: placementv1beta1.ResourceBindingSpec{
 					State:                        placementv1beta1.BindingStateScheduled,
@@ -170,7 +170,7 @@ func boundBindingsCreatedOrUpdatedForClustersActual(clusters []string, scoreByCl
 					Labels: map[string]string{
 						placementv1beta1.CRPTrackingLabel: crpName,
 					},
-					Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+					Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 				},
 				Spec: placementv1beta1.ResourceBindingSpec{
 					State:                        placementv1beta1.BindingStateBound,
@@ -231,7 +231,7 @@ func unscheduledBindingsCreatedOrUpdatedForClustersActual(clusters []string, sco
 					Labels: map[string]string{
 						placementv1beta1.CRPTrackingLabel: crpName,
 					},
-					Finalizers: []string{placementv1beta1.SchedulerCRBReconcileFinalizer},
+					Finalizers: []string{placementv1beta1.SchedulerCRBCleanupFinalizer},
 				},
 				Spec: placementv1beta1.ResourceBindingSpec{
 					State:                        placementv1beta1.BindingStateUnscheduled,

--- a/test/scheduler/suite_test.go
+++ b/test/scheduler/suite_test.go
@@ -38,6 +38,7 @@ import (
 	"go.goms.io/fleet/pkg/scheduler"
 	"go.goms.io/fleet/pkg/scheduler/clustereligibilitychecker"
 	"go.goms.io/fleet/pkg/scheduler/queue"
+	"go.goms.io/fleet/pkg/scheduler/watchers/clusterresourcebinding"
 	"go.goms.io/fleet/pkg/scheduler/watchers/clusterresourceplacement"
 	"go.goms.io/fleet/pkg/scheduler/watchers/clusterschedulingpolicysnapshot"
 	"go.goms.io/fleet/pkg/scheduler/watchers/membercluster"
@@ -583,6 +584,13 @@ func beforeSuiteForProcess1() []byte {
 	}
 	err = memberClusterWatcher.SetupWithManager(ctrlMgr)
 	Expect(err).NotTo(HaveOccurred(), "Failed to set up member cluster watcher with controller manager")
+
+	clusterResourceBindingWatcher := clusterresourcebinding.Reconciler{
+		Client:             hubClient,
+		SchedulerWorkQueue: schedulerWorkQueue,
+	}
+	err = clusterResourceBindingWatcher.SetupWithManager(ctrlMgr)
+	Expect(err).NotTo(HaveOccurred(), "Failed to set up cluster resource binding watcher with controller manager")
 
 	// Set up the scheduler.
 	fw := buildSchedulerFramework(ctrlMgr, clusterEligibilityChecker)


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

- Adding scheduler clean up finalizers for CRBs when CRBs are created in a scheduling cycle
- Removing scheduler clean up finalizers for CRBs when CRBs are deleting with deleting timestamp
- Added CRB scheduler watcher to pick up deleting CRBs and enqueue CRP name to trigger scheduling cycle, also added watcher IT
- Added logic to clean up CRBs, by removing scheduler clean up finalizer when CRP is deleting

These changes are needed for the new PlacementEviction API
