### PR TITLE
feat: add kubeadm cluster-admin group in fleet guard rail & bump kindest node to use 1.30.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY ?= ghcr.io
-KIND_IMAGE ?= kindest/node:v1.28.0
+KIND_IMAGE ?= kindest/node:v1.30.0
 ifndef TAG
 	TAG ?= $(shell git rev-parse --short=7 HEAD)
 endif

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export this variable which specifies the number of member clusters that will be 
 export MEMBER_CLUSTER_COUNT=1
 ```
 
-from the root directory of the repo run the following command, by default a hub cluster gets created which is the control plane for fleet (**The makefile uses kindest/node:v1.28.0**)
+from the root directory of the repo run the following command, by default a hub cluster gets created which is the control plane for fleet (**The makefile uses kindest/node:v1.30.0**)
 
 ```shell
 make setup-clusters

--- a/pkg/webhook/validation/uservalidation_test.go
+++ b/pkg/webhook/validation/uservalidation_test.go
@@ -37,6 +37,21 @@ func TestValidateUserForResource(t *testing.T) {
 			},
 			wantResponse: admission.Allowed(fmt.Sprintf(ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{mastersGroup}), admissionv1.Create, &utils.RoleMetaGVK, "", types.NamespacedName{Name: "test-role", Namespace: "test-namespace"})),
 		},
+		"allow user in kubeadm:cluster-admin group": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:        "test-role",
+					Namespace:   "test-namespace",
+					RequestKind: &utils.RoleMetaGVK,
+					UserInfo: authenticationv1.UserInfo{
+						Username: "test-user",
+						Groups:   []string{kubeadmClusterAdminsGroup},
+					},
+					Operation: admissionv1.Create,
+				},
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf(ResourceAllowedFormat, "test-user", utils.GenerateGroupString([]string{kubeadmClusterAdminsGroup}), admissionv1.Create, &utils.RoleMetaGVK, "", types.NamespacedName{Name: "test-role", Namespace: "test-namespace"})),
+		},
 		// UT to test GenerateGroupString in pkg/utils/common.gp
 		"allow user in system:masters group along with 10 other groups": {
 			req: admission.Request{

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 # Before updating the default kind image to use, verify that the version is supported
 # by the current kind release.
-KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.28.0}"
+KIND_IMAGE="${KIND_IMAGE:-kindest/node:v1.30.0}"
 KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
 MEMBER_CLUSTER_COUNT=$1
 


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

Addressing https://github.com/Azure/fleet/pull/911#issuecomment-2428232162

- KIND started using kubeadm https://kind.sigs.k8s.io/docs/user/configuration/#kubeadm-config-patches
- https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/#generate-kubeconfig-files-for-control-plane-components; kubeadm creates kubernetes-admin user in kubeadm:cluster-admin group

Before this change kubernetes-admin use belonged to system:masters group


