### PR TITLE
refactor: Move file from interfaces to authtoken package directories and add comments

### DIFF
--- a/cmd/authtoken/main.go
+++ b/cmd/authtoken/main.go
@@ -16,15 +16,14 @@ import (
 	"go.goms.io/fleet/pkg/authtoken"
 	"go.goms.io/fleet/pkg/authtoken/providers/azure"
 	"go.goms.io/fleet/pkg/authtoken/providers/secret"
-	"go.goms.io/fleet/pkg/interfaces"
 )
 
 var (
 	configPath string
 )
 
-func parseArgs() (interfaces.AuthTokenProvider, error) {
-	var tokenProvider interfaces.AuthTokenProvider
+func parseArgs() (authtoken.AuthTokenProvider, error) {
+	var tokenProvider authtoken.AuthTokenProvider
 	rootCmd := &cobra.Command{Use: "refreshtoken", Args: cobra.NoArgs}
 	rootCmd.PersistentFlags().StringVar(&configPath, "file-path", "/config/token", "token file path")
 

--- a/cmd/authtoken/main.go
+++ b/cmd/authtoken/main.go
@@ -22,8 +22,8 @@ var (
 	configPath string
 )
 
-func parseArgs() (authtoken.AuthTokenProvider, error) {
-	var tokenProvider authtoken.AuthTokenProvider
+func parseArgs() (authtoken.Provider, error) {
+	var tokenProvider authtoken.Provider
 	rootCmd := &cobra.Command{Use: "refreshtoken", Args: cobra.NoArgs}
 	rootCmd.PersistentFlags().StringVar(&configPath, "file-path", "/config/token", "token file path")
 

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -12,7 +12,6 @@ RUN go mod download
 # Copy the go source
 COPY cmd/authtoken/main.go main.go
 COPY pkg/authtoken pkg/authtoken
-COPY pkg/interfaces pkg/interfaces
 
 ARG TARGETARCH
 

--- a/pkg/authtoken/interfaces.go
+++ b/pkg/authtoken/interfaces.go
@@ -9,22 +9,22 @@ import (
 	"time"
 )
 
-// An AuthToken is an authorization token for the fleet
+// An AuthToken is an authentication token used to communicate with the hub API server.
 type AuthToken struct {
 	Token     string    // name of token
 	ExpiresOn time.Time // expiration time of token
 }
 
-// AuthTokenProvider defines a method for fetching an AuthToken
-type AuthTokenProvider interface {
-	// FetchToken fetches an AuthToken
-	// It returns an error if it is unable to fetch an AuthToken for the given input context
+// Provider defines a method for fetching an AuthToken.
+type Provider interface {
+	// FetchToken fetches an AuthToken.
+	// It returns an error if it is unable to fetch an AuthToken for the given input context.
 	FetchToken(ctx context.Context) (AuthToken, error)
 }
 
-// AuthTokenWriter defines a method for writing an AuthToken
-type AuthTokenWriter interface {
-	// WriteToken writes an AuthToken
-	// It returns an error if it is unable to write the AuthToken
+// Writer defines a method for writing an AuthToken.
+type Writer interface {
+	// WriteToken writes an AuthToken.
+	// It returns an error if it is unable to write the AuthToken.
 	WriteToken(token AuthToken) error
 }

--- a/pkg/authtoken/interfaces.go
+++ b/pkg/authtoken/interfaces.go
@@ -11,20 +11,20 @@ import (
 
 // An AuthToken is an authentication token used to communicate with the hub API server.
 type AuthToken struct {
-	Token     string    // name of token
-	ExpiresOn time.Time // expiration time of token
+	Token     string    // The authentication token string.
+	ExpiresOn time.Time // The expiration time of the token.
 }
 
-// Provider defines a method for fetching an AuthToken.
+// Provider defines a method for fetching an authentication token.
 type Provider interface {
-	// FetchToken fetches an AuthToken.
-	// It returns an error if it is unable to fetch an AuthToken for the given input context.
+	// FetchToken fetches an authentication token to make requests to its associated fleet's hub cluster.
+	// It returns the token for a given input context, or an error if the retrieval fails.
 	FetchToken(ctx context.Context) (AuthToken, error)
 }
 
-// Writer defines a method for writing an AuthToken.
+// Writer defines a method for writing an authentication token to a specified location.
 type Writer interface {
-	// WriteToken writes an AuthToken.
-	// It returns an error if it is unable to write the AuthToken.
+	// WriteToken writes the provided authentication token to a filepath location specified in a TokenWriter.
+	// It returns an error if the writing process fails.
 	WriteToken(token AuthToken) error
 }

--- a/pkg/authtoken/interfaces.go
+++ b/pkg/authtoken/interfaces.go
@@ -2,22 +2,25 @@
 Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 */
-package interfaces
+package authtoken
 
 import (
 	"context"
 	"time"
 )
 
+// AuthToken: Authorization Token containing token name as a string and its expiration time
 type AuthToken struct {
 	Token     string
 	ExpiresOn time.Time
 }
 
+// AuthTokenProvider: Interface with a function that takes in a context input in order to fetch an AuthToken
 type AuthTokenProvider interface {
 	FetchToken(ctx context.Context) (AuthToken, error)
 }
 
+// AuthTokenWriter: Interface with a function to write an AuthToken
 type AuthTokenWriter interface {
 	WriteToken(token AuthToken) error
 }

--- a/pkg/authtoken/interfaces.go
+++ b/pkg/authtoken/interfaces.go
@@ -9,18 +9,22 @@ import (
 	"time"
 )
 
-// AuthToken: Authorization Token containing token name as a string and its expiration time
+// An AuthToken is an authorization token for the fleet
 type AuthToken struct {
-	Token     string
-	ExpiresOn time.Time
+	Token     string    // name of token
+	ExpiresOn time.Time // expiration time of token
 }
 
-// AuthTokenProvider: Interface with a function that takes in a context input in order to fetch an AuthToken
+// AuthTokenProvider defines a method for fetching an AuthToken
 type AuthTokenProvider interface {
+	// FetchToken fetches an AuthToken
+	// It returns an error if it is unable to fetch an AuthToken for the given input context
 	FetchToken(ctx context.Context) (AuthToken, error)
 }
 
-// AuthTokenWriter: Interface with a function to write an AuthToken
+// AuthTokenWriter defines a method for writing an AuthToken
 type AuthTokenWriter interface {
+	// WriteToken writes an AuthToken
+	// It returns an error if it is unable to write the AuthToken
 	WriteToken(token AuthToken) error
 }

--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -8,13 +8,13 @@ import (
 	"context"
 	"fmt"
 
-	"go.goms.io/fleet/pkg/authtoken"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+
+	"go.goms.io/fleet/pkg/authtoken"
 )
 
 const (

--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -7,6 +7,7 @@ package azure
 import (
 	"context"
 	"fmt"
+
 	"go.goms.io/fleet/pkg/authtoken"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"

--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -25,7 +25,7 @@ type AuthTokenProvider struct {
 	Scope    string
 }
 
-func New(clientID, scope string) authtoken.AuthTokenProvider {
+func New(clientID, scope string) authtoken.Provider {
 	if scope == "" {
 		scope = aksScope
 	}

--- a/pkg/authtoken/providers/azure/azure_msi.go
+++ b/pkg/authtoken/providers/azure/azure_msi.go
@@ -7,14 +7,13 @@ package azure
 import (
 	"context"
 	"fmt"
+	"go.goms.io/fleet/pkg/authtoken"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
-
-	"go.goms.io/fleet/pkg/interfaces"
 )
 
 const (
@@ -26,7 +25,7 @@ type AuthTokenProvider struct {
 	Scope    string
 }
 
-func New(clientID, scope string) interfaces.AuthTokenProvider {
+func New(clientID, scope string) authtoken.AuthTokenProvider {
 	if scope == "" {
 		scope = aksScope
 	}
@@ -37,8 +36,8 @@ func New(clientID, scope string) interfaces.AuthTokenProvider {
 }
 
 // FetchToken gets a new token to make request to the associated fleet' hub cluster.
-func (a *AuthTokenProvider) FetchToken(ctx context.Context) (interfaces.AuthToken, error) {
-	token := interfaces.AuthToken{}
+func (a *AuthTokenProvider) FetchToken(ctx context.Context) (authtoken.AuthToken, error) {
+	token := authtoken.AuthToken{}
 	opts := &azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID(a.ClientID)}
 
 	klog.V(2).InfoS("FetchToken", "client ID", a.ClientID)

--- a/pkg/authtoken/providers/secret/k8s_secret.go
+++ b/pkg/authtoken/providers/secret/k8s_secret.go
@@ -28,7 +28,7 @@ type secretAuthTokenProvider struct {
 	secretNamespace string
 }
 
-func New(secretName, namespace string) (authtoken.AuthTokenProvider, error) {
+func New(secretName, namespace string) (authtoken.Provider, error) {
 	client, err := getClient()
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred will creating client: %w", err)

--- a/pkg/authtoken/providers/secret/k8s_secret.go
+++ b/pkg/authtoken/providers/secret/k8s_secret.go
@@ -9,14 +9,14 @@ import (
 	"fmt"
 	"time"
 
-	"go.goms.io/fleet/pkg/authtoken"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"go.goms.io/fleet/pkg/authtoken"
 )
 
 var (

--- a/pkg/authtoken/providers/secret/k8s_secret.go
+++ b/pkg/authtoken/providers/secret/k8s_secret.go
@@ -7,8 +7,9 @@ package secret
 import (
 	"context"
 	"fmt"
-	"go.goms.io/fleet/pkg/authtoken"
 	"time"
+
+	"go.goms.io/fleet/pkg/authtoken"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/authtoken/providers/secret/k8s_secret.go
+++ b/pkg/authtoken/providers/secret/k8s_secret.go
@@ -7,6 +7,7 @@ package secret
 import (
 	"context"
 	"fmt"
+	"go.goms.io/fleet/pkg/authtoken"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,8 +16,6 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"go.goms.io/fleet/pkg/interfaces"
 )
 
 var (
@@ -29,7 +28,7 @@ type secretAuthTokenProvider struct {
 	secretNamespace string
 }
 
-func New(secretName, namespace string) (interfaces.AuthTokenProvider, error) {
+func New(secretName, namespace string) (authtoken.AuthTokenProvider, error) {
 	client, err := getClient()
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred will creating client: %w", err)
@@ -41,9 +40,9 @@ func New(secretName, namespace string) (interfaces.AuthTokenProvider, error) {
 	}, nil
 }
 
-func (s *secretAuthTokenProvider) FetchToken(ctx context.Context) (interfaces.AuthToken, error) {
+func (s *secretAuthTokenProvider) FetchToken(ctx context.Context) (authtoken.AuthToken, error) {
 	klog.V(2).InfoS("fetching token from secret", "secret", klog.KRef(s.secretName, s.secretNamespace))
-	token := interfaces.AuthToken{}
+	token := authtoken.AuthToken{}
 	secret, err := s.fetchSecret(ctx)
 	if err != nil {
 		return token, fmt.Errorf("cannot get the secret: %w", err)

--- a/pkg/authtoken/token_refresher.go
+++ b/pkg/authtoken/token_refresher.go
@@ -10,22 +10,20 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
-
-	"go.goms.io/fleet/pkg/interfaces"
 )
 
-type RefreshDurationFuncType func(token interfaces.AuthToken) time.Duration
+type RefreshDurationFuncType func(token AuthToken) time.Duration
 type CreateTickerFuncType func(time.Duration) <-chan time.Time
 
 type Refresher struct {
-	provider         interfaces.AuthTokenProvider
-	writer           interfaces.AuthTokenWriter
+	provider         AuthTokenProvider
+	writer           AuthTokenWriter
 	refreshCalculate RefreshDurationFuncType
 	createTicker     CreateTickerFuncType
 }
 
-func NewAuthTokenRefresher(tokenProvider interfaces.AuthTokenProvider,
-	writer interfaces.AuthTokenWriter,
+func NewAuthTokenRefresher(tokenProvider AuthTokenProvider,
+	writer AuthTokenWriter,
 	refreshCalculate RefreshDurationFuncType,
 	createTicker CreateTickerFuncType) *Refresher {
 	return &Refresher{
@@ -37,14 +35,14 @@ func NewAuthTokenRefresher(tokenProvider interfaces.AuthTokenProvider,
 }
 
 var (
-	DefaultRefreshDurationFunc = func(token interfaces.AuthToken) time.Duration {
+	DefaultRefreshDurationFunc = func(token AuthToken) time.Duration {
 		return time.Until(token.ExpiresOn) / 2
 	}
 	DefaultCreateTicker    = time.Tick
 	DefaultRefreshDuration = time.Second * 30
 )
 
-func (at *Refresher) callFetchToken(ctx context.Context) (interfaces.AuthToken, error) {
+func (at *Refresher) callFetchToken(ctx context.Context) (AuthToken, error) {
 	klog.V(2).InfoS("FetchToken start")
 	deadline := time.Now().Add(DefaultRefreshDuration)
 	fetchTokenContext, cancel := context.WithDeadline(ctx, deadline)

--- a/pkg/authtoken/token_refresher.go
+++ b/pkg/authtoken/token_refresher.go
@@ -16,14 +16,14 @@ type RefreshDurationFuncType func(token AuthToken) time.Duration
 type CreateTickerFuncType func(time.Duration) <-chan time.Time
 
 type Refresher struct {
-	provider         AuthTokenProvider
-	writer           AuthTokenWriter
+	provider         Provider
+	writer           Writer
 	refreshCalculate RefreshDurationFuncType
 	createTicker     CreateTickerFuncType
 }
 
-func NewAuthTokenRefresher(tokenProvider AuthTokenProvider,
-	writer AuthTokenWriter,
+func NewAuthTokenRefresher(tokenProvider Provider,
+	writer Writer,
 	refreshCalculate RefreshDurationFuncType,
 	createTicker CreateTickerFuncType) *Refresher {
 	return &Refresher{

--- a/pkg/authtoken/token_refresher_test.go
+++ b/pkg/authtoken/token_refresher_test.go
@@ -12,22 +12,20 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.goms.io/fleet/pkg/interfaces"
 )
 
 type MockAuthTokenProvider struct {
-	Token interfaces.AuthToken
+	Token AuthToken
 }
 
-func (m MockAuthTokenProvider) FetchToken(_ context.Context) (interfaces.AuthToken, error) {
+func (m MockAuthTokenProvider) FetchToken(_ context.Context) (AuthToken, error) {
 	return m.Token, nil
 }
 
 // TestRefreshTokenOnce test to refresh/rewrite token for one time
 func TestRefreshTokenOnce(t *testing.T) {
 	provider := MockAuthTokenProvider{
-		Token: interfaces.AuthToken{
+		Token: AuthToken{
 			Token:     "test token",
 			ExpiresOn: time.Now(),
 		},
@@ -60,7 +58,7 @@ func TestRefreshTokenOnce(t *testing.T) {
 // TestRefreshToken test to refresh/rewrite token multiple times
 func TestRefreshToken(t *testing.T) {
 	provider := MockAuthTokenProvider{
-		Token: interfaces.AuthToken{
+		Token: AuthToken{
 			Token:     "test token",
 			ExpiresOn: time.Now(),
 		},
@@ -99,7 +97,7 @@ func TestRefreshToken(t *testing.T) {
 // TestRefresherCancelContext test if the func will be canceled/returned once the ctx is canceled
 func TestRefresherCancelContext(t *testing.T) {
 	provider := MockAuthTokenProvider{
-		Token: interfaces.AuthToken{
+		Token: AuthToken{
 			Token:     "test token",
 			ExpiresOn: time.Now().Add(100 * time.Millisecond),
 		},

--- a/pkg/authtoken/token_writer.go
+++ b/pkg/authtoken/token_writer.go
@@ -10,8 +10,6 @@ import (
 	"os"
 
 	"k8s.io/klog/v2"
-
-	"go.goms.io/fleet/pkg/interfaces"
 )
 
 type Factory struct {
@@ -34,13 +32,13 @@ type Writer struct {
 	writerFactory func() (io.WriteCloser, error)
 }
 
-func NewWriter(factory func() (io.WriteCloser, error)) interfaces.AuthTokenWriter {
+func NewWriter(factory func() (io.WriteCloser, error)) AuthTokenWriter {
 	return &Writer{
 		writerFactory: factory,
 	}
 }
 
-func (w *Writer) WriteToken(token interfaces.AuthToken) error {
+func (w *Writer) WriteToken(token AuthToken) error {
 	writer, err := w.writerFactory()
 	if err != nil {
 		return err

--- a/pkg/authtoken/token_writer.go
+++ b/pkg/authtoken/token_writer.go
@@ -28,17 +28,17 @@ func (w Factory) Create() (io.WriteCloser, error) {
 	return wc, nil
 }
 
-type Writer struct {
+type TokenWriter struct {
 	writerFactory func() (io.WriteCloser, error)
 }
 
-func NewWriter(factory func() (io.WriteCloser, error)) AuthTokenWriter {
-	return &Writer{
+func NewWriter(factory func() (io.WriteCloser, error)) Writer {
+	return &TokenWriter{
 		writerFactory: factory,
 	}
 }
 
-func (w *Writer) WriteToken(token AuthToken) error {
+func (w *TokenWriter) WriteToken(token AuthToken) error {
 	writer, err := w.writerFactory()
 	if err != nil {
 		return err

--- a/pkg/authtoken/token_writer_test.go
+++ b/pkg/authtoken/token_writer_test.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"go.goms.io/fleet/pkg/interfaces"
 )
 
 type BufferWriterFactory struct {
@@ -43,7 +41,7 @@ func (c BufferWriter) Close() error {
 }
 
 func TestWriteToken(t *testing.T) {
-	token := interfaces.AuthToken{
+	token := AuthToken{
 		Token:     "test token",
 		ExpiresOn: time.Now(),
 	}


### PR DESCRIPTION
### Description of your changes

Move interfaces.go from interfaces to authtoken/providers directory and add missing documentation for type AuthToken struct, AuthTokenProvider interface and AuthTokenWriter interface.

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
