### PR TITLE
feat: drift detection/takeover prerequisite (1/): enable the CRP controller to copy drift/diff details to the status

### DIFF
--- a/pkg/controllers/clusterresourceplacement/placement_status.go
+++ b/pkg/controllers/clusterresourceplacement/placement_status.go
@@ -261,6 +261,8 @@ func (r *Reconciler) setResourcePlacementStatusPerCluster(crp *fleetv1beta1.Clus
 			case condition.AppliedCondition, condition.AvailableCondition:
 				if bindingCond.Status == metav1.ConditionFalse {
 					status.FailedPlacements = binding.Status.FailedPlacements
+					status.DiffedPlacements = binding.Status.DiffedPlacements
+					status.DriftedPlacements = binding.Status.DriftedPlacements
 				}
 			}
 			cond := metav1.Condition{


### PR DESCRIPTION
### Description of your changes

This PR enables the CRP controller to copy drift/diff details as reported in the binding status to the CRP status.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests


### Special notes for your reviewer

Currently drift/diff details are not yet populated.