### PR TITLE
fix: track generate name in the WorkResourceIdentifier

### DIFF
--- a/apis/placement/v1/work_types.go
+++ b/apis/placement/v1/work_types.go
@@ -103,15 +103,19 @@ type WorkResourceIdentifier struct {
 	// Kind is the kind of the resource.
 	Kind string `json:"kind,omitempty"`
 
-	// Resource is the resource type of the resource
+	// Resource is the resource type of the resource.
 	Resource string `json:"resource,omitempty"`
 
 	// Namespace is the namespace of the resource, the resource is cluster scoped if the value
-	// is empty
+	// is empty.
 	Namespace string `json:"namespace,omitempty"`
 
-	// Name is the name of the resource
+	// Name is the name of the resource.
 	Name string `json:"name,omitempty"`
+
+	// GenerateName is the generate name of the resource. This field will be populated if the
+	// object to place has a generate name only.
+	GenerateName string `json:"generateName,omitempty"`
 }
 
 // ManifestCondition represents the conditions of the resources deployed on

--- a/config/crd/bases/placement.kubernetes-fleet.io_appliedworks.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_appliedworks.yaml
@@ -78,6 +78,11 @@ spec:
                     AppliedResourceMeta represents the group, version, resource, name and namespace of a resource.
                     Since these resources have been created, they must have valid group, version, resource, namespace, and name.
                   properties:
+                    generateName:
+                      description: |-
+                        GenerateName is the generate name of the resource. This field will be populated if the
+                        object to place has a generate name only.
+                      type: string
                     group:
                       description: Group is the group of the resource.
                       type: string
@@ -85,12 +90,12 @@ spec:
                       description: Kind is the kind of the resource.
                       type: string
                     name:
-                      description: Name is the name of the resource
+                      description: Name is the name of the resource.
                       type: string
                     namespace:
                       description: |-
                         Namespace is the namespace of the resource, the resource is cluster scoped if the value
-                        is empty
+                        is empty.
                       type: string
                     ordinal:
                       description: |-
@@ -98,7 +103,7 @@ spec:
                         to a manifest even though manifest cannot be parsed successfully.
                       type: integer
                     resource:
-                      description: Resource is the resource type of the resource
+                      description: Resource is the resource type of the resource.
                       type: string
                     uid:
                       description: |-

--- a/config/crd/bases/placement.kubernetes-fleet.io_works.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_works.yaml
@@ -266,6 +266,11 @@ spec:
                       description: resourceId represents a identity of a resource
                         linking to manifests in spec.
                       properties:
+                        generateName:
+                          description: |-
+                            GenerateName is the generate name of the resource. This field will be populated if the
+                            object to place has a generate name only.
+                          type: string
                         group:
                           description: Group is the group of the resource.
                           type: string
@@ -273,12 +278,12 @@ spec:
                           description: Kind is the kind of the resource.
                           type: string
                         name:
-                          description: Name is the name of the resource
+                          description: Name is the name of the resource.
                           type: string
                         namespace:
                           description: |-
                             Namespace is the namespace of the resource, the resource is cluster scoped if the value
-                            is empty
+                            is empty.
                           type: string
                         ordinal:
                           description: |-
@@ -286,7 +291,7 @@ spec:
                             to a manifest even though manifest cannot be parsed successfully.
                           type: integer
                         resource:
-                          description: Resource is the resource type of the resource
+                          description: Resource is the resource type of the resource.
                           type: string
                         version:
                           description: Version is the version of the resource.


### PR DESCRIPTION
### Description of your changes

This API change is a prerequisite for Fleet to fix the issue where objects with generate names cannot be applied correctly.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

API change only; currently the field is not yet populated.