### PR TITLE
fix: remove VnetName check from common cloudConfig package

### DIFF
--- a/pkg/utils/cloudconfig/azure/config.go
+++ b/pkg/utils/cloudconfig/azure/config.go
@@ -88,10 +88,6 @@ func (cfg *CloudConfig) validate() error {
 		return fmt.Errorf("resource group is empty")
 	}
 
-	if cfg.UserAgent == "fleet-member-agent" && cfg.VnetName == "" {
-		return fmt.Errorf("virtual network name is empty")
-	}
-
 	if cfg.VnetResourceGroup == "" {
 		cfg.VnetResourceGroup = cfg.ResourceGroup
 	}

--- a/pkg/utils/cloudconfig/azure/config.go
+++ b/pkg/utils/cloudconfig/azure/config.go
@@ -88,8 +88,8 @@ func (cfg *CloudConfig) validate() error {
 		return fmt.Errorf("resource group is empty")
 	}
 
-	if cfg.VnetName == "" {
-		return fmt.Errorf("virtual network name is empty")
+	if cfg.UserAgent == "fleet-member-agent" && cfg.VnetName == "" {
+		return fmt.Errorf("vnet name is empty")
 	}
 
 	if cfg.VnetResourceGroup == "" {

--- a/pkg/utils/cloudconfig/azure/config.go
+++ b/pkg/utils/cloudconfig/azure/config.go
@@ -89,7 +89,7 @@ func (cfg *CloudConfig) validate() error {
 	}
 
 	if cfg.UserAgent == "fleet-member-agent" && cfg.VnetName == "" {
-		return fmt.Errorf("vnet name is empty")
+		return fmt.Errorf("virtual network name is empty")
 	}
 
 	if cfg.VnetResourceGroup == "" {

--- a/pkg/utils/cloudconfig/azure/config_test.go
+++ b/pkg/utils/cloudconfig/azure/config_test.go
@@ -133,23 +133,6 @@ func TestValidate(t *testing.T) {
 			},
 			wantPass: false,
 		},
-		"VnetName empty": {
-			config: &CloudConfig{
-				ARMClientConfig: azclient.ARMClientConfig{
-					Cloud:     "c",
-					UserAgent: "fleet-member-agent",
-				},
-				AzureAuthConfig: azclient.AzureAuthConfig{
-					UseManagedIdentityExtension: true,
-					UserAssignedIdentityID:      "a",
-				},
-				Location:       "l",
-				SubscriptionID: "s",
-				ResourceGroup:  "v",
-				VnetName:       "",
-			},
-			wantPass: false,
-		},
 		"VnetResourceGroup empty": {
 			config: &CloudConfig{
 				ARMClientConfig: azclient.ARMClientConfig{

--- a/pkg/utils/cloudconfig/azure/config_test.go
+++ b/pkg/utils/cloudconfig/azure/config_test.go
@@ -136,7 +136,8 @@ func TestValidate(t *testing.T) {
 		"VnetName empty": {
 			config: &CloudConfig{
 				ARMClientConfig: azclient.ARMClientConfig{
-					Cloud: "c",
+					Cloud:     "c",
+					UserAgent: "fleet-member-agent",
 				},
 				AzureAuthConfig: azclient.AzureAuthConfig{
 					UseManagedIdentityExtension: true,
@@ -559,8 +560,9 @@ func TestNewCloudConfigFromFile(t *testing.T) {
 			filePath: "./test/azure_valid_config.json",
 			wantConfig: &CloudConfig{
 				ARMClientConfig: azclient.ARMClientConfig{
-					Cloud:    "AzurePublicCloud",
-					TenantID: "00000000-0000-0000-0000-000000000000",
+					Cloud:     "AzurePublicCloud",
+					TenantID:  "00000000-0000-0000-0000-000000000000",
+					UserAgent: "fleet-member-agent",
 				},
 				AzureAuthConfig: azclient.AzureAuthConfig{
 					UseManagedIdentityExtension: true,

--- a/pkg/utils/cloudconfig/azure/test/azure_valid_config.json
+++ b/pkg/utils/cloudconfig/azure/test/azure_valid_config.json
@@ -1,5 +1,6 @@
 {
   "cloud": "AzurePublicCloud",
+  "userAgent": "fleet-member-agent",
   "tenantId": "00000000-0000-0000-0000-000000000000",
   "subscriptionId": "00000000-0000-0000-0000-000000000000",
   "useManagedIdentityExtension": true,

--- a/test/e2e/azure_valid_config.yaml
+++ b/test/e2e/azure_valid_config.yaml
@@ -1,6 +1,7 @@
 config:
   azureCloudConfig:
     cloud: "AzurePublicCloud"
+    userAgent: "fleet-member-agent"
     tenantId: "00000000-0000-0000-0000-000000000000"
     subscriptionId: "00000000-0000-0000-0000-000000000000"
     useManagedIdentityExtension: true


### PR DESCRIPTION
### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have: remove `VnetName` check from common package. This is so that the `VnetName` is not required on fleet-networking repo.

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

Will add check to another PR where I load the cloudConfig.
