### PR TITLE
feat: support placement field in the override

### DIFF
--- a/pkg/utils/overrider/overrider.go
+++ b/pkg/utils/overrider/overrider.go
@@ -107,7 +107,7 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 	for i := range croList.Items {
 		placementInOverride := croList.Items[i].Spec.OverrideSpec.Placement
 		if placementInOverride != nil && placementInOverride.Name != crp {
-			klog.V(2).InfoS("Skipping this override which was created for another placement", "clusterResourceOverride", klog.KObj(&croList.Items[i]), "placementInOverride", placementInOverride, "clusterResourcePlacement", crp)
+			klog.V(2).InfoS("Skipping this override which was created for another placement", "clusterResourceOverride", klog.KObj(&croList.Items[i]), "placementInOverride", placementInOverride.Name, "clusterResourcePlacement", crp)
 			continue
 		}
 
@@ -127,7 +127,7 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 	for i := range roList.Items {
 		placementInOverride := roList.Items[i].Spec.OverrideSpec.Placement
 		if placementInOverride != nil && placementInOverride.Name != crp {
-			klog.V(2).InfoS("Skipping this override which was created for another placement", "resourceOverride", klog.KObj(&roList.Items[i]), "placementInOverride", placementInOverride, "clusterResourcePlacement", crp)
+			klog.V(2).InfoS("Skipping this override which was created for another placement", "resourceOverride", klog.KObj(&roList.Items[i]), "placementInOverride", placementInOverride.Name, "clusterResourcePlacement", crp)
 			continue
 		}
 

--- a/pkg/utils/overrider/overrider.go
+++ b/pkg/utils/overrider/overrider.go
@@ -30,6 +30,7 @@ import (
 )
 
 // FetchAllMatchingOverridesForResourceSnapshot fetches all the matching overrides which are attached to the selected resources.
+// TODO: to improve the performance, we can add the index on the placement field of the override snapshots.
 func FetchAllMatchingOverridesForResourceSnapshot(
 	ctx context.Context,
 	c client.Client,
@@ -104,6 +105,12 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 	filteredCRO := make([]*placementv1alpha1.ClusterResourceOverrideSnapshot, 0, len(croList.Items))
 	filteredRO := make([]*placementv1alpha1.ResourceOverrideSnapshot, 0, len(roList.Items))
 	for i := range croList.Items {
+		placementInOverride := croList.Items[i].Spec.OverrideSpec.Placement
+		if placementInOverride != nil && placementInOverride.Name != crp {
+			klog.V(2).InfoS("Skipping this override which was created for another placement", "clusterResourceOverride", klog.KObj(&croList.Items[i]), "placementInOverride", placementInOverride, "clusterResourcePlacement", crp)
+			continue
+		}
+
 		for _, selector := range croList.Items[i].Spec.OverrideSpec.ClusterResourceSelectors {
 			croKey := placementv1beta1.ResourceIdentifier{
 				Group:   selector.Group,
@@ -118,6 +125,12 @@ func FetchAllMatchingOverridesForResourceSnapshot(
 		}
 	}
 	for i := range roList.Items {
+		placementInOverride := roList.Items[i].Spec.OverrideSpec.Placement
+		if placementInOverride != nil && placementInOverride.Name != crp {
+			klog.V(2).InfoS("Skipping this override which was created for another placement", "resourceOverride", klog.KObj(&roList.Items[i]), "placementInOverride", placementInOverride, "clusterResourcePlacement", crp)
+			continue
+		}
+
 		for _, selector := range roList.Items[i].Spec.OverrideSpec.ResourceSelectors {
 			roKey := placementv1beta1.ResourceIdentifier{
 				Group:     selector.Group,


### PR DESCRIPTION
### Description of your changes
Filter out when the override is not configured for the target placement when rolling out the resources

Fixes #

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

added unit test


### Special notes for your reviewer

Watching the override snapshot resources in the rollout controller will be in a separate PR
