### PR TITLE
fix: fix empty WorkCreated status in clusterResourceBindings

### DIFF
--- a/apis/cluster/v1beta1/zz_generated.deepcopy.go
+++ b/apis/cluster/v1beta1/zz_generated.deepcopy.go
@@ -10,7 +10,7 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/apis/placement/v1/binding_types.go
+++ b/apis/placement/v1/binding_types.go
@@ -13,7 +13,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,categories={fleet,fleet-placement},shortName=rb
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Bound")].status`,name="WorkCreated",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="WorkSynchronized")].status`,name="WorkCreated",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Applied")].status`,name="ResourcesApplied",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 

--- a/apis/placement/v1beta1/binding_types.go
+++ b/apis/placement/v1beta1/binding_types.go
@@ -20,7 +20,7 @@ const (
 // +kubebuilder:resource:scope=Cluster,categories={fleet,fleet-placement},shortName=rb
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
-// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Bound")].status`,name="WorkCreated",type=string
+// +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="WorkSynchronized")].status`,name="WorkCreated",type=string
 // +kubebuilder:printcolumn:JSONPath=`.status.conditions[?(@.type=="Applied")].status`,name="ResourcesApplied",type=string
 // +kubebuilder:printcolumn:JSONPath=`.metadata.creationTimestamp`,name="Age",type=date
 

--- a/apis/placement/v1beta1/zz_generated.deepcopy.go
+++ b/apis/placement/v1beta1/zz_generated.deepcopy.go
@@ -10,7 +10,7 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -11,7 +11,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterresourcebindings.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterresourcebindings.yaml
@@ -20,7 +20,7 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Bound")].status
+    - jsonPath: .status.conditions[?(@.type=="WorkSynchronized")].status
       name: WorkCreated
       type: string
     - jsonPath: .status.conditions[?(@.type=="Applied")].status
@@ -387,7 +387,7 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Bound")].status
+    - jsonPath: .status.conditions[?(@.type=="WorkSynchronized")].status
       name: WorkCreated
       type: string
     - jsonPath: .status.conditions[?(@.type=="Applied")].status

--- a/test/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/test/apis/v1alpha1/zz_generated.deepcopy.go
@@ -10,7 +10,7 @@ Licensed under the MIT license.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
### Description of your changes
Fix empty "WORKCREATED" status when getting clusterResourceBindings:
```
NAME                          WORKCREATED   RESOURCESAPPLIED   AGE
example-placement-member1-***               True               2d22h
```
<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
After the fix:
<img width="686" alt="image" src="https://github.com/user-attachments/assets/60c05079-43a8-4be2-8125-c7247d82df2d" />

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
