### PR TITLE
feat: enable clusterStagedUpdateRun controller

### DIFF
--- a/apis/placement/v1alpha1/common.go
+++ b/apis/placement/v1alpha1/common.go
@@ -12,8 +12,17 @@ const (
 	// ResourceOverrideKind is the kind of the ResourceOverride.
 	ResourceOverrideKind = "ResourceOverride"
 
-	// ResourceOverrideSnapshotKind is the kind of the ResourceOverrideSnapshotKind.
+	// ResourceOverrideSnapshotKind is the kind of the ResourceOverrideSnapshot.
 	ResourceOverrideSnapshotKind = "ResourceOverrideSnapshot"
+
+	// ClusterStagedUpdateRunKind is the kind of the ClusterStagedUpdateRun.
+	ClusterStagedUpdateRunKind = "ClusterStagedUpdateRun"
+
+	// ClusterStagedUpdateStrategyKind is the kind of the ClusterStagedUpdateStrategy.
+	ClusterStagedUpdateStrategyKind = "ClusterStagedUpdateStrategy"
+
+	// ClusterApprovalRequestKind is the kind of the ClusterApprovalRequest.
+	ClusterApprovalRequestKind = "ClusterApprovalRequest"
 
 	// ClusterStagedUpdateRunFinalizer is used by the ClusterStagedUpdateRun controller to make sure that the ClusterStagedUpdateRun
 	// object is not deleted until all its dependent resources are deleted.

--- a/charts/hub-agent/templates/deployment.yaml
+++ b/charts/hub-agent/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
             - --enable-v1alpha1-apis={{ .Values.enableV1Alpha1APIs }}
             - --enable-v1beta1-apis={{ .Values.enableV1Beta1APIs }}
             - --enable-cluster-inventory-apis={{ .Values.enableClusterInventoryAPI }}
+            - --enable-staged-update-run-apis={{ .Values.enableStagedUpdateRunAPIs }}
             - --max-concurrent-cluster-placement={{ .Values.MaxConcurrentClusterPlacement }}
             - --concurrent-resource-change-syncs={{ .Values.ConcurrentResourceChangeSyncs }}
             - --log_file_max_size={{ .Values.logFileMaxSize }}

--- a/charts/hub-agent/values.yaml
+++ b/charts/hub-agent/values.yaml
@@ -36,6 +36,7 @@ affinity: {}
 enableV1Alpha1APIs: false
 enableV1Beta1APIs: true
 enableClusterInventoryAPI: true
+enableStagedUpdateRunAPIs: true
 
 hubAPIQPS: 250
 hubAPIBurst: 1000

--- a/cmd/hubagent/options/options.go
+++ b/cmd/hubagent/options/options.go
@@ -83,6 +83,8 @@ type Options struct {
 	EnableClusterInventoryAPIs bool
 	// ForceDeleteWaitTime is the duration the hub agent waits before force deleting a member cluster.
 	ForceDeleteWaitTime metav1.Duration
+	// EnableStagedUpdateRunAPIs enables the agents to watch the clusterStagedUpdateRun CRs.
+	EnableStagedUpdateRunAPIs bool
 }
 
 // NewOptions builds an empty options.
@@ -99,6 +101,7 @@ func NewOptions() *Options {
 		MaxFleetSizeSupported:         100,
 		EnableV1Alpha1APIs:            false,
 		EnableClusterInventoryAPIs:    false,
+		EnableStagedUpdateRunAPIs:     false,
 	}
 }
 
@@ -140,6 +143,7 @@ func (o *Options) AddFlags(flags *flag.FlagSet) {
 	flags.BoolVar(&o.EnableV1Beta1APIs, "enable-v1beta1-apis", true, "If set, the agents will watch for the v1beta1 APIs.")
 	flags.BoolVar(&o.EnableClusterInventoryAPIs, "enable-cluster-inventory-apis", false, "If set, the agents will watch for the ClusterInventory APIs.")
 	flags.DurationVar(&o.ForceDeleteWaitTime.Duration, "force-delete-wait-time", 15*time.Minute, "The duration the hub agent waits before force deleting a member cluster.")
+	flags.BoolVar(&o.EnableStagedUpdateRunAPIs, "enable-staged-update-run-apis", false, "If set, the agents will watch for the ClusterStagedUpdateRun APIs.")
 
 	o.RateLimiterOpts.AddFlags(flags)
 }

--- a/examples/stagedupdaterun/clusterStagedUpdateRun.yaml
+++ b/examples/stagedupdaterun/clusterStagedUpdateRun.yaml
@@ -4,10 +4,10 @@ metadata:
   name: example-run
 spec:
   placementName: example-placement
-  resourceSnapshotIndex: "1"
+  resourceSnapshotIndex: example-placement-0-snapshot
   stagedRolloutStrategyName: example-strategy
 status:
-  policySnapshotIndexUsed: "1"
+  policySnapshotIndexUsed: example-placement-0
   policyObservedClusterCount: 3
   appliedStrategy:
     type: Immediate

--- a/pkg/controllers/updaterun/controller.go
+++ b/pkg/controllers/updaterun/controller.go
@@ -133,7 +133,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 	// Execute the updateRun.
 	klog.V(2).InfoS("Continue to execute the clusterStagedUpdateRun", "updatingStageIndex", updatingStageIndex, "clusterStagedUpdateRun", runObjRef)
 	finished, waitTime, execErr := r.execute(ctx, &updateRun, updatingStageIndex, toBeUpdatedBindings, toBeDeletedBindings)
-	if execErr != nil && errors.Is(execErr, errStagedUpdatedAborted) {
+	if errors.Is(execErr, errStagedUpdatedAborted) {
 		// errStagedUpdatedAborted cannot be retried.
 		return runtime.Result{}, r.recordUpdateRunFailed(ctx, &updateRun, execErr.Error())
 	}

--- a/pkg/controllers/updaterun/controller_integration_test.go
+++ b/pkg/controllers/updaterun/controller_integration_test.go
@@ -268,7 +268,7 @@ func generateTestClusterSchedulingPolicySnapshot(idx int) *placementv1beta1.Clus
 	}
 }
 
-func generateTestClusterResourceBinding(policySnapshotName, targetCluster string) *placementv1beta1.ClusterResourceBinding {
+func generateTestClusterResourceBinding(policySnapshotName, targetCluster string, state placementv1beta1.BindingState) *placementv1beta1.ClusterResourceBinding {
 	binding := &placementv1beta1.ClusterResourceBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "binding-" + testResourceSnapshotName + "-" + targetCluster,
@@ -277,7 +277,7 @@ func generateTestClusterResourceBinding(policySnapshotName, targetCluster string
 			},
 		},
 		Spec: placementv1beta1.ResourceBindingSpec{
-			State:                        placementv1beta1.BindingStateScheduled,
+			State:                        state,
 			TargetCluster:                targetCluster,
 			SchedulingPolicySnapshotName: policySnapshotName,
 		},

--- a/pkg/controllers/updaterun/validation_integration_test.go
+++ b/pkg/controllers/updaterun/validation_integration_test.go
@@ -63,14 +63,14 @@ var _ = Describe("UpdateRun validation tests", func() {
 			}
 			// reserse the order of the clusters by index
 			targetClusters[i] = generateTestMemberCluster(numTargetClusters-1-i, "cluster-"+strconv.Itoa(i), map[string]string{"group": "prod", "region": region})
-			resourceBindings[i] = generateTestClusterResourceBinding(policySnapshot.Name, targetClusters[i].Name)
+			resourceBindings[i] = generateTestClusterResourceBinding(policySnapshot.Name, targetClusters[i].Name, placementv1beta1.BindingStateBound)
 		}
 
 		unscheduledCluster = make([]*clusterv1beta1.MemberCluster, numUnscheduledClusters)
 		for i := range unscheduledCluster {
 			unscheduledCluster[i] = generateTestMemberCluster(i, "unscheduled-cluster-"+strconv.Itoa(i), map[string]string{"group": "staging"})
 			// update the policySnapshot name so that these clusters are considered to-be-deleted
-			resourceBindings[numTargetClusters+i] = generateTestClusterResourceBinding(policySnapshot.Name+"a", unscheduledCluster[i].Name)
+			resourceBindings[numTargetClusters+i] = generateTestClusterResourceBinding(policySnapshot.Name+"a", unscheduledCluster[i].Name, placementv1beta1.BindingStateUnscheduled)
 		}
 
 		var err error


### PR DESCRIPTION
### Description of your changes
Add the flag and conditionally enable the `clusterStagedUpdateRun` controller.

Fix a bug found during testing: the updateRun controller need to add `rolloutStarted` condition to binding too for the workgenerator to continue.
 
Also add an additional check during initialization to make sure a binding with old policyschedulingsnapshot is expected to be in `Unscheduled` state.

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
