### PR TITLE
fix: fix stagedUpdateRun PolicyObservedClusterCount

### DIFF
--- a/pkg/controllers/updaterun/execution_integration_test.go
+++ b/pkg/controllers/updaterun/execution_integration_test.go
@@ -283,7 +283,8 @@ var _ = Describe("UpdateRun execution tests", func() {
 			waitEndTime := meta.FindStatusCondition(updateRun.Status.StagesStatus[0].AfterStageTaskStatus[0].Conditions, string(placementv1beta1.AfterStageTaskConditionWaitTimeElapsed)).LastTransitionTime.Time
 			// In this test, I set wait time to be 4 seconds, while stageClusterUpdatingWaitTime is 3 seconds.
 			// So it needs 2 rounds of reconcile to wait for the waitTime to elapse, waitEndTime - waitStartTime should be around 6 seconds.
-			Expect(waitStartTime.Add(updateStrategy.Spec.Stages[0].AfterStageTasks[0].WaitTime.Duration).Before(waitEndTime)).Should(BeTrue())
+			Expect(waitStartTime.Add(updateStrategy.Spec.Stages[0].AfterStageTasks[0].WaitTime.Duration).Before(waitEndTime)).Should(BeTrue(),
+				fmt.Sprintf("waitEndTime %v did not pass waitStartTime %v long enough, want at least %v", waitEndTime, waitStartTime, updateStrategy.Spec.Stages[0].AfterStageTasks[0].WaitTime.Duration))
 		})
 
 		It("Should mark the 1st cluster in the 2nd stage as succeeded after marking the binding available", func() {

--- a/pkg/controllers/updaterun/validation_integration_test.go
+++ b/pkg/controllers/updaterun/validation_integration_test.go
@@ -333,12 +333,13 @@ var _ = Describe("UpdateRun validation tests", func() {
 		})
 
 		It("Should fail to validate if the number of clusters has changed in a stage", func() {
-			By("Deleting a cluster resource binding")
-			Expect(k8sClient.Delete(ctx, resourceBindings[0])).Should(Succeed())
+			By("Changing 1st cluster's so that it's selected by the 1st stage")
+			targetClusters[0].Labels["region"] = regionEastus
+			Expect(k8sClient.Update(ctx, targetClusters[0])).Should(Succeed())
 
 			By("Validating the validation failed")
 			wantStatus = generateFailedValidationStatus(updateRun, wantStatus)
-			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "the number of clusters in index `1` stage has changed")
+			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "the number of clusters in index `0` stage has changed")
 		})
 
 		It("Should fail to validate if the cluster name has changed in a stage", func() {


### PR DESCRIPTION
### Description of your changes
1. When scheduling policy is PickAll, we update PolicyObservedClusterCount to the number of scheduled/bound clusterResourceBindings, instead of -1. For PickFix and PickN, we validate if the number of bindings match the expected count.
2. Add more output in one of the integration test to help debugging UT flakes.

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
