### PR TITLE
test: fix the resource override webhook logic and fix related flaky e2e

### DIFF
--- a/pkg/utils/validator/resourceoverride.go
+++ b/pkg/utils/validator/resourceoverride.go
@@ -92,11 +92,11 @@ func validateOverridePolicy(policy *fleetv1alpha1.OverridePolicy) error {
 			for _, selector := range rule.ClusterSelector.ClusterSelectorTerms {
 				// Check that only label selector is supported
 				if selector.PropertySelector != nil || selector.PropertySorter != nil {
-					allErr = append(allErr, fmt.Errorf("invalid clusterSelector %v: only labelSelector is supported", selector))
+					allErr = append(allErr, fmt.Errorf("invalid clusterSelector %+v: only labelSelector is supported", selector))
 					continue
 				}
 				if selector.LabelSelector == nil {
-					allErr = append(allErr, fmt.Errorf("invalid clusterSelector %v: labelSelector is required", selector))
+					allErr = append(allErr, fmt.Errorf("invalid clusterSelector %+v: labelSelector is required", selector))
 				} else if err := validateLabelSelector(selector.LabelSelector, "cluster selector"); err != nil {
 					allErr = append(allErr, err)
 				}

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -1197,47 +1197,39 @@ var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered
 	})
 
 	It("should deny update RO with invalid resource override", func() {
-		Eventually(func(g Gomega) error {
-			By("creating a new resource override")
-			ro1 := &placementv1alpha1.ResourceOverride{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("test-ro-%d", GinkgoParallelProcess()),
-					Namespace: roNamespace,
-				},
-				Spec: placementv1alpha1.ResourceOverrideSpec{
-					ResourceSelectors: []placementv1alpha1.ResourceSelector{
+		newSelector := placementv1alpha1.ResourceSelector{
+			Group:   "apps",
+			Kind:    "Deployment",
+			Version: "v1",
+			Name:    "test-deployment-x",
+		}
+		ro1 := &placementv1alpha1.ResourceOverride{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("test-ro-%d", GinkgoParallelProcess()),
+				Namespace: roNamespace,
+			},
+			Spec: placementv1alpha1.ResourceOverrideSpec{
+				Policy: &placementv1alpha1.OverridePolicy{
+					OverrideRules: []placementv1alpha1.OverrideRule{
 						{
-							Group:   "apps",
-							Kind:    "Deployment",
-							Version: "v1",
-							Name:    "test-deployment-1",
-						},
-					},
-					Policy: &placementv1alpha1.OverridePolicy{
-						OverrideRules: []placementv1alpha1.OverrideRule{
-							{
-								ClusterSelector: nil,
-								JSONPatchOverrides: []placementv1alpha1.JSONPatchOverride{
-									{
-										Operator: placementv1alpha1.JSONPatchOverrideOpRemove,
-										Path:     "/meta/labels/test-key",
-									},
+							ClusterSelector: nil,
+							JSONPatchOverrides: []placementv1alpha1.JSONPatchOverride{
+								{
+									Operator: placementv1alpha1.JSONPatchOverrideOpRemove,
+									Path:     "/meta/labels/test-key",
 								},
 							},
 						},
 					},
 				},
-			}
-			Expect(hubClient.Create(ctx, ro1)).To(Succeed(), "Failed to create RO %s", ro1.Name)
-
+			},
+		}
+		ro1.Spec.ResourceSelectors = append(ro1.Spec.ResourceSelectors, newSelector)
+		By("creating a new resource override")
+		Expect(hubClient.Create(ctx, ro1)).To(Succeed(), "Failed to create RO %s", ro1.Name)
+		Eventually(func(g Gomega) error {
 			var ro placementv1alpha1.ResourceOverride
 			g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: roName, Namespace: roNamespace}, &ro)).Should(Succeed())
-			newSelector := placementv1alpha1.ResourceSelector{
-				Group:   "apps",
-				Kind:    "Deployment",
-				Version: "v1",
-				Name:    fmt.Sprintf("test-deployment-%d", 1),
-			}
 			ro.Spec.ResourceSelectors = append(ro.Spec.ResourceSelectors, newSelector)
 			clusterSelectorTerm := placementv1beta1.ClusterSelectorTerm{
 				PropertySelector: &placementv1beta1.PropertySelector{


### PR DESCRIPTION
### Description of your changes

1 fix the resource webhook logic that didn't filter by the namespace
2. fix related flaky e2e ( https://github.com/Azure/fleet/actions/runs/12775197652/job/35611032906) which is caused by the cached list in the webhook

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
