### PR TITLE
feat: watch for drift/diff reportings in the CRB watcher

### DIFF
--- a/apis/placement/v1beta1/zz_generated.deepcopy.go
+++ b/apis/placement/v1beta1/zz_generated.deepcopy.go
@@ -10,7 +10,7 @@ Licensed under the MIT license.
 package v1beta1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )

--- a/pkg/controllers/clusterresourcebindingwatcher/watcher.go
+++ b/pkg/controllers/clusterresourcebindingwatcher/watcher.go
@@ -115,14 +115,23 @@ func isBindingStatusUpdated(oldBinding, newBinding *fleetv1beta1.ClusterResource
 		oldCond := oldBinding.GetCondition(string(i.ResourceBindingConditionType()))
 		newCond := newBinding.GetCondition(string(i.ResourceBindingConditionType()))
 		if !condition.EqualCondition(oldCond, newCond) {
-			klog.V(2).InfoS("The binding condition has changed, need to update the corresponding CRP", "oldBinding", klog.KObj(oldBinding), "newBinding", klog.KObj(newBinding), "type", i.ResourceBindingConditionType())
+			klog.V(2).InfoS("The binding status conditions have changed, need to refresh the CRP status", "binding", klog.KObj(oldBinding), "type", i.ResourceBindingConditionType())
 			return true
 		}
 	}
 	if !utils.IsFailedResourcePlacementsEqual(oldBinding.Status.FailedPlacements, newBinding.Status.FailedPlacements) {
-		klog.V(2).InfoS("The binding failed placement has changed, need to update the corresponding CRP", "oldBinding", klog.KObj(oldBinding), "newBinding", klog.KObj(newBinding))
+		klog.V(2).InfoS("Failed placements reported on the binding status has changed, need to refresh the CRP status", "binding", klog.KObj(oldBinding))
 		return true
 	}
-	klog.V(5).InfoS("The binding status has not changed, no need to update the corresponding CRP", "oldBinding", klog.KObj(oldBinding), "newBinding", klog.KObj(newBinding))
+	if !utils.IsDriftedResourcePlacementsEqual(oldBinding.Status.DriftedPlacements, newBinding.Status.DriftedPlacements) {
+		klog.V(2).InfoS("Drifted placements reported on the binding status has changed, need to refresh the CRP status", "binding", klog.KObj(oldBinding))
+		return true
+	}
+	if !utils.IsDiffedResourcePlacementsEqual(oldBinding.Status.DiffedPlacements, newBinding.Status.DiffedPlacements) {
+		klog.V(2).InfoS("Diffed placements reported on the binding status has changed, need to refresh the CRP status", "binding", klog.KObj(oldBinding))
+		return true
+	}
+
+	klog.V(5).InfoS("The binding status has not changed, no need to refresh the CRP status", "binding", klog.KObj(oldBinding))
 	return false
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -597,6 +597,30 @@ var LessFuncDriftedResourcePlacements = func(a, b placementv1beta1.DriftedResour
 	return aStr < bStr
 }
 
+// IsDriftedResourcePlacementsEqual returns true if the two set of drifted resource placements are equal.
+func IsDriftedResourcePlacementsEqual(oldDriftedResourcePlacements, newDriftedResourcePlacements []placementv1beta1.DriftedResourcePlacement) bool {
+	if len(oldDriftedResourcePlacements) != len(newDriftedResourcePlacements) {
+		return false
+	}
+	sort.Slice(oldDriftedResourcePlacements, func(i, j int) bool {
+		return LessFuncDriftedResourcePlacements(oldDriftedResourcePlacements[i], oldDriftedResourcePlacements[j])
+	})
+	sort.Slice(newDriftedResourcePlacements, func(i, j int) bool {
+		return LessFuncDriftedResourcePlacements(newDriftedResourcePlacements[i], newDriftedResourcePlacements[j])
+	})
+	for i := range oldDriftedResourcePlacements {
+		oldDriftedResourcePlacement := oldDriftedResourcePlacements[i]
+		newDriftedResourcePlacement := newDriftedResourcePlacements[i]
+
+		// Note that here Fleet will not attempt to sort the ObservedDrifts slice as it yields no
+		// performance benefits; ObservedDrifts changes are always paired with ObservationTime changes.
+		if !equality.Semantic.DeepEqual(oldDriftedResourcePlacement, newDriftedResourcePlacement) {
+			return false
+		}
+	}
+	return true
+}
+
 // LessFuncDiffedResourcePlacements is a less function for sorting drifted resource placements
 var LessFuncDiffedResourcePlacements = func(a, b placementv1beta1.DiffedResourcePlacement) bool {
 	var aStr, bStr string
@@ -612,6 +636,29 @@ var LessFuncDiffedResourcePlacements = func(a, b placementv1beta1.DiffedResource
 
 	}
 	return aStr < bStr
+}
+
+// IsDiffedResourcePlacementsEqual returns true if the two sets of diffed resource placements are equal.
+func IsDiffedResourcePlacementsEqual(oldDiffedResourcePlacements, newDiffedResourcePlacements []placementv1beta1.DiffedResourcePlacement) bool {
+	if len(oldDiffedResourcePlacements) != len(newDiffedResourcePlacements) {
+		return false
+	}
+	sort.Slice(oldDiffedResourcePlacements, func(i, j int) bool {
+		return LessFuncDiffedResourcePlacements(oldDiffedResourcePlacements[i], oldDiffedResourcePlacements[j])
+	})
+	sort.Slice(newDiffedResourcePlacements, func(i, j int) bool {
+		return LessFuncDiffedResourcePlacements(newDiffedResourcePlacements[i], newDiffedResourcePlacements[j])
+	})
+	for i := range oldDiffedResourcePlacements {
+		oldDiffedResourcePlacement := oldDiffedResourcePlacements[i]
+		newDiffedResourcePlacement := newDiffedResourcePlacements[i]
+		// Note that here Fleet will not attempt to sort the ObservedDiffs slice as it yields no
+		// performance benefits; ObservedDiffs changes are always paired with ObservationTime changes.
+		if !equality.Semantic.DeepEqual(oldDiffedResourcePlacement, newDiffedResourcePlacement) {
+			return false
+		}
+	}
+	return true
 }
 
 // IsFleetAnnotationPresent returns true if a key with fleet prefix is present in the annotations map.

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 )
@@ -616,6 +617,574 @@ func TestIsFailedResourcePlacementsEqual(t *testing.T) {
 			got := IsFailedResourcePlacementsEqual(tc.old, tc.new)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("IsFailedResourcePlacementsEqual() status mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestIsDriftedResourcePlacementsEqual tests the IsDriftedResourcePlacementsEqual function.
+func TestIsDriftedResourcePlacementsEqual(t *testing.T) {
+	now := metav1.Now()
+
+	testCases := []struct {
+		name   string
+		oldDRP []fleetv1beta1.DriftedResourcePlacement
+		newDRP []fleetv1beta1.DriftedResourcePlacement
+		want   bool
+	}{
+		{
+			name:   "two empty slices",
+			oldDRP: []fleetv1beta1.DriftedResourcePlacement{},
+			newDRP: []fleetv1beta1.DriftedResourcePlacement{},
+			want:   true,
+		},
+		{
+			name:   "old is nil, new is empty",
+			oldDRP: nil,
+			newDRP: []fleetv1beta1.DriftedResourcePlacement{},
+			want:   true,
+		},
+		{
+			name:   "old is empty, new is nil",
+			oldDRP: []fleetv1beta1.DriftedResourcePlacement{},
+			newDRP: nil,
+			want:   true,
+		},
+		{
+			name: "different length",
+			oldDRP: []fleetv1beta1.DriftedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+			},
+			newDRP: []fleetv1beta1.DriftedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "same list, different order",
+			oldDRP: []fleetv1beta1.DriftedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+			newDRP: []fleetv1beta1.DriftedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "same list, same order",
+			oldDRP: []fleetv1beta1.DriftedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+			newDRP: []fleetv1beta1.DriftedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "drift info updated",
+			oldDRP: []fleetv1beta1.DriftedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+			newDRP: []fleetv1beta1.DriftedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 metav1.Now(),
+					FirstDriftedObservedTime:        now,
+					TargetClusterObservedGeneration: 1,
+					ObservedDrifts: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsDriftedResourcePlacementsEqual(tc.oldDRP, tc.newDRP)
+			if got != tc.want {
+				t.Errorf("IsDriftedResourcePlacementsEqual() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsDiffedResourcePlacementEqual tests the IsDiffedResourcePlacementEqual function.
+func TestIsDiffedResourcePlacementEqual(t *testing.T) {
+	now := metav1.Now()
+
+	testCases := []struct {
+		name   string
+		oldDRP []fleetv1beta1.DiffedResourcePlacement
+		newDRP []fleetv1beta1.DiffedResourcePlacement
+		want   bool
+	}{
+		{
+			name:   "two empty slices",
+			oldDRP: []fleetv1beta1.DiffedResourcePlacement{},
+			newDRP: []fleetv1beta1.DiffedResourcePlacement{},
+			want:   true,
+		},
+		{
+			name:   "old is nil, new is empty",
+			oldDRP: nil,
+			newDRP: []fleetv1beta1.DiffedResourcePlacement{},
+			want:   true,
+		},
+		{
+			name:   "old is empty, new is nil",
+			oldDRP: []fleetv1beta1.DiffedResourcePlacement{},
+			newDRP: nil,
+			want:   true,
+		},
+		{
+			name: "different length",
+			oldDRP: []fleetv1beta1.DiffedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+			},
+			newDRP: []fleetv1beta1.DiffedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "same list, different order",
+			oldDRP: []fleetv1beta1.DiffedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+			newDRP: []fleetv1beta1.DiffedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "same list, same order",
+			oldDRP: []fleetv1beta1.DiffedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+			},
+			newDRP: []fleetv1beta1.DiffedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Name:      "nginx",
+						Namespace: "default",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/spec/replicas",
+							ValueInHub:    "1",
+							ValueInMember: "2",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "diff info updated",
+			oldDRP: []fleetv1beta1.DiffedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(1)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+			newDRP: []fleetv1beta1.DiffedResourcePlacement{
+				{
+					ResourceIdentifier: fleetv1beta1.ResourceIdentifier{
+						Group:   "",
+						Version: "v1",
+						Kind:    "Namespace",
+						Name:    "work",
+					},
+					ObservationTime:                 now,
+					FirstDiffedObservedTime:         now,
+					TargetClusterObservedGeneration: ptr.To(int64(2)),
+					ObservedDiffs: []fleetv1beta1.PatchDetail{
+						{
+							Path:          "/metadata/labels/custom",
+							ValueInMember: "1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsDiffedResourcePlacementsEqual(tc.oldDRP, tc.newDRP)
+			if got != tc.want {
+				t.Errorf("IsDiffedResourcePlacementsEqual() = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

This PR enables the CRB watcher controller to detect drift/diff reporting changes.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests

### Special notes for your reviewer
