### PR TITLE
fix: address an issue in the rollout controller where bindings might not receive status refresh after binding spec changes

### DIFF
--- a/pkg/controllers/rollout/controller.go
+++ b/pkg/controllers/rollout/controller.go
@@ -378,7 +378,7 @@ func (r *Reconciler) pickBindingsToRoll(
 	// minimum AvailableNumber of copies as we won't reduce the total unavailable number of bindings.
 	applyFailedUpdateCandidates := make([]toBeUpdatedBinding, 0)
 
-	// Those are the bindings that have been bound to a cluster and have the lastest
+	// Those are the bindings that have been bound to a cluster and have the latest
 	// resource/override snapshots, but might or might not have the refresh status information.
 	upToDateBoundBindings := make([]toBeUpdatedBinding, 0)
 

--- a/pkg/controllers/rollout/controller.go
+++ b/pkg/controllers/rollout/controller.go
@@ -526,7 +526,7 @@ func determineBindingsToUpdate(
 	updateCandidateUnselectedIndex := 0
 	if maxNumberToRemove > 0 {
 		i := 0
-		// we first remove the bindings that are not selectedfgvvv by the scheduler anymore
+		// we first remove the bindings that are not selected by the scheduler anymore
 		for ; i < maxNumberToRemove && i < len(removeCandidates); i++ {
 			toBeUpdatedBindingList = append(toBeUpdatedBindingList, removeCandidates[i])
 		}

--- a/pkg/controllers/rollout/controller.go
+++ b/pkg/controllers/rollout/controller.go
@@ -189,7 +189,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req runtime.Request) (runtim
 	klog.V(2).InfoS("Successfully updated status of the stale bindings", "clusterResourcePlacement", crpName, "numberOfStaleBindings", len(staleBoundBindings))
 
 	// upToDateBoundBindings contains all the ClusterResourceBindings that does not need to have
-	// their resource/overrride snapshots updated, but might need to have their status updated.
+	// their resource/override snapshots updated, but might need to have their status updated.
 	//
 	// Bindings might have up to date resource/override snapshots but stale status information when
 	// an apply strategy update has just been applied, or an error has occurred during the

--- a/pkg/controllers/rollout/controller_integration_test.go
+++ b/pkg/controllers/rollout/controller_integration_test.go
@@ -198,24 +198,17 @@ var _ = Describe("Test the rollout Controller", func() {
 					},
 				}
 				// The scheduled binding will be set to the Bound state with the RolloutStarted
-				// condition set to True; the unscheduled binding will receive a False
-				// RolloutStarted condition; the bound bindings will receive a True RolloutStarted
-				// condition.
+				// condition set to True; the bound binding will receive a True RolloutStarted
+				// condition; the unscheduled binding will have no RolloutStarted condition update.
 				if binding.Spec.State == fleetv1beta1.BindingStateUnscheduled {
 					wantBindingStatus = &fleetv1beta1.ResourceBindingStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
-								Status:             metav1.ConditionFalse,
-								Reason:             condition.RolloutNotStartedYetReason,
-								ObservedGeneration: gotBinding.Generation,
-							},
-						},
+						Conditions: []metav1.Condition{},
 					}
 				}
 				if diff := cmp.Diff(
 					&gotBinding.Status, wantBindingStatus,
 					ignoreCondLTTAndMessageFields,
+					cmpopts.EquateEmpty(),
 				); diff != "" {
 					return fmt.Errorf("binding status diff (%v/%v) (-got, +want):\n%s", binding.Spec.State, gotBinding.Spec.State, diff)
 				}
@@ -299,24 +292,17 @@ var _ = Describe("Test the rollout Controller", func() {
 					},
 				}
 				// The scheduled binding will be set to the Bound state with the RolloutStarted
-				// condition set to True; the unscheduled binding will receive a False
-				// RolloutStarted condition; the bound bindings will receive a True RolloutStarted
-				// condition.
+				// condition set to True; the bound binding will receive a True RolloutStarted
+				// condition; the unscheduled binding will have no RolloutStarted condition update.
 				if binding.Spec.State == fleetv1beta1.BindingStateUnscheduled {
 					wantBindingStatus = &fleetv1beta1.ResourceBindingStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
-								Status:             metav1.ConditionFalse,
-								Reason:             condition.RolloutNotStartedYetReason,
-								ObservedGeneration: gotBinding.Generation,
-							},
-						},
+						Conditions: []metav1.Condition{},
 					}
 				}
 				if diff := cmp.Diff(
 					&gotBinding.Status, wantBindingStatus,
 					ignoreCondLTTAndMessageFields,
+					cmpopts.EquateEmpty(),
 				); diff != "" {
 					return fmt.Errorf("binding status diff (%v/%v) (-got, +want):\n%s", binding.Spec.State, gotBinding.Spec.State, diff)
 				}

--- a/pkg/controllers/rollout/controller_integration_test.go
+++ b/pkg/controllers/rollout/controller_integration_test.go
@@ -24,6 +24,7 @@ import (
 	fleetv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/utils"
+	"go.goms.io/fleet/pkg/utils/condition"
 )
 
 const (
@@ -37,6 +38,7 @@ const (
 var (
 	ignoreCRBTypeMetaAndStatusFields = cmpopts.IgnoreFields(fleetv1beta1.ClusterResourceBinding{}, "TypeMeta", "Status")
 	ignoreObjectMetaAutoGenFields    = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "CreationTimestamp", "Generation", "ResourceVersion", "SelfLink", "UID", "ManagedFields")
+	ignoreCondLTTAndMessageFields    = cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "Message")
 )
 
 var testCRPName string
@@ -103,7 +105,7 @@ var _ = Describe("Test the rollout Controller", func() {
 		}, timeout, interval).Should(BeTrue(), "rollout controller should roll all the bindings to Bound state")
 	})
 
-	It("should push apply strategy changes to all the bindings (if applicable)", func() {
+	It("should push apply strategy changes to all the bindings (if applicable) and refresh their status", func() {
 		// Create a CRP.
 		targetClusterCount := int32(3)
 		rolloutCRP = clusterResourcePlacementForTest(
@@ -176,6 +178,51 @@ var _ = Describe("Test the rollout Controller", func() {
 			return nil
 		}, timeout, interval).Should(Succeed(), "Failed to verify that all the bindings are bound")
 
+		// Verify that all bindings have their status refreshed (i.e., have fresh RolloutStarted
+		// conditions).
+		Eventually(func() error {
+			for _, binding := range bindings {
+				gotBinding := &fleetv1beta1.ClusterResourceBinding{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: binding.GetName()}, gotBinding); err != nil {
+					return fmt.Errorf("failed to get binding %s: %w", binding.Name, err)
+				}
+
+				wantBindingStatus := &fleetv1beta1.ResourceBindingStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
+							Status:             metav1.ConditionTrue,
+							Reason:             condition.RolloutStartedReason,
+							ObservedGeneration: gotBinding.Generation,
+						},
+					},
+				}
+				// The scheduled binding will be set to the Bound state with the RolloutStarted
+				// condition set to True; the unscheduled binding will receive a False
+				// RolloutStarted condition; the bound bindings will receive a True RolloutStarted
+				// condition.
+				if binding.Spec.State == fleetv1beta1.BindingStateUnscheduled {
+					wantBindingStatus = &fleetv1beta1.ResourceBindingStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
+								Status:             metav1.ConditionFalse,
+								Reason:             condition.RolloutNotStartedYetReason,
+								ObservedGeneration: gotBinding.Generation,
+							},
+						},
+					}
+				}
+				if diff := cmp.Diff(
+					&gotBinding.Status, wantBindingStatus,
+					ignoreCondLTTAndMessageFields,
+				); diff != "" {
+					return fmt.Errorf("binding status diff (%v/%v) (-got, +want):\n%s", binding.Spec.State, gotBinding.Spec.State, diff)
+				}
+			}
+			return nil
+		}, timeout, interval).Should(Succeed(), "Failed to verify that all the bindings have their status refreshed")
+
 		// Update the CRP with a new apply strategy.
 		rolloutCRP.Spec.Strategy.ApplyStrategy = &fleetv1beta1.ApplyStrategy{
 			ComparisonOption: fleetv1beta1.ComparisonOptionTypeFullComparison,
@@ -231,6 +278,51 @@ var _ = Describe("Test the rollout Controller", func() {
 			}
 			return nil
 		}, timeout, interval).Should(Succeed(), "Failed to update all bindings with the new apply strategy")
+
+		// Verify that all bindings have their status refreshed (i.e., have fresh RolloutStarted
+		// conditions).
+		Eventually(func() error {
+			for _, binding := range bindings {
+				gotBinding := &fleetv1beta1.ClusterResourceBinding{}
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: binding.GetName()}, gotBinding); err != nil {
+					return fmt.Errorf("failed to get binding %s: %w", binding.Name, err)
+				}
+
+				wantBindingStatus := &fleetv1beta1.ResourceBindingStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
+							Status:             metav1.ConditionTrue,
+							Reason:             condition.RolloutStartedReason,
+							ObservedGeneration: gotBinding.Generation,
+						},
+					},
+				}
+				// The scheduled binding will be set to the Bound state with the RolloutStarted
+				// condition set to True; the unscheduled binding will receive a False
+				// RolloutStarted condition; the bound bindings will receive a True RolloutStarted
+				// condition.
+				if binding.Spec.State == fleetv1beta1.BindingStateUnscheduled {
+					wantBindingStatus = &fleetv1beta1.ResourceBindingStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
+								Status:             metav1.ConditionFalse,
+								Reason:             condition.RolloutNotStartedYetReason,
+								ObservedGeneration: gotBinding.Generation,
+							},
+						},
+					}
+				}
+				if diff := cmp.Diff(
+					&gotBinding.Status, wantBindingStatus,
+					ignoreCondLTTAndMessageFields,
+				); diff != "" {
+					return fmt.Errorf("binding status diff (%v/%v) (-got, +want):\n%s", binding.Spec.State, gotBinding.Spec.State, diff)
+				}
+			}
+			return nil
+		}, timeout, interval).Should(Succeed(), "Failed to verify that all the bindings have their status refreshed")
 	})
 
 	It("Should rollout all the selected bindings when the rollout strategy is not set", func() {

--- a/pkg/controllers/rollout/controller_test.go
+++ b/pkg/controllers/rollout/controller_test.go
@@ -757,6 +757,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 		wantTobeUpdatedBindings     []int
 		wantDesiredBindingsSpec     []fleetv1beta1.ResourceBindingSpec // used to construct the want toBeUpdatedBindings
 		wantStaleUnselectedBindings []int
+		wantUpToDateBoundBindings   []int
 		wantNeedRoll                bool
 		wantWaitTime                time.Duration
 		wantErr                     error
@@ -1106,6 +1107,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 				createPlacementRolloutStrategyForTest(fleetv1beta1.RollingUpdateRolloutStrategyType, generateDefaultRollingUpdateConfig(), nil)),
 			wantTobeUpdatedBindings:     []int{},
 			wantStaleUnselectedBindings: []int{},
+			wantUpToDateBoundBindings:   []int{0},
 			wantNeedRoll:                false,
 		},
 		"test failed to apply bound binding, outdated resources - rollout allowed": {
@@ -1350,7 +1352,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 				createPlacementPolicyForTest(fleetv1beta1.PickNPlacementType, 2),
 				createPlacementRolloutStrategyForTest(fleetv1beta1.RollingUpdateRolloutStrategyType, generateDefaultRollingUpdateConfig(), nil)), // maxUnavailable is set to 1.
 			wantTobeUpdatedBindings:     []int{0}, // one ready unscheduled binding is removed since maxUnavailable is set to 1.
-			wantStaleUnselectedBindings: []int{},  //  remove candidate doesn't get appended as stale binding.
+			wantStaleUnselectedBindings: []int{1},
 			wantDesiredBindingsSpec: []fleetv1beta1.ResourceBindingSpec{
 				{},
 				{},
@@ -1418,6 +1420,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 					UnavailablePeriodSeconds: ptr.To(60),
 				}, nil)), // UnavailablePeriodSeconds is 60s -> readyTimeCutOff = t - 60s
 			wantStaleUnselectedBindings: []int{0, 1},
+			wantUpToDateBoundBindings:   []int{2},
 			wantDesiredBindingsSpec: []fleetv1beta1.ResourceBindingSpec{
 				{
 					State:                fleetv1beta1.BindingStateBound,
@@ -1454,7 +1457,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 					},
 					UnavailablePeriodSeconds: ptr.To(60),
 				}, nil)), // UnavailablePeriodSeconds is 60s -> readyTimeCutOff = t - 60s
-			wantStaleUnselectedBindings: []int{},                              // empty list as unscheduled bindings will be removed and are not tracked in the CRP today.
+			wantStaleUnselectedBindings: []int{0, 1},                          // empty list as unscheduled bindings will be removed and are not tracked in the CRP today.
 			wantDesiredBindingsSpec:     []fleetv1beta1.ResourceBindingSpec{}, // unscheduled binding does not have desired spec so that putting the empty here
 			wantNeedRoll:                true,
 			wantWaitTime:                25 * time.Second, // minWaitTime = (t - 35 seconds) - (t - 60 seconds) = 25 seconds
@@ -1506,7 +1509,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 				},
 			},
 			wantTobeUpdatedBindings:     []int{2}, // specified MaxSurge helps us pick only one scheduled binding to rollout. we don't have any ready unscheduled bindings so we don't remove any binding.
-			wantStaleUnselectedBindings: []int{3}, // remove candidates i.e. unscheduled bindings are not added to the stale unselected bindings.
+			wantStaleUnselectedBindings: []int{3, 1},
 			wantNeedRoll:                true,
 			wantWaitTime:                time.Second,
 		},
@@ -1683,6 +1686,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 			},
 			wantTobeUpdatedBindings:     []int{2, 3}, // both new scheduled bindings are rolled out, target number by itself is greater than canBeReady bindings.
 			wantStaleUnselectedBindings: []int{},
+			wantUpToDateBoundBindings:   []int{1},
 			wantNeedRoll:                true,
 			wantWaitTime:                0,
 		},
@@ -1734,7 +1738,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 				},
 			},
 			wantTobeUpdatedBindings:     []int{2, 3, 4}, // specified MaxSurge helps us pick three new scheduled bindings out of four, target number + MaxSurge is greater than canBeReady bindings, unscheduled binding is a canBeReady binding & maxUnavailable is set to zero.
-			wantStaleUnselectedBindings: []int{5},
+			wantStaleUnselectedBindings: []int{5, 1},
 			wantNeedRoll:                true,
 			wantWaitTime:                time.Second,
 		},
@@ -1811,6 +1815,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 			},
 			wantTobeUpdatedBindings:     []int{3}, // more ready bindings than required, we remove the unscheduled binding.
 			wantStaleUnselectedBindings: []int{},
+			wantUpToDateBoundBindings:   []int{0, 1},
 			wantNeedRoll:                true,
 			wantWaitTime:                0,
 		},
@@ -1843,6 +1848,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 			},
 			wantTobeUpdatedBindings:     []int{2, 3}, // more ready bindings than required we remove the unscheduled binding, specified MaxUnavailable helps us remove one more unscheduled binding.
 			wantStaleUnselectedBindings: []int{},
+			wantUpToDateBoundBindings:   []int{1},
 			wantNeedRoll:                true,
 			wantWaitTime:                0,
 		},
@@ -1885,8 +1891,8 @@ func TestPickBindingsToRoll(t *testing.T) {
 					ResourceSnapshotName: "snapshot-1",
 				},
 			},
-			wantTobeUpdatedBindings:     []int{1},    // more ready bindings than required we remove one unscheduled binding
-			wantStaleUnselectedBindings: []int{4, 5}, // since three unscheduled bindings are already canBeReady we don't roll out new scheduled bindings.
+			wantTobeUpdatedBindings:     []int{1},          // more ready bindings than required we remove one unscheduled binding
+			wantStaleUnselectedBindings: []int{4, 5, 2, 3}, // since three unscheduled bindings are already canBeReady we don't roll out new scheduled bindings.
 			wantNeedRoll:                true,
 			wantWaitTime:                0,
 		},
@@ -1930,7 +1936,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 				},
 			},
 			wantTobeUpdatedBindings:     []int{4, 5}, // no ready unscheduled bindings, so scheduled bindings were chosen.
-			wantStaleUnselectedBindings: []int{},
+			wantStaleUnselectedBindings: []int{1, 2, 3},
 			wantNeedRoll:                true,
 			wantWaitTime:                defaultUnavailablePeriod * time.Second,
 		},
@@ -1973,8 +1979,8 @@ func TestPickBindingsToRoll(t *testing.T) {
 					ResourceSnapshotName: "snapshot-2",
 				},
 			},
-			wantTobeUpdatedBindings:     []int{2}, // remove candidates (unscheduled bindings) are chosen before update candidates (bound bindings)
-			wantStaleUnselectedBindings: []int{1}, // since maxUnavailable is set to zero, we can't remove the ready unscheduled and ready bound binding (remove candidates aren't added to stale bindings)
+			wantTobeUpdatedBindings:     []int{2},    // remove candidates (unscheduled bindings) are chosen before update candidates (bound bindings)
+			wantStaleUnselectedBindings: []int{1, 3}, // since maxUnavailable is set to zero, we can't remove the ready unscheduled and ready bound binding
 			wantNeedRoll:                true,
 			wantWaitTime:                0,
 		},
@@ -2043,7 +2049,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 					Name: tt.latestResourceSnapshotName,
 				},
 			}
-			gotUpdatedBindings, gotStaleUnselectedBindings, gotNeedRoll, gotWaitTime, err := r.pickBindingsToRoll(context.Background(), tt.allBindings, resourceSnapshot, tt.crp, tt.matchedCROs, tt.matchedROs)
+			gotUpdatedBindings, gotStaleUnselectedBindings, gotUpToDateBoundBindings, gotNeedRoll, gotWaitTime, err := r.pickBindingsToRoll(context.Background(), tt.allBindings, resourceSnapshot, tt.crp, tt.matchedCROs, tt.matchedROs)
 			if (err != nil) != (tt.wantErr != nil) || err != nil && !errors.Is(err, tt.wantErr) {
 				t.Fatalf("pickBindingsToRoll() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -2073,12 +2079,19 @@ func TestPickBindingsToRoll(t *testing.T) {
 					wantStaleUnselectedBindings[i].currentBinding = tt.allBindings[index]
 				}
 			}
+			wantUpToDateBoundBindings := make([]toBeUpdatedBinding, len(tt.wantUpToDateBoundBindings))
+			for i, index := range tt.wantUpToDateBoundBindings {
+				wantUpToDateBoundBindings[i].currentBinding = tt.allBindings[index]
+			}
 
 			if diff := cmp.Diff(wantTobeUpdatedBindings, gotUpdatedBindings, cmpOptions...); diff != "" {
 				t.Errorf("pickBindingsToRoll() toBeUpdatedBindings mismatch (-want, +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(wantStaleUnselectedBindings, gotStaleUnselectedBindings, cmpOptions...); diff != "" {
 				t.Errorf("pickBindingsToRoll() staleUnselectedBindings mismatch (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(wantUpToDateBoundBindings, gotUpToDateBoundBindings, cmpOptions...); diff != "" {
+				t.Errorf("pickBindingsToRoll() upToDateBoundBindings mismatch (-want, +got):\n%s", diff)
 			}
 			if gotNeedRoll != tt.wantNeedRoll {
 				t.Errorf("pickBindingsToRoll() = needRoll %v, want %v", gotNeedRoll, tt.wantNeedRoll)
@@ -2276,7 +2289,7 @@ func TestUpdateStaleBindingsStatus(t *testing.T) {
 				},
 			},
 		},
-		"skip updating unscheduled binding status": {
+		"update unscheduled binding status": {
 			bindings: []fleetv1beta1.ClusterResourceBinding{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2293,7 +2306,7 @@ func TestUpdateStaleBindingsStatus(t *testing.T) {
 							{
 								Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
 								Status:             metav1.ConditionTrue,
-								ObservedGeneration: 15,
+								ObservedGeneration: 14,
 								LastTransitionTime: metav1.NewTime(currentTime),
 								Reason:             condition.RolloutStartedReason,
 							},
@@ -2316,10 +2329,10 @@ func TestUpdateStaleBindingsStatus(t *testing.T) {
 						Conditions: []metav1.Condition{
 							{
 								Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
-								Status:             metav1.ConditionTrue,
+								Status:             metav1.ConditionFalse,
 								ObservedGeneration: 15,
 								LastTransitionTime: metav1.NewTime(currentTime),
-								Reason:             condition.RolloutStartedReason,
+								Reason:             condition.RolloutNotStartedYetReason,
 							},
 						},
 					},
@@ -2443,6 +2456,138 @@ func TestUpdateStaleBindingsStatus(t *testing.T) {
 			}
 			if diff := cmp.Diff(tt.wantBindings, bindingList.Items, cmpOptions...); diff != "" {
 				t.Errorf("updateStaleBindingsStatus List() mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRefreshUpToDateBindingStatus(t *testing.T) {
+	currentTime := time.Now()
+
+	testCases := []struct {
+		name             string
+		upToDateBindings []fleetv1beta1.ClusterResourceBinding
+		wantBindings     []fleetv1beta1.ClusterResourceBinding
+	}{
+		{
+			name:             "nil array",
+			upToDateBindings: nil,
+			wantBindings:     nil,
+		},
+		{
+			name:             "empty array",
+			upToDateBindings: []fleetv1beta1.ClusterResourceBinding{},
+			wantBindings:     nil,
+		},
+		{
+			name: "up to date bindings",
+			upToDateBindings: []fleetv1beta1.ClusterResourceBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "binding-1",
+						Generation: 1,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						State:                fleetv1beta1.BindingStateBound,
+						TargetCluster:        cluster1,
+						ResourceSnapshotName: "snapshot-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "binding-2",
+						Generation: 2,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						State:                fleetv1beta1.BindingStateBound,
+						TargetCluster:        cluster2,
+						ResourceSnapshotName: "snapshot-1",
+					},
+				},
+			},
+			wantBindings: []fleetv1beta1.ClusterResourceBinding{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "binding-1",
+						Generation: 1,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						State:                fleetv1beta1.BindingStateBound,
+						TargetCluster:        cluster1,
+						ResourceSnapshotName: "snapshot-1",
+					},
+					Status: fleetv1beta1.ResourceBindingStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
+								Status:             metav1.ConditionTrue,
+								ObservedGeneration: 1,
+								LastTransitionTime: metav1.NewTime(currentTime),
+								Reason:             condition.RolloutStartedReason,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "binding-2",
+						Generation: 2,
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						State:                fleetv1beta1.BindingStateBound,
+						TargetCluster:        cluster2,
+						ResourceSnapshotName: "snapshot-1",
+					},
+					Status: fleetv1beta1.ResourceBindingStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(fleetv1beta1.ResourceBindingRolloutStarted),
+								Status:             metav1.ConditionTrue,
+								ObservedGeneration: 2,
+								LastTransitionTime: metav1.NewTime(currentTime),
+								Reason:             condition.RolloutStartedReason,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var objects []client.Object
+			for i := range tc.upToDateBindings {
+				objects = append(objects, &tc.upToDateBindings[i])
+			}
+			scheme := serviceScheme(t)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				WithStatusSubresource(objects...).
+				Build()
+			r := Reconciler{
+				Client: fakeClient,
+			}
+			ctx := context.Background()
+			upToDateBindings := make([]toBeUpdatedBinding, 0, len(tc.upToDateBindings))
+			for i := range tc.upToDateBindings {
+				// Get the data from the api server first so that the update won't fail because of the revision.
+				binding := &fleetv1beta1.ClusterResourceBinding{}
+				if err := fakeClient.Get(ctx, client.ObjectKey{Name: tc.upToDateBindings[i].Name}, binding); err != nil {
+					t.Fatalf("failed to get binding: %v", err)
+				}
+				upToDateBindings = append(upToDateBindings, toBeUpdatedBinding{currentBinding: binding})
+			}
+			if err := r.refreshUpToDateBindingStatus(ctx, upToDateBindings); err != nil {
+				t.Fatalf("updateStaleBindingsStatus() = %v, want no error", err)
+			}
+			bindingList := &fleetv1beta1.ClusterResourceBindingList{}
+			if err := fakeClient.List(ctx, bindingList); err != nil {
+				t.Fatalf("ClusterResourceBinding List() = %v, want no errpr", err)
+			}
+			if diff := cmp.Diff(bindingList.Items, tc.wantBindings, cmpOptions...); diff != "" {
+				t.Errorf("ClusterResourceBindings mismatches (-got, +want):\n%s", diff)
 			}
 		})
 	}
@@ -2644,10 +2789,11 @@ func TestProcessApplyStrategyUpdates(t *testing.T) {
 	now := metav1.Now().Rfc3339Copy()
 
 	testCases := []struct {
-		name            string
-		crp             *fleetv1beta1.ClusterResourcePlacement
-		allBindings     []*fleetv1beta1.ClusterResourceBinding
-		wantAllBindings []*fleetv1beta1.ClusterResourceBinding
+		name                     string
+		crp                      *fleetv1beta1.ClusterResourcePlacement
+		allBindings              []*fleetv1beta1.ClusterResourceBinding
+		wantAllBindings          []*fleetv1beta1.ClusterResourceBinding
+		wantApplyStrategyUpdated bool
 	}{
 		{
 			name: "nil apply strategy",
@@ -2682,6 +2828,7 @@ func TestProcessApplyStrategyUpdates(t *testing.T) {
 					},
 				},
 			},
+			wantApplyStrategyUpdated: true,
 		},
 		{
 			name: "push apply strategy to bindings of various states",
@@ -2788,6 +2935,97 @@ func TestProcessApplyStrategyUpdates(t *testing.T) {
 					},
 				},
 			},
+			wantApplyStrategyUpdated: true,
+		},
+		{
+			name: "no apply strategy update needed",
+			crp: &fleetv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crpName,
+				},
+				Spec: fleetv1beta1.ClusterResourcePlacementSpec{
+					Strategy: fleetv1beta1.RolloutStrategy{
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type:             fleetv1beta1.ApplyStrategyTypeClientSideApply,
+							ComparisonOption: fleetv1beta1.ComparisonOptionTypePartialComparison,
+							WhenToApply:      fleetv1beta1.WhenToApplyTypeIfNotDrifted,
+							WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeIfNoDiff,
+						},
+					},
+				},
+			},
+			allBindings: []*fleetv1beta1.ClusterResourceBinding{
+				// A binding that has been marked for deletion.
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "binding-1",
+						DeletionTimestamp: &now,
+						// The fake client requires that all objects that have been marked
+						// for deletion should have at least one finalizer set.
+						Finalizers: []string{
+							"custom-deletion-blocker",
+						},
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type:             fleetv1beta1.ApplyStrategyTypeClientSideApply,
+							ComparisonOption: fleetv1beta1.ComparisonOptionTypePartialComparison,
+							WhenToApply:      fleetv1beta1.WhenToApplyTypeIfNotDrifted,
+							WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeIfNoDiff,
+						},
+					},
+				},
+				// A binding that already has the latest apply strategy.
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "binding-2",
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						ResourceSnapshotName: "snapshot-2",
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type:             fleetv1beta1.ApplyStrategyTypeClientSideApply,
+							ComparisonOption: fleetv1beta1.ComparisonOptionTypePartialComparison,
+							WhenToApply:      fleetv1beta1.WhenToApplyTypeIfNotDrifted,
+							WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeIfNoDiff,
+						},
+					},
+				},
+			},
+			wantAllBindings: []*fleetv1beta1.ClusterResourceBinding{
+				// Binding that has been marked for deletion should not be updated.
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "binding-1",
+						DeletionTimestamp: &now,
+						Finalizers: []string{
+							"custom-deletion-blocker",
+						},
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type:             fleetv1beta1.ApplyStrategyTypeClientSideApply,
+							ComparisonOption: fleetv1beta1.ComparisonOptionTypePartialComparison,
+							WhenToApply:      fleetv1beta1.WhenToApplyTypeIfNotDrifted,
+							WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeIfNoDiff,
+						},
+					},
+				},
+				// Binding that already has the latest apply strategy should not be updated.
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "binding-2",
+					},
+					Spec: fleetv1beta1.ResourceBindingSpec{
+						ResourceSnapshotName: "snapshot-2",
+						ApplyStrategy: &fleetv1beta1.ApplyStrategy{
+							Type:             fleetv1beta1.ApplyStrategyTypeClientSideApply,
+							ComparisonOption: fleetv1beta1.ComparisonOptionTypePartialComparison,
+							WhenToApply:      fleetv1beta1.WhenToApplyTypeIfNotDrifted,
+							WhenToTakeOver:   fleetv1beta1.WhenToTakeOverTypeIfNoDiff,
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -2807,8 +3045,12 @@ func TestProcessApplyStrategyUpdates(t *testing.T) {
 				Client: fakeClient,
 			}
 
-			if err := r.processApplyStrategyUpdates(ctx, tc.crp, tc.allBindings); err != nil {
+			applyStrategyUpdated, err := r.processApplyStrategyUpdates(ctx, tc.crp, tc.allBindings)
+			if err != nil {
 				t.Errorf("processApplyStrategyUpdates() error = %v, want no error", err)
+			}
+			if applyStrategyUpdated != tc.wantApplyStrategyUpdated {
+				t.Errorf("processApplyStrategyUpdates() = %v, want %v", applyStrategyUpdated, tc.wantApplyStrategyUpdated)
 			}
 
 			for idx := range tc.wantAllBindings {

--- a/pkg/controllers/rollout/controller_test.go
+++ b/pkg/controllers/rollout/controller_test.go
@@ -1980,7 +1980,7 @@ func TestPickBindingsToRoll(t *testing.T) {
 				},
 			},
 			wantTobeUpdatedBindings:     []int{2}, // remove candidates (unscheduled bindings) are chosen before update candidates (bound bindings)
-			wantStaleUnselectedBindings: []int{1}, // since maxUnavailable is set to zero, we can't remove the ready unscheduled and ready bound binding
+			wantStaleUnselectedBindings: []int{1}, // since maxUnavailable is set to zero, we can't remove the ready unscheduled and ready bound binding (remove candidates aren't added to stale bindings)
 			wantNeedRoll:                true,
 			wantWaitTime:                0,
 		},

--- a/pkg/controllers/rollout/controller_test.go
+++ b/pkg/controllers/rollout/controller_test.go
@@ -2584,7 +2584,7 @@ func TestRefreshUpToDateBindingStatus(t *testing.T) {
 			}
 			bindingList := &fleetv1beta1.ClusterResourceBindingList{}
 			if err := fakeClient.List(ctx, bindingList); err != nil {
-				t.Fatalf("ClusterResourceBinding List() = %v, want no errpr", err)
+				t.Fatalf("ClusterResourceBinding List() = %v, want no error", err)
 			}
 			if diff := cmp.Diff(bindingList.Items, tc.wantBindings, cmpOptions...); diff != "" {
 				t.Errorf("ClusterResourceBindings mismatches (-got, +want):\n%s", diff)


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue in the rollout controller where bindings might not receive status refresh after binding spec changes.

Specifically, when 

a) a `Bound` binding with up to date resource/override snapshot; or
b) an `Unscheduled` binding that has not been deleted yet

has its spec changed (e.g., apply strategy update), rollout controller will stop processing them and such bindings will no longer have fresh `RolloutStarted` condition added to their status. As a result, work generator will refuse to process these bindings and the system will be stuck.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Unit tests
- [x] Integration tests
- [] E2E tests will be added in a separate PR (enable the new work applier)  


### Special notes for your reviewer

N/A
