### PR TITLE
interface: [updateRun] remove waitTime default value in afterStageTasks

### DIFF
--- a/apis/placement/v1alpha1/stagedupdate_types.go
+++ b/apis/placement/v1alpha1/stagedupdate_types.go
@@ -142,7 +142,6 @@ type AfterStageTask struct {
 	Type AfterStageTaskType `json:"type"`
 
 	// The time to wait after all the clusters in the current stage complete the update before moving to the next stage.
-	// +kubebuilder:default="1h"
 	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(s|m|h))+$"
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Optional

--- a/apis/placement/v1beta1/stageupdate_types.go
+++ b/apis/placement/v1beta1/stageupdate_types.go
@@ -142,7 +142,6 @@ type AfterStageTask struct {
 	Type AfterStageTaskType `json:"type"`
 
 	// The time to wait after all the clusters in the current stage complete the update before moving to the next stage.
-	// +kubebuilder:default="1h"
 	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(s|m|h))+$"
 	// +kubebuilder:validation:Type=string
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterstagedupdateruns.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterstagedupdateruns.yaml
@@ -820,7 +820,6 @@ spec:
                                 - Approval
                                 type: string
                               waitTime:
-                                default: 1h
                                 description: The time to wait after all the clusters
                                   in the current stage complete the update before
                                   moving to the next stage.
@@ -2040,7 +2039,6 @@ spec:
                                 - Approval
                                 type: string
                               waitTime:
-                                default: 1h
                                 description: The time to wait after all the clusters
                                   in the current stage complete the update before
                                   moving to the next stage.

--- a/config/crd/bases/placement.kubernetes-fleet.io_clusterstagedupdatestrategies.yaml
+++ b/config/crd/bases/placement.kubernetes-fleet.io_clusterstagedupdatestrategies.yaml
@@ -70,7 +70,6 @@ spec:
                             - Approval
                             type: string
                           waitTime:
-                            default: 1h
                             description: The time to wait after all the clusters in
                               the current stage complete the update before moving
                               to the next stage.
@@ -209,7 +208,6 @@ spec:
                             - Approval
                             type: string
                           waitTime:
-                            default: 1h
                             description: The time to wait after all the clusters in
                               the current stage complete the update before moving
                               to the next stage.

--- a/test/apis/placement/v1beta1/api_validation_integration_test.go
+++ b/test/apis/placement/v1beta1/api_validation_integration_test.go
@@ -369,6 +369,8 @@ var _ = Describe("Test placement v1beta1 API validation", func() {
 				},
 			}
 			Expect(hubClient.Create(ctx, &strategy)).Should(Succeed())
+			Expect(strategy.Spec.Stages[0].AfterStageTasks[0].WaitTime).Should(Equal(metav1.Duration{Duration: 0}))
+			Expect(strategy.Spec.Stages[0].AfterStageTasks[1].WaitTime).Should(Equal(metav1.Duration{Duration: time.Second * 10}))
 			Expect(hubClient.Delete(ctx, &strategy)).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
### Description of your changes
Since waitTime is only meaningful when after-stage task type is "Timedwait", setting an unconditional default value of 1h looks confusing when type is "Approval":
```
- afterStageTasks:
  - type: Approval
    waitTime: 1h
```
We do have a check during initialization to make sure the value is valid when type is "Timedwait": https://github.com/Azure/fleet/blob/main/pkg/controllers/updaterun/initialization.go#L389C2-L395C3
<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
