### PR TITLE
feat: add metric for crp completion

### DIFF
--- a/pkg/controllers/clusterresourceplacement/controller.go
+++ b/pkg/controllers/clusterresourceplacement/controller.go
@@ -101,7 +101,7 @@ func (r *Reconciler) handleDelete(ctx context.Context, crp *fleetv1beta1.Cluster
 	}
 	klog.V(2).InfoS("Removed crp-cleanup finalizer", "clusterResourcePlacement", crpKObj)
 	r.Recorder.Event(crp, corev1.EventTypeNormal, "PlacementCleanupFinalizerRemoved", "Deleted the snapshots and removed the placement cleanup finalizer")
-	metrics.FleetPlacementCount.Delete(prometheus.Labels{"name": crp.Name, "status": controller.LabelComplete})
+	metrics.FleetPlacementStatus.Delete(prometheus.Labels{"name": crp.Name})
 	return ctrl.Result{}, nil
 }
 
@@ -222,12 +222,12 @@ func (r *Reconciler) handleUpdate(ctx context.Context, crp *fleetv1beta1.Cluster
 			klog.V(2).InfoS("Placement has finished the rollout process and reached the desired status", "clusterResourcePlacement", crpKObj, "generation", crp.Generation)
 			r.Recorder.Event(crp, corev1.EventTypeNormal, "PlacementRolloutCompleted", "Placement has finished the rollout process and reached the desired status")
 		}
-		metrics.FleetPlacementCount.WithLabelValues(crp.Name, controller.LabelComplete).Set(1)
+		metrics.FleetPlacementStatus.WithLabelValues(crp.Name).Set(1)
 		// We don't need to requeue any request now by watching the binding changes
 		return ctrl.Result{}, nil
 	}
 
-	metrics.FleetPlacementCount.WithLabelValues(crp.Name, controller.LabelComplete).Set(0)
+	metrics.FleetPlacementStatus.WithLabelValues(crp.Name).Set(0)
 	if !isClusterScheduled {
 		// Note:
 		// If the scheduledCondition is failed, it means the placement requirement cannot be satisfied fully. For example,

--- a/pkg/utils/controller/controller.go
+++ b/pkg/utils/controller/controller.go
@@ -37,7 +37,6 @@ const (
 	labelRequeueAfter = "requeue_after"
 	labelRequeue      = "requeue"
 	labelSuccess      = "success"
-	LabelComplete     = "complete"
 )
 
 var (

--- a/pkg/utils/controller/controller.go
+++ b/pkg/utils/controller/controller.go
@@ -37,6 +37,7 @@ const (
 	labelRequeueAfter = "requeue_after"
 	labelRequeue      = "requeue"
 	labelSuccess      = "success"
+	LabelComplete     = "complete"
 )
 
 var (

--- a/pkg/utils/controller/metrics/metrics.go
+++ b/pkg/utils/controller/metrics/metrics.go
@@ -50,10 +50,10 @@ var (
 		Help: "Number of currently used workers per controller",
 	}, []string{"controller"})
 
-	FleetPlacementCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	FleetPlacementStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "fleet_workload_placement_complete",
 		Help: "Placement complete status ",
-	}, []string{"name", "status"})
+	}, []string{"name"})
 )
 
 func init() {
@@ -63,6 +63,6 @@ func init() {
 		FleetReconcileTime,
 		FleetWorkerCount,
 		FleetActiveWorkers,
-		FleetPlacementCount,
+		FleetPlacementStatus,
 	)
 }

--- a/pkg/utils/controller/metrics/metrics.go
+++ b/pkg/utils/controller/metrics/metrics.go
@@ -49,6 +49,11 @@ var (
 		Name: "fleet_workload_active_workers",
 		Help: "Number of currently used workers per controller",
 	}, []string{"controller"})
+
+	FleetPlacementCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "fleet_workload_placement_complete",
+		Help: "Placement complete status ",
+	}, []string{"name", "status"})
 )
 
 func init() {
@@ -58,5 +63,6 @@ func init() {
 		FleetReconcileTime,
 		FleetWorkerCount,
 		FleetActiveWorkers,
+		FleetPlacementCount,
 	)
 }


### PR DESCRIPTION
### Description of your changes
I have: add prometheus metric to show CRP completion which will be used for alerting and monitoring.

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer
![image](https://github.com/user-attachments/assets/26d047be-cf6f-4f59-bc03-f44954238ac4)
Metric includes label for CRP name. If value is "1", CRP rollout is completed. Otherwise, if value is "0", the CRP rollout is incomplete.

Once CRP is deleted, the metric will also disappear. Below I deleted the CRP "test-crp", which is no longer on the list below.
![image](https://github.com/user-attachments/assets/bcdeaedd-e3d8-4f2c-acc5-6f39e5658f2b)

![image](https://github.com/user-attachments/assets/08a3eeeb-0fcc-4ff4-bf18-cfeb1043f7a7)

