### PR TITLE
fix: fix waitTime and approval task blocking each other

### DIFF
--- a/pkg/controllers/updaterun/controller_integration_test.go
+++ b/pkg/controllers/updaterun/controller_integration_test.go
@@ -335,6 +335,9 @@ func generateTestClusterStagedUpdateStrategy() *placementv1beta1.ClusterStagedUp
 								Duration: time.Second * 4,
 							},
 						},
+						{
+							Type: placementv1beta1.AfterStageTaskTypeApproval,
+						},
 					},
 				},
 				{
@@ -349,6 +352,12 @@ func generateTestClusterStagedUpdateStrategy() *placementv1beta1.ClusterStagedUp
 					AfterStageTasks: []placementv1beta1.AfterStageTask{
 						{
 							Type: placementv1beta1.AfterStageTaskTypeApproval,
+						},
+						{
+							Type: placementv1beta1.AfterStageTaskTypeTimedWait,
+							WaitTime: metav1.Duration{
+								Duration: time.Second * 4,
+							},
 						},
 					},
 				},

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -267,6 +267,8 @@ func (r *Reconciler) checkAfterStageTasksStatus(ctx context.Context, updatingSta
 		klog.V(2).InfoS("There is no after stage task for this stage", "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
 		return true, 0, nil
 	}
+	passed := true
+	afterStageWaitTime := time.Duration(-1)
 	for i, task := range updatingStage.AfterStageTasks {
 		switch task.Type {
 		case placementv1beta1.AfterStageTaskTypeTimedWait:
@@ -275,10 +277,12 @@ func (r *Reconciler) checkAfterStageTasksStatus(ctx context.Context, updatingSta
 			waitTime := time.Until(waitStartTime.Add(task.WaitTime.Duration))
 			if waitTime > 0 {
 				klog.V(2).InfoS("The after stage task still need to wait", "waitStartTime", waitStartTime, "waitTime", task.WaitTime, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
-				return false, waitTime, nil
+				passed = false
+				afterStageWaitTime = waitTime
+			} else {
+				markAfterStageWaitTimeElapsed(&updatingStageStatus.AfterStageTaskStatus[i], updateRun.Generation)
+				klog.V(2).InfoS("The after stage wait task has completed", "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
 			}
-			markAfterStageWaitTimeElapsed(&updatingStageStatus.AfterStageTaskStatus[i], updateRun.Generation)
-			klog.V(2).InfoS("The after stage wait task has completed", "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
 		case placementv1beta1.AfterStageTaskTypeApproval:
 			// Check if the approval request has been created.
 			approvalRequest := placementv1beta1.ClusterApprovalRequest{
@@ -310,20 +314,26 @@ func (r *Reconciler) checkAfterStageTasksStatus(ctx context.Context, updatingSta
 						return false, -1, fmt.Errorf("%w: %s", errStagedUpdatedAborted, unexpectedErr.Error())
 					}
 					approvalAccepted := condition.IsConditionStatusTrue(meta.FindStatusCondition(approvalRequest.Status.Conditions, string(placementv1beta1.ApprovalRequestConditionApprovalAccepted)), approvalRequest.Generation)
+					approved := condition.IsConditionStatusTrue(meta.FindStatusCondition(approvalRequest.Status.Conditions, string(placementv1beta1.ApprovalRequestConditionApproved)), approvalRequest.Generation)
 					// Approved state should not change once the approval is accepted.
-					if !approvalAccepted && !condition.IsConditionStatusTrue(meta.FindStatusCondition(approvalRequest.Status.Conditions, string(placementv1beta1.ApprovalRequestConditionApproved)), approvalRequest.Generation) {
+					if !approvalAccepted && !approved {
 						klog.V(2).InfoS("The approval request has not been approved yet", "approvalRequestTask", requestRef, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
-						return false, -1, nil
-					}
-					klog.V(2).InfoS("The approval request has been approved", "approvalRequestTask", requestRef, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
-					if !approvalAccepted {
-						if err = r.updateApprovalRequestAccepted(ctx, &approvalRequest); err != nil {
-							klog.ErrorS(err, "Failed to accept the approved approval request", "approvalRequest", requestRef, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
-							// retriable err
-							return false, 0, err
+						passed = false
+					} else {
+						if !approved {
+							klog.V(2).InfoS("The approval request has been approval-accepted, ignoring changing back to unapproved", "approvalRequestTask", requestRef, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
+						} else {
+							klog.V(2).InfoS("The approval request has been approved", "approvalRequestTask", requestRef, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
 						}
+						if !approvalAccepted {
+							if err = r.updateApprovalRequestAccepted(ctx, &approvalRequest); err != nil {
+								klog.ErrorS(err, "Failed to accept the approved approval request", "approvalRequest", requestRef, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
+								// retriable err
+								return false, -1, err
+							}
+						}
+						markAfterStageRequestApproved(&updatingStageStatus.AfterStageTaskStatus[i], updateRun.Generation)
 					}
-					markAfterStageRequestApproved(&updatingStageStatus.AfterStageTaskStatus[i], updateRun.Generation)
 				} else {
 					// retriable error
 					klog.ErrorS(err, "Failed to create the approval request", "approvalRequest", requestRef, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
@@ -333,12 +343,14 @@ func (r *Reconciler) checkAfterStageTasksStatus(ctx context.Context, updatingSta
 				// The approval request has been created for the first time.
 				klog.V(2).InfoS("The approval request has been created", "approvalRequestTask", requestRef, "stage", updatingStage.Name, "clusterStagedUpdateRun", updateRunRef)
 				markAfterStageRequestCreated(&updatingStageStatus.AfterStageTaskStatus[i], updateRun.Generation)
-				return false, -1, nil
+				passed = false
 			}
 		}
 	}
-	// All the after stage tasks have been finished or the for loop will return before this line.
-	return true, 0, nil
+	if passed {
+		afterStageWaitTime = 0
+	}
+	return passed, afterStageWaitTime, nil
 }
 
 // updateBindingRolloutStarted updates the binding status to indicate the rollout has started.

--- a/pkg/controllers/updaterun/initialization_integration_test.go
+++ b/pkg/controllers/updaterun/initialization_integration_test.go
@@ -770,6 +770,10 @@ func generateSucceededInitializationStatus(
 				},
 				AfterStageTaskStatus: []placementv1beta1.AfterStageTaskStatus{
 					{Type: placementv1beta1.AfterStageTaskTypeTimedWait},
+					{
+						Type:                placementv1beta1.AfterStageTaskTypeApproval,
+						ApprovalRequestName: updateRun.Name + "-stage1",
+					},
 				},
 			},
 			{
@@ -786,6 +790,7 @@ func generateSucceededInitializationStatus(
 						Type:                placementv1beta1.AfterStageTaskTypeApproval,
 						ApprovalRequestName: updateRun.Name + "-stage2",
 					},
+					{Type: placementv1beta1.AfterStageTaskTypeTimedWait},
 				},
 			},
 		},


### PR DESCRIPTION
### Description of your changes
Fix an issue that when both Timedwait and Approval after-stage tasks are present, it might block each other: the ApprovalReq is only created after wait time has passed; the wait time check is only done when the ApprovalReq is approved.
<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
