### PR TITLE
test: address an inconsistency in upgrade tests

### DIFF
--- a/test/upgrade/after/actuals_test.go
+++ b/test/upgrade/after/actuals_test.go
@@ -11,14 +11,13 @@ import (
 
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/controllers/clusterresourceplacement"
-	"go.goms.io/fleet/pkg/controllers/work"
 	scheduler "go.goms.io/fleet/pkg/scheduler/framework"
 	"go.goms.io/fleet/pkg/utils/condition"
 	"go.goms.io/fleet/test/e2e/framework"
 )
 
 func resourcePlacementRolloutCompletedConditions(generation int64, resourceIsTrackable bool, hasOverride bool) []metav1.Condition {
-	availableConditionReason := work.WorkNotTrackableReason
+	availableConditionReason := condition.WorkNotAvailabilityTrackableReason
 	if resourceIsTrackable {
 		availableConditionReason = condition.AllWorkAvailableReason
 	}

--- a/test/upgrade/before/actuals_test.go
+++ b/test/upgrade/before/actuals_test.go
@@ -11,7 +11,6 @@ import (
 
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/controllers/clusterresourceplacement"
-	"go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/controllers/workapplier"
 	scheduler "go.goms.io/fleet/pkg/scheduler/framework"
 	"go.goms.io/fleet/pkg/utils/condition"
@@ -19,7 +18,7 @@ import (
 )
 
 func resourcePlacementRolloutCompletedConditions(generation int64, resourceIsTrackable bool, hasOverride bool) []metav1.Condition {
-	availableConditionReason := work.WorkNotTrackableReason
+	availableConditionReason := condition.WorkNotAvailabilityTrackableReason
 	if resourceIsTrackable {
 		availableConditionReason = condition.AllWorkAvailableReason
 	}

--- a/test/upgrade/before/setup_test.go
+++ b/test/upgrade/before/setup_test.go
@@ -33,7 +33,9 @@ import (
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	placementv1alpha1 "go.goms.io/fleet/apis/placement/v1alpha1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/controllers/work"
 	"go.goms.io/fleet/pkg/utils"
+	"go.goms.io/fleet/pkg/utils/condition"
 	"go.goms.io/fleet/test/e2e/framework"
 )
 
@@ -113,12 +115,27 @@ var (
 	ignoreServicePortNodePortProtocolField = cmpopts.IgnoreFields(corev1.ServicePort{}, "NodePort", "Protocol")
 	ignoreRPSClusterNameField              = cmpopts.IgnoreFields(placementv1beta1.ResourcePlacementStatus{}, "ClusterName")
 
+	// Since Fleet agents v0.14.0 a minor reason string change was applied on the hub side that
+	// affects CRP availability status reportings in the resource placement section when untrackable
+	// resources are involved. This transformer is added to ensure that the compatibility test specs
+	// can handle this string change smoothly.
+	//
+	// Note that the aforementioned change is hub side exclusive and is for informational purposes only.
+	availableDueToUntrackableResCondAcyclicTransformer = cmpopts.AcyclicTransformer("AvailableDueToUntrackableResCond", func(cond metav1.Condition) metav1.Condition {
+		transformedCond := cond.DeepCopy()
+		if cond.Type == string(placementv1beta1.ResourcesAvailableConditionType) && cond.Reason == work.WorkNotTrackableReason {
+			transformedCond.Reason = condition.WorkNotAvailabilityTrackableReason
+		}
+		return *transformedCond
+	})
+
 	crpStatusCmpOptions = cmp.Options{
 		cmpopts.SortSlices(lessFuncConditionByType),
 		cmpopts.SortSlices(lessFuncPlacementStatusByClusterName),
 		cmpopts.SortSlices(utils.LessFuncResourceIdentifier),
 		cmpopts.SortSlices(utils.LessFuncFailedResourcePlacements),
 		utils.IgnoreConditionLTTAndMessageFields,
+		availableDueToUntrackableResCondAcyclicTransformer,
 		cmpopts.EquateEmpty(),
 	}
 	crpWithStuckRolloutStatusCmpOptions = cmp.Options{
@@ -128,6 +145,7 @@ var (
 		cmpopts.SortSlices(utils.LessFuncFailedResourcePlacements),
 		utils.IgnoreConditionLTTAndMessageFields,
 		ignoreRPSClusterNameField,
+		availableDueToUntrackableResCondAcyclicTransformer,
 		cmpopts.EquateEmpty(),
 	}
 )


### PR DESCRIPTION
### Description of your changes

This PR address an inconsistency issue in upgrade tests where the tests expect a reason string from older Fleet versions while new value has taken effect

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

### Special notes for your reviewer

N/A
