### PR TITLE
feat: support arbitrary key on the cluster as the value of override

### DIFF
--- a/apis/placement/v1alpha1/common.go
+++ b/apis/placement/v1alpha1/common.go
@@ -18,10 +18,12 @@ const (
 	// OverrideClusterNameVariable is the reserved variable in the override value that will be replaced by the actual cluster name.
 	OverrideClusterNameVariable = "${MEMBER-CLUSTER-NAME}"
 
-	// OverrideClusterLabelKeyVariablePrefix is the reserved variable prefix in the override expression.
-	// The string will be replaced by the actual label value associated with the key following the prefix.
+	// OverrideClusterLabelKeyVariablePrefix is a reserved variable in the override expression.
+	// We use this variable to find the associated the key following the prefix.
 	// The key name ends with a "}" character (but not include it).
-	// The key name must be a valid label name and case-sensitive.
-	// For example, if the key name is "kube-fleet.io/region", the variable will be "${MEMBER-CLUSTER-LABEL-KEY-kube-fleet.io/region}"
+	// The key name must be a valid Kubernetes label name and case-sensitive.
+	// The content of the string containing this variable will be replaced by the actual label value on the member cluster.
+	// For example, if the string is "${MEMBER-CLUSTER-LABEL-KEY-kube-fleet.io/region}" then the key name is "kube-fleet.io/region".
+	// If there is a label "kube-fleet.io/region": "us-west-1" on the member cluster, this string will be replaced by "us-west-1".
 	OverrideClusterLabelKeyVariablePrefix = "${MEMBER-CLUSTER-LABEL-KEY-"
 )

--- a/apis/placement/v1alpha1/common.go
+++ b/apis/placement/v1alpha1/common.go
@@ -19,9 +19,9 @@ const (
 	OverrideClusterNameVariable = "${MEMBER-CLUSTER-NAME}"
 
 	// OverrideClusterLabelKeyVariablePrefix is the reserved variable prefix in the override expression.
-	// The string will be replaced by the actual label value with the given the name of the key following the prefix.
-	// The key name ends with a "}" character.
-	// The key name has a maximum length of 63 characters and must be a valid label name.
-	// For example, if the key name is "region", the variable will be "${MEMBER-CLUSTER-LABEL-KEY-region}"
+	// The string will be replaced by the actual label value associated with the key following the prefix.
+	// The key name ends with a "}" character (but not include it).
+	// The key name must be a valid label name and case-sensitive.
+	// For example, if the key name is "kube-fleet.io/region", the variable will be "${MEMBER-CLUSTER-LABEL-KEY-kube-fleet.io/region}"
 	OverrideClusterLabelKeyVariablePrefix = "${MEMBER-CLUSTER-LABEL-KEY-"
 )

--- a/apis/placement/v1alpha1/common.go
+++ b/apis/placement/v1alpha1/common.go
@@ -17,4 +17,11 @@ const (
 
 	// OverrideClusterNameVariable is the reserved variable in the override value that will be replaced by the actual cluster name.
 	OverrideClusterNameVariable = "${MEMBER-CLUSTER-NAME}"
+
+	// OverrideClusterLabelKeyVariablePrefix is the reserved variable prefix in the override expression.
+	// The string will be replaced by the actual label value with the given the name of the key following the prefix.
+	// The key name ends with a "}" character.
+	// The key name has a maximum length of 63 characters and must be a valid label name.
+	// For example, if the key name is "region", the variable will be "${MEMBER-CLUSTER-LABEL-KEY-region}"
+	OverrideClusterLabelKeyVariablePrefix = "${MEMBER-CLUSTER-LABEL-KEY-"
 )

--- a/pkg/controllers/workgenerator/override.go
+++ b/pkg/controllers/workgenerator/override.go
@@ -185,7 +185,7 @@ func applyOverrideRules(resource *placementv1beta1.ResourceContent, cluster *clu
 			return nil
 		}
 		// Apply JSONPatchOverrides by default
-		if err := applyJSONPatchOverride(resource, cluster, rule.JSONPatchOverrides); err != nil {
+		if err = applyJSONPatchOverride(resource, cluster, rule.JSONPatchOverrides); err != nil {
 			klog.ErrorS(err, "Failed to apply JSON patch override")
 			return controller.NewUserError(err)
 		}
@@ -195,16 +195,24 @@ func applyOverrideRules(resource *placementv1beta1.ResourceContent, cluster *clu
 
 // applyJSONPatchOverride applies a JSON patch on the selected resources following [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902).
 func applyJSONPatchOverride(resourceContent *placementv1beta1.ResourceContent, cluster *clusterv1beta1.MemberCluster, overrides []placementv1alpha1.JSONPatchOverride) error {
+	var err error
 	if len(overrides) == 0 { // do nothing
 		return nil
 	}
 	// go through the JSON patch overrides to replace the built-in variables before json Marshal
 	// as it may contain the built-in variables that cannot be marshaled directly
 	for i := range overrides {
-		// find and replace a few special built-in variables
-		// replace the built-in variable with the actual cluster name
-		processedJSONStr := []byte(strings.ReplaceAll(string(overrides[i].Value.Raw), placementv1alpha1.OverrideClusterNameVariable, cluster.Name))
-		overrides[i].Value.Raw = processedJSONStr
+		// Process the JSON string to replace variables
+		jsonStr := string(overrides[i].Value.Raw)
+		// Replace the built-in ${MEMBER-CLUSTER-NAME} variable with the actual cluster name
+		jsonStr = strings.ReplaceAll(jsonStr, placementv1alpha1.OverrideClusterNameVariable, cluster.Name)
+		// Replace label key variables with actual label values
+		jsonStr, err = replaceClusterLabelKeyVariables(jsonStr, cluster)
+		if err != nil {
+			klog.ErrorS(err, "Failed to replace cluster label key variables in JSON patch override")
+			return err
+		}
+		overrides[i].Value.Raw = []byte(jsonStr)
 	}
 
 	jsonPatchBytes, err := json.Marshal(overrides)
@@ -226,4 +234,39 @@ func applyJSONPatchOverride(resourceContent *placementv1beta1.ResourceContent, c
 	}
 	resourceContent.Raw = patchedObjectJSONBytes
 	return nil
+}
+
+// replaceClusterLabelKeyVariables finds all occurrences of the OverrideClusterLabelKeyVariablePrefix pattern
+// (e.g. ${MEMBER-CLUSTER-LABEL-KEY-region}) in the input string and replaces them with
+// the corresponding label values from the cluster.
+// If a label with the specified key doesn't exist, the variable remains unchanged.
+func replaceClusterLabelKeyVariables(input string, cluster *clusterv1beta1.MemberCluster) (string, error) {
+	prefixLen := len(placementv1alpha1.OverrideClusterLabelKeyVariablePrefix)
+	result := input
+
+	for {
+		startIdx := strings.Index(result, placementv1alpha1.OverrideClusterLabelKeyVariablePrefix)
+		if startIdx == -1 {
+			break
+		}
+		// extract the key value user wants to replace
+		endIdx := strings.Index(result[startIdx+prefixLen:], "}")
+		if endIdx == -1 {
+			klog.V(2).InfoS("malformed key ${MEMBER-CLUSTER-LABEL-KEY without the closing `}`", "input", input)
+			return "", fmt.Errorf("input %s is missing the closing bracket `}`", input)
+		}
+		endIdx += startIdx + prefixLen
+		// extract the key name
+		keyName := result[startIdx+prefixLen : endIdx]
+		// check if the key exists in the cluster labels
+		labelValue, exists := cluster.ObjectMeta.Labels[keyName]
+		if !exists {
+			klog.V(2).InfoS("Label key not found on cluster", "key", keyName, "cluster", cluster.Name)
+			return "", fmt.Errorf("label key %s not found on cluster %s", keyName, cluster.Name)
+		}
+		// replace this instance of the variable with the actual label value
+		fullVariable := result[startIdx : endIdx+1]
+		result = strings.Replace(result, fullVariable, labelValue, 1)
+	}
+	return result, nil
 }

--- a/pkg/controllers/workgenerator/override.go
+++ b/pkg/controllers/workgenerator/override.go
@@ -239,7 +239,7 @@ func applyJSONPatchOverride(resourceContent *placementv1beta1.ResourceContent, c
 // replaceClusterLabelKeyVariables finds all occurrences of the OverrideClusterLabelKeyVariablePrefix pattern
 // (e.g. ${MEMBER-CLUSTER-LABEL-KEY-region}) in the input string and replaces them with
 // the corresponding label values from the cluster.
-// If a label with the specified key doesn't exist, the variable remains unchanged.
+// If a label with the specified key doesn't exist, it returns an error.
 func replaceClusterLabelKeyVariables(input string, cluster *clusterv1beta1.MemberCluster) (string, error) {
 	prefixLen := len(placementv1alpha1.OverrideClusterLabelKeyVariablePrefix)
 	result := input

--- a/pkg/controllers/workgenerator/override_test.go
+++ b/pkg/controllers/workgenerator/override_test.go
@@ -2760,7 +2760,7 @@ func TestApplyJSONPatchOverride(t *testing.T) {
 	}
 }
 
-func Test_replaceClusterLabelKeyVariables(t *testing.T) {
+func TestReplaceClusterLabelKeyVariables(t *testing.T) {
 	tests := map[string]struct {
 		cluster   *clusterv1beta1.MemberCluster
 		input     string
@@ -2819,6 +2819,17 @@ func Test_replaceClusterLabelKeyVariables(t *testing.T) {
 			input:     "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-region}",
 			expectErr: true,
 		},
+		"ClusterLabelKey Variable key case not match": {
+			cluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"region": "us-west-1",
+					},
+				},
+			},
+			input:     "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-REGION}",
+			expectErr: true,
+		},
 		"Invalid  clusterLabelKey variable format": {
 			cluster: &clusterv1beta1.MemberCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2828,6 +2839,17 @@ func Test_replaceClusterLabelKeyVariables(t *testing.T) {
 				},
 			},
 			input:     "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-region",
+			expectErr: true,
+		},
+		"ClusterLabelKey variable key empty": {
+			cluster: &clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"region": "us-west-1",
+					},
+				},
+			},
+			input:     "The cluster is in ${MEMBER-CLUSTER-LABEL-KEY-}",
 			expectErr: true,
 		},
 	}

--- a/pkg/controllers/workgenerator/override_test.go
+++ b/pkg/controllers/workgenerator/override_test.go
@@ -2050,6 +2050,11 @@ func TestApplyOverrides_namespacedScopeResource(t *testing.T) {
 					},
 				},
 			},
+			cluster: clusterv1beta1.MemberCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-1",
+				},
+			},
 			roMap: map[placementv1beta1.ResourceIdentifier][]*placementv1alpha1.ResourceOverrideSnapshot{
 				{
 					Group:     utils.DeploymentGVK.Group,


### PR DESCRIPTION
### Description of your changes

Allow user to use the value of an arbitrary key on the cluster as the override
example 
${MEMBER-CLUSTER-LABEL-KEY-fleet.azure.com/location-region_public} 

would be replaced by the value of the key fleet.azure.com/location-region_public on the cluster

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
