### PR TITLE
test: log ns deletion timestamp in e2e to debug resource cleanup flakiness

### DIFF
--- a/test/e2e/actuals_test.go
+++ b/test/e2e/actuals_test.go
@@ -7,6 +7,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
@@ -975,8 +976,11 @@ func workNamespaceRemovedFromClusterActual(cluster *framework.Cluster) func() er
 
 	ns := appNamespace()
 	return func() error {
-		if err := client.Get(ctx, types.NamespacedName{Name: ns.Name}, &corev1.Namespace{}); !errors.IsNotFound(err) {
-			return fmt.Errorf("work namespace %s still exists or an unexpected error occurred: %w", ns.Name, err)
+		if err := client.Get(ctx, types.NamespacedName{Name: ns.Name}, &ns); !errors.IsNotFound(err) {
+			if err == nil {
+				return fmt.Errorf("work namespace %s still exist, deletion timestamp: %v, current timestamp: %v", ns.Name, ns.DeletionTimestamp, time.Now())
+			}
+			return fmt.Errorf("getting work namespace %s failed: %w", ns.Name, err)
 		}
 		return nil
 	}

--- a/test/e2e/actuals_test.go
+++ b/test/e2e/actuals_test.go
@@ -989,7 +989,7 @@ func workNamespaceRemovedFromClusterActual(cluster *framework.Cluster) func() er
 						},
 					},
 				}); listErr != nil {
-					return fmt.Errorf("work namespace %s still exists and failed to list resources: %v, deletion timestamp: %v, current timestamp: %v",
+					return fmt.Errorf("work namespace %s still exists and failed to list resources: %w, deletion timestamp: %v, current timestamp: %v",
 						ns.Name, listErr, ns.DeletionTimestamp, time.Now())
 				}
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -743,7 +743,7 @@ func checkIfRemovedWorkResourcesFromMemberClusters(clusters []*framework.Cluster
 		memberCluster := clusters[idx]
 
 		workResourcesRemovedActual := workNamespaceRemovedFromClusterActual(memberCluster)
-		Eventually(workResourcesRemovedActual, 3*eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove work resources from member cluster %s", memberCluster.ClusterName)
+		Eventually(workResourcesRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove work resources from member cluster %s", memberCluster.ClusterName)
 	}
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -743,7 +743,7 @@ func checkIfRemovedWorkResourcesFromMemberClusters(clusters []*framework.Cluster
 		memberCluster := clusters[idx]
 
 		workResourcesRemovedActual := workNamespaceRemovedFromClusterActual(memberCluster)
-		Eventually(workResourcesRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove work resources from member cluster %s", memberCluster.ClusterName)
+		Eventually(workResourcesRemovedActual, 2*eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove work resources from member cluster %s", memberCluster.ClusterName)
 	}
 }
 

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -743,7 +743,7 @@ func checkIfRemovedWorkResourcesFromMemberClusters(clusters []*framework.Cluster
 		memberCluster := clusters[idx]
 
 		workResourcesRemovedActual := workNamespaceRemovedFromClusterActual(memberCluster)
-		Eventually(workResourcesRemovedActual, 2*eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove work resources from member cluster %s", memberCluster.ClusterName)
+		Eventually(workResourcesRemovedActual, 3*eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove work resources from member cluster %s", memberCluster.ClusterName)
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

Resource cleanup relies on garbage collection of child resources when their owner (AppliedWork) is deleted. The controllers do not wait for the clean up to fully complete to return. Our e2e test is flaky when checking the resources are completely deleted as current 10s wait time is not enough. Sample failures:

https://github.com/Azure/fleet/actions/runs/13911855578/job/38927583698
https://github.com/Azure/fleet/actions/runs/13840189622/job/38725462003?pr=1079

This PR logs the ns deletion timestamp to help debug.

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
