### PR TITLE
fix: enable the work applier to process objects with both name and generate name specified

### DIFF
--- a/pkg/controllers/workapplier/controller.go
+++ b/pkg/controllers/workapplier/controller.go
@@ -148,7 +148,7 @@ type manifestProcessingAppliedResultType string
 const (
 	// The result types and descriptions for processing failures.
 	ManifestProcessingApplyResultTypeDecodingErred                  manifestProcessingAppliedResultType = "DecodingErred"
-	ManifestProcessingApplyResultTypeFoundGenerateNames             manifestProcessingAppliedResultType = "FoundGenerateNames"
+	ManifestProcessingApplyResultTypeFoundGenerateName              manifestProcessingAppliedResultType = "FoundGenerateName"
 	ManifestProcessingApplyResultTypeDuplicated                     manifestProcessingAppliedResultType = "Duplicated"
 	ManifestProcessingApplyResultTypeFailedToFindObjInMemberCluster manifestProcessingAppliedResultType = "FailedToFindObjInMemberCluster"
 	ManifestProcessingApplyResultTypeFailedToTakeOver               manifestProcessingAppliedResultType = "FailedToTakeOver"

--- a/pkg/controllers/workapplier/controller_integration_test.go
+++ b/pkg/controllers/workapplier/controller_integration_test.go
@@ -895,6 +895,197 @@ var _ = Describe("applying manifests", func() {
 			// deletion; consequently this test suite would not attempt so verify its deletion.
 		})
 	})
+
+	Context("should handle objects with generate names properly", Ordered, func() {
+		workName := fmt.Sprintf(workNameTemplate, utils.RandStr())
+
+		// The environment prepared by the envtest package does not support namespace
+		// deletion; each test case would use a new namespace.
+		nsName := fmt.Sprintf(nsNameTemplate, utils.RandStr())
+
+		nsGenerateName := "work-"
+		deployGenerateName := "deploy-foo-"
+
+		var appliedWorkOwnerRef *metav1.OwnerReference
+		var regularNS *corev1.Namespace
+		var regularDeploy *appsv1.Deployment
+
+		BeforeAll(func() {
+			// Prepare a NS object with both generate name and name.
+			// This should be handled by the work applier properly.
+			regularNS = ns.DeepCopy()
+			regularNS.Name = nsName
+			regularNS.GenerateName = nsGenerateName
+			regularNSJSON := marshalK8sObjJSON(regularNS)
+
+			// Prepare a Deployment object with only generate name.
+			// This should be rejected by the work applier.
+			regularDeploy = deploy.DeepCopy()
+			regularDeploy.Namespace = nsName
+			regularDeploy.Name = ""
+			regularDeploy.GenerateName = deployGenerateName
+			regularDeployJSON := marshalK8sObjJSON(regularDeploy)
+
+			// Create a new Work object with all the manifest JSONs.
+			createWorkObject(workName, nil, regularNSJSON, regularDeployJSON)
+		})
+
+		It("should add cleanup finalizer to the Work object", func() {
+			finalizerAddedActual := workFinalizerAddedActual(workName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add cleanup finalizer to the Work object")
+		})
+
+		It("should prepare an AppliedWork object", func() {
+			appliedWorkCreatedActual := appliedWorkCreatedActual(workName)
+			Eventually(appliedWorkCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to prepare an AppliedWork object")
+
+			appliedWorkOwnerRef = prepareAppliedWorkOwnerRef(workName)
+		})
+
+		It("should apply some of the manifests", func() {
+			// Ensure that the NS object has been applied as expected.
+			Eventually(func() error {
+				// Retrieve the NS object.
+				gotNS := &corev1.Namespace{}
+				if err := memberClient.Get(ctx, client.ObjectKey{Name: nsName}, gotNS); err != nil {
+					return fmt.Errorf("failed to retrieve the NS object: %w", err)
+				}
+
+				// Check that the NS object has been created as expected.
+
+				// To ignore default values automatically, here the test suite rebuilds the objects.
+				wantNS := ns.DeepCopy()
+				wantNS.TypeMeta = metav1.TypeMeta{}
+				wantNS.Name = nsName
+				wantNS.GenerateName = nsGenerateName
+				wantNS.OwnerReferences = []metav1.OwnerReference{
+					*appliedWorkOwnerRef,
+				}
+
+				rebuiltGotNS := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            gotNS.Name,
+						GenerateName:    gotNS.GenerateName,
+						OwnerReferences: gotNS.OwnerReferences,
+					},
+				}
+
+				if diff := cmp.Diff(rebuiltGotNS, wantNS); diff != "" {
+					return fmt.Errorf("namespace diff (-got +want):\n%s", diff)
+				}
+				return nil
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to apply the namespace object")
+
+			Expect(memberClient.Get(ctx, client.ObjectKey{Name: nsName}, regularNS)).To(Succeed(), "Failed to retrieve the NS object")
+		})
+
+		It("should not apply the Deployment object", func() {
+			Consistently(func() error {
+				// List all Deployments.
+				gotDeployList := &appsv1.DeploymentList{}
+				if err := memberClient.List(ctx, gotDeployList, client.InNamespace(nsName)); err != nil {
+					return fmt.Errorf("failed to list the Deployment object: %w", err)
+				}
+
+				for _, gotDeploy := range gotDeployList.Items {
+					if gotDeploy.GenerateName == deployGenerateName {
+						return fmt.Errorf("deployment object that should not be applied exists: %s", gotDeploy.Name)
+					}
+				}
+				return nil
+			}, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Applied the deployment object; expected an error")
+		})
+
+		It("should update the Work object status", func() {
+			// Prepare the status information.
+			workConds := []metav1.Condition{
+				{
+					Type:   fleetv1beta1.WorkConditionTypeApplied,
+					Status: metav1.ConditionFalse,
+					Reason: WorkNotAllManifestsAppliedReason,
+				},
+			}
+			manifestConds := []fleetv1beta1.ManifestCondition{
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeApplied,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ManifestProcessingApplyResultTypeApplied),
+							ObservedGeneration: 0,
+						},
+						{
+							Type:               fleetv1beta1.WorkConditionTypeAvailable,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ManifestProcessingAvailabilityResultTypeAvailable),
+							ObservedGeneration: 0,
+						},
+					},
+				},
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:   1,
+						Group:     "apps",
+						Version:   "v1",
+						Kind:      "Deployment",
+						Resource:  "deployments",
+						Namespace: nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeApplied,
+							Status:             metav1.ConditionFalse,
+							Reason:             string(ManifestProcessingApplyResultTypeFoundGenerateName),
+							ObservedGeneration: 0,
+						},
+					},
+				},
+			}
+
+			workStatusUpdatedActual := workStatusUpdated(workName, workConds, manifestConds, nil, nil)
+			Eventually(workStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update work status")
+		})
+
+		It("should update the AppliedWork object status", func() {
+			// Prepare the status information.
+			appliedResourceMeta := []fleetv1beta1.AppliedResourceMeta{
+				{
+					WorkResourceIdentifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					UID: regularNS.UID,
+				},
+			}
+
+			appliedWorkStatusUpdatedActual := appliedWorkStatusUpdated(workName, appliedResourceMeta)
+			Eventually(appliedWorkStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update appliedWork status")
+		})
+
+		AfterAll(func() {
+			// Delete the Work object and related resources.
+			cleanupWorkObject(workName)
+
+			// Ensure that all applied manifests have been removed.
+			appliedWorkRemovedActual := appliedWorkRemovedActual(workName)
+			Eventually(appliedWorkRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the AppliedWork object")
+
+			// The environment prepared by the envtest package does not support namespace
+			// deletion; consequently this test suite would not attempt so verify its deletion.
+		})
+	})
 })
 
 var _ = Describe("drift detection and takeover", func() {

--- a/pkg/controllers/workapplier/controller_integration_test.go
+++ b/pkg/controllers/workapplier/controller_integration_test.go
@@ -984,12 +984,12 @@ var _ = Describe("applying manifests", func() {
 				// List all Deployments.
 				gotDeployList := &appsv1.DeploymentList{}
 				if err := memberClient.List(ctx, gotDeployList, client.InNamespace(nsName)); err != nil {
-					return fmt.Errorf("failed to list the Deployment object: %w", err)
+					return fmt.Errorf("failed to list Deployment objects: %w", err)
 				}
 
 				for _, gotDeploy := range gotDeployList.Items {
 					if gotDeploy.GenerateName == deployGenerateName {
-						return fmt.Errorf("deployment object that should not be applied exists: %s", gotDeploy.Name)
+						return fmt.Errorf("found a Deployment object with generate name that should not be applied")
 					}
 				}
 				return nil

--- a/pkg/controllers/workapplier/preprocess.go
+++ b/pkg/controllers/workapplier/preprocess.go
@@ -61,11 +61,12 @@ func (r *Reconciler) preProcessManifests(
 			return
 		}
 
-		// Reject objects with generate names.
-		if len(manifestObj.GetGenerateName()) > 0 {
-			klog.V(2).InfoS("Reject objects with generate names", "manifestObj", klog.KObj(manifestObj), "work", klog.KObj(work))
-			bundle.applyErr = fmt.Errorf("objects with generate names are not supported")
-			bundle.applyResTyp = ManifestProcessingApplyResultTypeFoundGenerateNames
+		// Reject objects with a generate name but no name.
+		if len(manifestObj.GetGenerateName()) > 0 && len(manifestObj.GetName()) == 0 {
+			// The manifest object has a generate name but no name.
+			klog.V(2).InfoS("Reject objects with only generate name", "manifestObj", klog.KObj(manifestObj), "work", klog.KObj(work))
+			bundle.applyErr = fmt.Errorf("objects with only generate name are not supported")
+			bundle.applyResTyp = ManifestProcessingApplyResultTypeFoundGenerateName
 			return
 		}
 


### PR DESCRIPTION
### Description of your changes

This PR fixes an issue where work applier will reject objects with both generate name and name set.

Note that objects with only generate name are still rejected by Fleet.

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Integration tests
- [x] E2E tests 

### Special notes for your reviewer

