### PR TITLE
fix: address the issue work applier has after disabling parallelism + add more log entries

### DIFF
--- a/pkg/controllers/workapplier/apply.go
+++ b/pkg/controllers/workapplier/apply.go
@@ -112,6 +112,8 @@ func (r *Reconciler) apply(
 
 		// Note that Fleet might choose to skip the last applied annotation due to size limits
 		// even if no error has occurred.
+		klog.V(2).InfoS("Completed the last applied annotation setting process", "isSet", isLastAppliedAnnotationSet,
+			"GVR", *gvr, "manifestObj", klog.KObj(manifestObjCopy))
 	}
 
 	// Create the object if it does not exist in the member cluster.
@@ -144,11 +146,15 @@ func (r *Reconciler) apply(
 		// The apply strategy dictates that three-way merge patch
 		// (client-side apply) should be used, and the last applied annotation
 		// has been set.
+		klog.V(2).InfoS("Using three-way merge patch to apply the manifest object",
+			"GVR", *gvr, "manifestObj", klog.KObj(manifestObjCopy))
 		return r.threeWayMergePatch(ctx, gvr, manifestObjCopy, inMemberClusterObj, isOptimisticLockEnabled, false)
 	case applyStrategy.Type == fleetv1beta1.ApplyStrategyTypeClientSideApply:
 		// The apply strategy dictates that three-way merge patch
 		// (client-side apply) should be used, but the last applied annotation
 		// cannot be set. Fleet will fall back to server-side apply.
+		klog.V(2).InfoS("Falling back to server-side apply as the last applied annotation cannot be set",
+			"GVR", *gvr, "manifestObj", klog.KObj(manifestObjCopy))
 		return r.serverSideApply(
 			ctx,
 			gvr, manifestObjCopy, inMemberClusterObj,
@@ -156,6 +162,8 @@ func (r *Reconciler) apply(
 		)
 	case applyStrategy.Type == fleetv1beta1.ApplyStrategyTypeServerSideApply:
 		// The apply strategy dictates that server-side apply should be used.
+		klog.V(2).InfoS("Using server-side apply to apply the manifest object",
+			"GVR", *gvr, "manifestObj", klog.KObj(manifestObjCopy))
 		return r.serverSideApply(
 			ctx,
 			gvr, manifestObjCopy, inMemberClusterObj,
@@ -184,6 +192,7 @@ func (r *Reconciler) createManifestObject(
 		wrappedErr := controller.NewAPIServerError(false, err)
 		return nil, fmt.Errorf("failed to create manifest object: %w", wrappedErr)
 	}
+	klog.V(2).InfoS("Created the manifest object", "GVR", *gvr, "manifestObj", klog.KObj(createdObj))
 	return createdObj, nil
 }
 

--- a/pkg/controllers/workapplier/availability_tracker.go
+++ b/pkg/controllers/workapplier/availability_tracker.go
@@ -41,6 +41,16 @@ func (r *Reconciler) trackInMemberClusterObjAvailability(ctx context.Context, bu
 			// The manifest object in the bundle has not been applied yet. No availability check
 			// is needed.
 			bundle.availabilityResTyp = ManifestProcessingAvailabilityResultTypeSkipped
+
+			// Note that some of the objects might have failed the pre-processing stage and do not
+			// even have a GVR or a manifest object.
+			if bundle.gvr != nil && bundle.manifestObj != nil {
+				klog.V(2).InfoS("The manifest object is not applied yet, skipping the availability check",
+					"GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj), "inMemberClusterObj", klog.KObj(bundle.inMemberClusterObj), "work", workRef)
+			} else {
+				klog.V(2).InfoS("The manifest object is not applied yet, skipping the availability check",
+					"ordinal", pieces, "work", workRef)
+			}
 			return
 		}
 

--- a/pkg/controllers/workapplier/controller_integration_test.go
+++ b/pkg/controllers/workapplier/controller_integration_test.go
@@ -266,6 +266,40 @@ func regularDeploymentObjectAppliedActual(nsName, deployName string, appliedWork
 	}
 }
 
+func regularConfigMapObjectAppliedActual(nsName, configMapName string, appliedWorkOwnerRef *metav1.OwnerReference) func() error {
+	return func() error {
+		// Retrieve the ConfigMap object.
+		gotConfigMap := &corev1.ConfigMap{}
+		if err := memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: configMapName}, gotConfigMap); err != nil {
+			return fmt.Errorf("failed to retrieve the ConfigMap object: %w", err)
+		}
+
+		// Check that the ConfigMap object has been created as expected.
+
+		// To ignore default values automatically, here the test suite rebuilds the objects.
+		wantConfigMap := configMap.DeepCopy()
+		wantConfigMap.TypeMeta = metav1.TypeMeta{}
+		wantConfigMap.Namespace = nsName
+		wantConfigMap.Name = configMapName
+		wantConfigMap.OwnerReferences = []metav1.OwnerReference{
+			*appliedWorkOwnerRef,
+		}
+
+		rebuiltGotConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            gotConfigMap.Name,
+				Namespace:       gotConfigMap.Namespace,
+				OwnerReferences: gotConfigMap.OwnerReferences,
+			},
+			Data: gotConfigMap.Data,
+		}
+		if diff := cmp.Diff(rebuiltGotConfigMap, wantConfigMap); diff != "" {
+			return fmt.Errorf("configmap diff (-got +want):\n%s", diff)
+		}
+		return nil
+	}
+}
+
 func markDeploymentAsAvailable(nsName, deployName string) {
 	// Retrieve the Deployment object.
 	gotDeploy := &appsv1.Deployment{}
@@ -439,6 +473,27 @@ func regularDeployRemovedActual(nsName, deployName string) func() error {
 
 		if err := memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: deployName}, deploy); !errors.IsNotFound(err) {
 			return fmt.Errorf("deployment object still exists or an unexpected error occurred: %w", err)
+		}
+		return nil
+	}
+}
+
+func regularConfigMapRemovedActual(nsName, configMapName string) func() error {
+	return func() error {
+		// Retrieve the ConfigMap object.
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: nsName,
+				Name:      configMapName,
+			},
+		}
+		if err := memberClient.Delete(ctx, configMap); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete the ConfigMap object: %w", err)
+		}
+
+		// Check that the ConfigMap object has been deleted.
+		if err := memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: configMapName}, configMap); !errors.IsNotFound(err) {
+			return fmt.Errorf("configMap object still exists or an unexpected error occurred: %w", err)
 		}
 		return nil
 	}
@@ -1083,6 +1138,194 @@ var _ = Describe("applying manifests", func() {
 			// Ensure that all applied manifests have been removed.
 			appliedWorkRemovedActual := appliedWorkRemovedActual(workName)
 			Eventually(appliedWorkRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the AppliedWork object")
+
+			// The environment prepared by the envtest package does not support namespace
+			// deletion; consequently this test suite would not attempt so verify its deletion.
+		})
+	})
+
+	Context("can handle partial failures (pre-processing, decoding error)", Ordered, func() {
+		workName := fmt.Sprintf(workNameTemplate, utils.RandStr())
+		// The environment prepared by the envtest package does not support namespace
+		// deletion; each test case would use a new namespace.
+		nsName := fmt.Sprintf(nsNameTemplate, utils.RandStr())
+
+		var appliedWorkOwnerRef *metav1.OwnerReference
+		var regularNS *corev1.Namespace
+		var decodingErredDeploy *appsv1.Deployment
+		var regularConfigMap *corev1.ConfigMap
+
+		BeforeAll(func() {
+			// Prepare a NS object.
+			regularNS = ns.DeepCopy()
+			regularNS.Name = nsName
+			regularNSJSON := marshalK8sObjJSON(regularNS)
+
+			// Prepare a mal-formed Deployment object.
+			decodingErredDeploy = deploy.DeepCopy()
+			decodingErredDeploy.TypeMeta = metav1.TypeMeta{
+				APIVersion: "dummy/v10",
+				Kind:       "Fake",
+			}
+			decodingErredDeploy.Namespace = nsName
+			decodingErredDeploy.Name = deployName
+			decodingErredDeployJSON := marshalK8sObjJSON(decodingErredDeploy)
+
+			// Prepare a ConfigMap object.
+			regularConfigMap = configMap.DeepCopy()
+			regularConfigMap.Namespace = nsName
+			regularConfigMapJSON := marshalK8sObjJSON(regularConfigMap)
+
+			// Create a new Work object with all the manifest JSONs.
+			createWorkObject(workName, nil, regularNSJSON, decodingErredDeployJSON, regularConfigMapJSON)
+		})
+
+		It("should add cleanup finalizer to the Work object", func() {
+			finalizerAddedActual := workFinalizerAddedActual(workName)
+			Eventually(finalizerAddedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to add cleanup finalizer to the Work object")
+		})
+
+		It("should prepare an AppliedWork object", func() {
+			appliedWorkCreatedActual := appliedWorkCreatedActual(workName)
+			Eventually(appliedWorkCreatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to prepare an AppliedWork object")
+
+			appliedWorkOwnerRef = prepareAppliedWorkOwnerRef(workName)
+		})
+
+		It("should apply the manifests", func() {
+			// Ensure that the NS object has been applied as expected.
+			regularNSObjectAppliedActual := regularNSObjectAppliedActual(nsName, appliedWorkOwnerRef)
+			Eventually(regularNSObjectAppliedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to apply the namespace object")
+
+			Expect(memberClient.Get(ctx, client.ObjectKey{Name: nsName}, regularNS)).To(Succeed(), "Failed to retrieve the NS object")
+
+			// Ensure that the ConfigMap object has been applied as expected.
+			regularConfigMapObjectAppliedActual := regularConfigMapObjectAppliedActual(nsName, configMapName, appliedWorkOwnerRef)
+			Eventually(regularConfigMapObjectAppliedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to apply the ConfigMap object")
+			Expect(memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: configMapName}, regularConfigMap)).To(Succeed(), "Failed to retrieve the Deployment object")
+		})
+
+		It("should update the Work object status", func() {
+			// Prepare the status information.
+			workConds := []metav1.Condition{
+				{
+					Type:   fleetv1beta1.WorkConditionTypeApplied,
+					Status: metav1.ConditionFalse,
+					Reason: WorkNotAllManifestsAppliedReason,
+				},
+			}
+			manifestConds := []fleetv1beta1.ManifestCondition{
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:               fleetv1beta1.WorkConditionTypeApplied,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ManifestProcessingApplyResultTypeApplied),
+							ObservedGeneration: 0,
+						},
+						{
+							Type:               fleetv1beta1.WorkConditionTypeAvailable,
+							Status:             metav1.ConditionTrue,
+							Reason:             string(ManifestProcessingAvailabilityResultTypeAvailable),
+							ObservedGeneration: 0,
+						},
+					},
+				},
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:   1,
+						Group:     "dummy",
+						Version:   "v10",
+						Kind:      "Fake",
+						Name:      deployName,
+						Namespace: nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:   fleetv1beta1.WorkConditionTypeApplied,
+							Status: metav1.ConditionFalse,
+							Reason: string(ManifestProcessingApplyResultTypeDecodingErred),
+						},
+					},
+				},
+				{
+					Identifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:   2,
+						Version:   "v1",
+						Kind:      "ConfigMap",
+						Resource:  "configmaps",
+						Name:      configMapName,
+						Namespace: nsName,
+					},
+					Conditions: []metav1.Condition{
+						{
+							Type:   fleetv1beta1.WorkConditionTypeApplied,
+							Status: metav1.ConditionTrue,
+							Reason: string(ManifestProcessingApplyResultTypeApplied),
+						},
+						{
+							Type:   fleetv1beta1.WorkConditionTypeAvailable,
+							Status: metav1.ConditionTrue,
+							Reason: string(ManifestProcessingAvailabilityResultTypeAvailable),
+						},
+					},
+				},
+			}
+
+			workStatusUpdatedActual := workStatusUpdated(workName, workConds, manifestConds, nil, nil)
+			Eventually(workStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update work status")
+		})
+
+		It("should update the AppliedWork object status", func() {
+			// Prepare the status information.
+			appliedResourceMeta := []fleetv1beta1.AppliedResourceMeta{
+				{
+					WorkResourceIdentifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:  0,
+						Group:    "",
+						Version:  "v1",
+						Kind:     "Namespace",
+						Resource: "namespaces",
+						Name:     nsName,
+					},
+					UID: regularNS.UID,
+				},
+				{
+					WorkResourceIdentifier: fleetv1beta1.WorkResourceIdentifier{
+						Ordinal:   2,
+						Group:     "",
+						Version:   "v1",
+						Kind:      "ConfigMap",
+						Resource:  "configmaps",
+						Name:      configMapName,
+						Namespace: nsName,
+					},
+					UID: regularConfigMap.UID,
+				},
+			}
+
+			appliedWorkStatusUpdatedActual := appliedWorkStatusUpdated(workName, appliedResourceMeta)
+			Eventually(appliedWorkStatusUpdatedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update appliedWork status")
+		})
+
+		AfterAll(func() {
+			// Delete the Work object and related resources.
+			cleanupWorkObject(workName)
+
+			// Ensure that all applied manifests have been removed.
+			appliedWorkRemovedActual := appliedWorkRemovedActual(workName)
+			Eventually(appliedWorkRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the AppliedWork object")
+
+			regularConfigMapRemovedActual := regularConfigMapRemovedActual(nsName, configMapName)
+			Eventually(regularConfigMapRemovedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the ConfigMap object")
 
 			// The environment prepared by the envtest package does not support namespace
 			// deletion; consequently this test suite would not attempt so verify its deletion.

--- a/pkg/controllers/workapplier/controller_integration_test.go
+++ b/pkg/controllers/workapplier/controller_integration_test.go
@@ -1202,7 +1202,7 @@ var _ = Describe("applying manifests", func() {
 			// Ensure that the ConfigMap object has been applied as expected.
 			regularConfigMapObjectAppliedActual := regularConfigMapObjectAppliedActual(nsName, configMapName, appliedWorkOwnerRef)
 			Eventually(regularConfigMapObjectAppliedActual, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to apply the ConfigMap object")
-			Expect(memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: configMapName}, regularConfigMap)).To(Succeed(), "Failed to retrieve the Deployment object")
+			Expect(memberClient.Get(ctx, client.ObjectKey{Namespace: nsName, Name: configMapName}, regularConfigMap)).To(Succeed(), "Failed to retrieve the ConfigMap object")
 		})
 
 		It("should update the Work object status", func() {

--- a/pkg/controllers/workapplier/controller_test.go
+++ b/pkg/controllers/workapplier/controller_test.go
@@ -94,6 +94,20 @@ var (
 	nsUnstructured *unstructured.Unstructured
 	nsJSON         []byte
 
+	configMap = &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsName,
+			Name:      configMapName,
+		},
+		Data: map[string]string{
+			dummyLabelKey: dummyLabelValue1,
+		},
+	}
+
 	dummyOwnerRef = metav1.OwnerReference{
 		APIVersion: "dummy.owner/v1",
 		Kind:       "DummyOwner",

--- a/pkg/controllers/workapplier/preprocess.go
+++ b/pkg/controllers/workapplier/preprocess.go
@@ -174,7 +174,7 @@ func (r *Reconciler) writeAheadManifestProcessingAttempts(
 		}
 		if _, found := checked[wriStr]; found {
 			klog.V(2).InfoS("A duplicate manifest has been found",
-				"ordinal", idx, "work", workRef, "WRI", wriStr)
+				"ordinal", idx, "work", workRef, "workResourceID", wriStr)
 			bundle.applyErr = fmt.Errorf("a duplicate manifest has been found")
 			bundle.applyResTyp = ManifestProcessingApplyResultTypeDuplicated
 			continue
@@ -186,7 +186,7 @@ func (r *Reconciler) writeAheadManifestProcessingAttempts(
 		manifestCondsForWA = append(manifestCondsForWA, manifestCondForWA)
 
 		klog.V(2).InfoS("Prepared write-ahead information for a manifest",
-			"manifestObj", klog.KObj(bundle.manifestObj), "WRI", wriStr, "work", workRef)
+			"manifestObj", klog.KObj(bundle.manifestObj), "workResourceID", wriStr, "work", workRef)
 	}
 
 	// Identify any manifests from previous runs that might have been applied and are now left

--- a/pkg/controllers/workapplier/preprocess.go
+++ b/pkg/controllers/workapplier/preprocess.go
@@ -64,7 +64,7 @@ func (r *Reconciler) preProcessManifests(
 		// Reject objects with a generate name but no name.
 		if len(manifestObj.GetGenerateName()) > 0 && len(manifestObj.GetName()) == 0 {
 			// The manifest object has a generate name but no name.
-			klog.V(2).InfoS("Reject objects with only generate name", "manifestObj", klog.KObj(manifestObj), "work", klog.KObj(work))
+			klog.V(2).InfoS("Rejected an object with only generate name", "manifestObj", klog.KObj(manifestObj), "work", klog.KObj(work))
 			bundle.applyErr = fmt.Errorf("objects with only generate name are not supported")
 			bundle.applyResTyp = ManifestProcessingApplyResultTypeFoundGenerateName
 			return
@@ -148,6 +148,8 @@ func (r *Reconciler) writeAheadManifestProcessingAttempts(
 			// Such manifests would still be reported in the status (see the later parts of the
 			// reconciliation loop), it is just that they are not relevant in the write-ahead
 			// process.
+			klog.V(2).InfoS("Skipped a manifest in the write-ahead process as it has failed pre-processing", "work", workRef,
+				"ordinal", idx, "applyErr", bundle.applyErr, "applyResTyp", bundle.applyResTyp)
 			continue
 		}
 
@@ -209,6 +211,7 @@ func (r *Reconciler) writeAheadManifestProcessingAttempts(
 	}
 	work.Status.ManifestConditions = manifestCondsForWA
 	if err := r.hubClient.Status().Update(ctx, work); err != nil {
+		klog.ErrorS(err, "Failed to write ahead manifest processing attempts", "work", workRef)
 		return controller.NewAPIServerError(false, fmt.Errorf("failed to write ahead manifest processing attempts: %w", err))
 	}
 	klog.V(2).InfoS("Write-ahead process completed", "work", workRef)

--- a/pkg/controllers/workapplier/process.go
+++ b/pkg/controllers/workapplier/process.go
@@ -312,6 +312,7 @@ func (r *Reconciler) reportDiffOnlyIfApplicable(
 		bundle.diffs = configDiffs
 		bundle.reportDiffResTyp = ManifestProcessingReportDiffResultTypeFoundDiff
 		klog.V(2).InfoS("Diff report completed; configuration diffs are found",
+			"diffCount", len(configDiffs),
 			"GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
 			"work", klog.KObj(work))
 	default:

--- a/pkg/controllers/workapplier/process.go
+++ b/pkg/controllers/workapplier/process.go
@@ -286,6 +286,9 @@ func (r *Reconciler) reportDiffOnlyIfApplicable(
 				ValueInHub: "(the whole object)",
 			},
 		}
+		klog.V(2).InfoS("Diff report completed; the object has not been created in the member cluster yet",
+			"GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
+			"work", klog.KObj(work))
 		return true
 	}
 
@@ -308,9 +311,15 @@ func (r *Reconciler) reportDiffOnlyIfApplicable(
 		// Configuration diffs are found.
 		bundle.diffs = configDiffs
 		bundle.reportDiffResTyp = ManifestProcessingReportDiffResultTypeFoundDiff
+		klog.V(2).InfoS("Diff report completed; configuration diffs are found",
+			"GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
+			"work", klog.KObj(work))
 	default:
 		// No configuration diffs are found.
 		bundle.reportDiffResTyp = ManifestProcessingReportDiffResultTypeNoDiffFound
+		klog.V(2).InfoS("Diff report completed; no configuration diffs are found",
+			"GVR", *bundle.gvr, "manifestObj", klog.KObj(bundle.manifestObj),
+			"work", klog.KObj(work))
 	}
 
 	klog.V(2).InfoS("ReportDiff process completed",

--- a/pkg/controllers/workapplier/process.go
+++ b/pkg/controllers/workapplier/process.go
@@ -32,7 +32,7 @@ func (r *Reconciler) processManifests(
 	for _, bundle := range bundles {
 		if bundle.applyErr != nil {
 			// Skip a manifest if it has failed pre-processing.
-			return
+			continue
 		}
 		r.processOneManifest(ctx, bundle, work, expectedAppliedWorkOwnerRef)
 		klog.V(2).InfoS("Processed a manifest", "manifestObj", klog.KObj(bundle.manifestObj), "work", klog.KObj(work))

--- a/pkg/controllers/workapplier/status.go
+++ b/pkg/controllers/workapplier/status.go
@@ -278,7 +278,7 @@ func setManifestAppliedCondition(
 	if appliedCond != nil {
 		meta.SetStatusCondition(&manifestCond.Conditions, *appliedCond)
 		klog.V(2).InfoS("Applied condition set in ManifestCondition",
-			"WRI", manifestCond.Identifier,
+			"workResourceID", manifestCond.Identifier,
 			"applyResTyp", appliedResTyp, "applyError", applyError,
 			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	} else {
@@ -286,7 +286,7 @@ func setManifestAppliedCondition(
 		// condition is not set.
 		meta.RemoveStatusCondition(&manifestCond.Conditions, fleetv1beta1.WorkConditionTypeApplied)
 		klog.V(2).InfoS("Applied condition removed from ManifestCondition",
-			"WRI", manifestCond.Identifier,
+			"workResourceID", manifestCond.Identifier,
 			"applyResTyp", appliedResTyp, "applyError", applyError,
 			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	}
@@ -346,7 +346,7 @@ func setManifestAvailableCondition(
 	if availableCond != nil {
 		meta.SetStatusCondition(&manifestCond.Conditions, *availableCond)
 		klog.V(2).InfoS("Available condition set in ManifestCondition",
-			"WRI", manifestCond.Identifier,
+			"workResourceID", manifestCond.Identifier,
 			"availabilityResTyp", availabilityResTyp, "availabilityError", availabilityError,
 			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	} else {
@@ -354,7 +354,7 @@ func setManifestAvailableCondition(
 		// condition is not set.
 		meta.RemoveStatusCondition(&manifestCond.Conditions, fleetv1beta1.WorkConditionTypeAvailable)
 		klog.V(2).InfoS("Available condition removed from ManifestCondition",
-			"WRI", manifestCond.Identifier,
+			"workResourceID", manifestCond.Identifier,
 			"availabilityResTyp", availabilityResTyp, "availabilityError", availabilityError,
 			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	}
@@ -407,7 +407,7 @@ func setManifestDiffReportedCondition(
 	if diffReportedCond != nil {
 		meta.SetStatusCondition(&manifestCond.Conditions, *diffReportedCond)
 		klog.V(2).InfoS("DiffReported condition set in ManifestCondition",
-			"WRI", manifestCond.Identifier,
+			"workResourceID", manifestCond.Identifier,
 			"reportDiffResTyp", reportDiffResTyp, "reportDiffError", reportDiffError,
 			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	} else {
@@ -415,7 +415,7 @@ func setManifestDiffReportedCondition(
 		// condition is not set.
 		meta.RemoveStatusCondition(&manifestCond.Conditions, fleetv1beta1.WorkConditionTypeDiffReported)
 		klog.V(2).InfoS("DiffReported condition removed from ManifestCondition",
-			"WRI", manifestCond.Identifier,
+			"workResourceID", manifestCond.Identifier,
 			"reportDiffResTyp", reportDiffResTyp, "reportDiffError", reportDiffError,
 			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	}

--- a/pkg/controllers/workapplier/status.go
+++ b/pkg/controllers/workapplier/status.go
@@ -210,6 +210,8 @@ func (r *Reconciler) refreshAppliedWorkStatus(
 	// Update the AppliedWork object status.
 	appliedWork.Status.AppliedResources = appliedResources
 	if err := r.spokeClient.Status().Update(ctx, appliedWork); err != nil {
+		klog.ErrorS(err, "Failed to update AppliedWork status",
+			"appliedWork", klog.KObj(appliedWork))
 		return controller.NewAPIServerError(false, err)
 	}
 	klog.V(2).InfoS("Refreshed AppliedWork object status",
@@ -275,10 +277,18 @@ func setManifestAppliedCondition(
 
 	if appliedCond != nil {
 		meta.SetStatusCondition(&manifestCond.Conditions, *appliedCond)
+		klog.V(2).InfoS("Applied condition set in ManifestCondition",
+			"WRI", manifestCond.Identifier,
+			"applyResTyp", appliedResTyp, "applyError", applyError,
+			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	} else {
 		// As the conditions are ported back; removal must be performed if the Applied
 		// condition is not set.
 		meta.RemoveStatusCondition(&manifestCond.Conditions, fleetv1beta1.WorkConditionTypeApplied)
+		klog.V(2).InfoS("Applied condition removed from ManifestCondition",
+			"WRI", manifestCond.Identifier,
+			"applyResTyp", appliedResTyp, "applyError", applyError,
+			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	}
 }
 
@@ -335,10 +345,18 @@ func setManifestAvailableCondition(
 
 	if availableCond != nil {
 		meta.SetStatusCondition(&manifestCond.Conditions, *availableCond)
+		klog.V(2).InfoS("Available condition set in ManifestCondition",
+			"WRI", manifestCond.Identifier,
+			"availabilityResTyp", availabilityResTyp, "availabilityError", availabilityError,
+			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	} else {
 		// As the conditions are ported back; removal must be performed if the Available
 		// condition is not set.
 		meta.RemoveStatusCondition(&manifestCond.Conditions, fleetv1beta1.WorkConditionTypeAvailable)
+		klog.V(2).InfoS("Available condition removed from ManifestCondition",
+			"WRI", manifestCond.Identifier,
+			"availabilityResTyp", availabilityResTyp, "availabilityError", availabilityError,
+			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	}
 }
 
@@ -388,10 +406,18 @@ func setManifestDiffReportedCondition(
 
 	if diffReportedCond != nil {
 		meta.SetStatusCondition(&manifestCond.Conditions, *diffReportedCond)
+		klog.V(2).InfoS("DiffReported condition set in ManifestCondition",
+			"WRI", manifestCond.Identifier,
+			"reportDiffResTyp", reportDiffResTyp, "reportDiffError", reportDiffError,
+			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	} else {
 		// As the conditions are ported back; removal must be performed if the DiffReported
 		// condition is not set.
 		meta.RemoveStatusCondition(&manifestCond.Conditions, fleetv1beta1.WorkConditionTypeDiffReported)
+		klog.V(2).InfoS("DiffReported condition removed from ManifestCondition",
+			"WRI", manifestCond.Identifier,
+			"reportDiffResTyp", reportDiffResTyp, "reportDiffError", reportDiffError,
+			"inMemberClusterObjGeneration", inMemberClusterObjGeneration)
 	}
 }
 
@@ -430,10 +456,16 @@ func setWorkAppliedCondition(
 
 	if appliedCond != nil {
 		meta.SetStatusCondition(&work.Status.Conditions, *appliedCond)
+		klog.V(2).InfoS("Applied condition set on Work object",
+			"appliedManifestCount", appliedManifestCount, "manifestCount", manifestCount,
+			"work", klog.KObj(work))
 	} else {
 		// For consistency reasons, Fleet will remove the Applied condition if the
 		// it is not set in the current run (i.e., ReportDiff mode is on).
 		meta.RemoveStatusCondition(&work.Status.Conditions, fleetv1beta1.WorkConditionTypeApplied)
+		klog.V(2).InfoS("Applied condition removed on Work object",
+			"appliedManifestCount", appliedManifestCount, "manifestCount", manifestCount,
+			"work", klog.KObj(work))
 	}
 }
 
@@ -483,10 +515,18 @@ func setWorkAvailableCondition(
 
 	if availableCond != nil {
 		meta.SetStatusCondition(&work.Status.Conditions, *availableCond)
+		klog.V(2).InfoS("Available condition set on Work object",
+			"availableManifestCount", availableManifestCount, "untrackableAppliedObjectsCount", untrackableAppliedObjectsCount,
+			"manifestCount", manifestCount,
+			"work", klog.KObj(work))
 	} else {
 		// Fleet will remove the Available condition if it is not set in the current run
 		// as it can change without Work object generation bumps.
 		meta.RemoveStatusCondition(&work.Status.Conditions, fleetv1beta1.WorkConditionTypeAvailable)
+		klog.V(2).InfoS("Available condition removed on Work object",
+			"availableManifestCount", availableManifestCount, "untrackableAppliedObjectsCount", untrackableAppliedObjectsCount,
+			"manifestCount", manifestCount,
+			"work", klog.KObj(work))
 	}
 }
 
@@ -521,10 +561,16 @@ func setWorkDiffReportedCondition(
 
 	if diffReportedCond != nil {
 		meta.SetStatusCondition(&work.Status.Conditions, *diffReportedCond)
+		klog.V(2).InfoS("DiffReported condition set on Work object",
+			"diffReportedObjectsCount", diffReportedObjectsCount, "manifestCount", manifestCount,
+			"work", klog.KObj(work))
 	} else {
 		// For consistency reasons, Fleet will remove the DiffReported condition if the
 		// ReportDiff mode is not being used.
 		meta.RemoveStatusCondition(&work.Status.Conditions, fleetv1beta1.WorkConditionTypeDiffReported)
+		klog.V(2).InfoS("DiffReported condition removed on Work object",
+			"diffReportedObjectsCount", diffReportedObjectsCount, "manifestCount", manifestCount,
+			"work", klog.KObj(work))
 	}
 }
 

--- a/test/e2e/placement_negative_cases_test.go
+++ b/test/e2e/placement_negative_cases_test.go
@@ -26,7 +26,7 @@ var _ = Describe("handling errors and failures gracefully", func() {
 	//
 	// TO-DO (chenyu1): reserve an API group exclusively on the hub cluster so that
 	// envelopes do not need to used for this test spec.
-	FContext("pre-processing failure (decoding errors)", Ordered, func() {
+	Context("pre-processing failure (decoding errors)", Ordered, func() {
 		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
 		workNamespaceName := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
 

--- a/test/e2e/placement_negative_cases_test.go
+++ b/test/e2e/placement_negative_cases_test.go
@@ -18,6 +18,7 @@ import (
 
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	"go.goms.io/fleet/pkg/controllers/workapplier"
+	"go.goms.io/fleet/test/e2e/framework"
 )
 
 var _ = Describe("handling errors and failures gracefully", func() {
@@ -172,7 +173,7 @@ var _ = Describe("handling errors and failures gracefully", func() {
 					return fmt.Errorf("CRP status diff (-got, +want): %s", diff)
 				}
 				return nil
-			}, eventuallyDuration*3, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
 		})
 
 		It("should place some manifests on member clusters", func() {
@@ -213,11 +214,7 @@ var _ = Describe("handling errors and failures gracefully", func() {
 
 		AfterAll(func() {
 			// Remove the CRP and the namespace from the hub cluster.
-			cleanupCRP(crpName)
-			cleanupWorkResources()
-
-			// Clean the placed resources.
-			cleanWorkResourcesOnCluster(allMemberClusters[0])
+			ensureCRPAndRelatedResourcesDeleted(crpName, []*framework.Cluster{memberCluster1EastProd})
 		})
 	})
 })

--- a/test/e2e/placement_negative_cases_test.go
+++ b/test/e2e/placement_negative_cases_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/controllers/workapplier"
+)
+
+var _ = Describe("handling errors and failures gracefully", func() {
+	// This test spec uses envelopes for placement as it is a bit tricky to simulate
+	// decoding errors with resources created directly in the hub cluster.
+	//
+	// TO-DO (chenyu1): reserve an API group exclusively on the hub cluster so that
+	// envelopes do not need to used for this test spec.
+	FContext("pre-processing failure (decoding errors)", Ordered, func() {
+		crpName := fmt.Sprintf(crpNameTemplate, GinkgoParallelProcess())
+		workNamespaceName := fmt.Sprintf(workNamespaceNameTemplate, GinkgoParallelProcess())
+
+		wrapperCMName := "wrapper"
+		wrappedCMName1 := "app-1"
+		wrappedCMName2 := "app-2"
+
+		cmDataKey := "foo"
+		cmDataVal1 := "bar"
+		cmDataVal2 := "baz"
+
+		BeforeAll(func() {
+			// Use an envelope to create duplicate resource entries.
+			ns := appNamespace()
+			Expect(hubClient.Create(ctx, &ns)).To(Succeed(), "Failed to create namespace %s", ns.Name)
+
+			// Create an envelope config map.
+			wrapperCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      wrapperCMName,
+					Namespace: ns.Name,
+					Annotations: map[string]string{
+						placementv1beta1.EnvelopeConfigMapAnnotation: "true",
+					},
+				},
+				Data: map[string]string{},
+			}
+
+			// Create configMaps as wrapped resources.
+			wrappedCM := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns.Name,
+					Name:      wrappedCMName1,
+				},
+				Data: map[string]string{
+					cmDataKey: cmDataVal1,
+				},
+			}
+			// Given Fleet's current resource sorting logic, this configMap
+			// will be considered as the duplicated resource entry.
+			wrappedCM1 := wrappedCM.DeepCopy()
+			wrappedCM1.TypeMeta = metav1.TypeMeta{
+				APIVersion: "dummy/v10",
+				Kind:       "Fake",
+			}
+			wrappedCM1Bytes, err := json.Marshal(wrappedCM1)
+			Expect(err).To(BeNil(), "Failed to marshal configMap %s", wrappedCM1.Name)
+			wrapperCM.Data["cm1.yaml"] = string(wrappedCM1Bytes)
+
+			wrappedCM2 := wrappedCM.DeepCopy()
+			wrappedCM2.Name = wrappedCMName2
+			wrappedCM2.Data[cmDataKey] = cmDataVal2
+			wrappedCM2Bytes, err := json.Marshal(wrappedCM2)
+			Expect(err).To(BeNil(), "Failed to marshal configMap %s", wrappedCM2.Name)
+			wrapperCM.Data["cm2.yaml"] = string(wrappedCM2Bytes)
+
+			Expect(hubClient.Create(ctx, wrapperCM)).To(Succeed(), "Failed to create configMap %s", wrapperCM.Name)
+
+			// Create a CRP.
+			crp := &placementv1beta1.ClusterResourcePlacement{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: crpName,
+					// Add a custom finalizer; this would allow us to better observe
+					// the behavior of the controllers.
+					Finalizers: []string{customDeletionBlockerFinalizer},
+				},
+				Spec: placementv1beta1.ClusterResourcePlacementSpec{
+					ResourceSelectors: workResourceSelector(),
+					Policy: &placementv1beta1.PlacementPolicy{
+						PlacementType: placementv1beta1.PickFixedPlacementType,
+						ClusterNames: []string{
+							memberCluster1EastProdName,
+						},
+					},
+					Strategy: placementv1beta1.RolloutStrategy{
+						Type: placementv1beta1.RollingUpdateRolloutStrategyType,
+						RollingUpdate: &placementv1beta1.RollingUpdateConfig{
+							UnavailablePeriodSeconds: ptr.To(2),
+						},
+					},
+				},
+			}
+			Expect(hubClient.Create(ctx, crp)).To(Succeed(), "Failed to create CRP")
+		})
+
+		It("should update CRP status as expected", func() {
+			Eventually(func() error {
+				crp := &placementv1beta1.ClusterResourcePlacement{}
+				if err := hubClient.Get(ctx, types.NamespacedName{Name: crpName}, crp); err != nil {
+					return err
+				}
+
+				wantStatus := placementv1beta1.ClusterResourcePlacementStatus{
+					Conditions: crpAppliedFailedConditions(crp.Generation),
+					PlacementStatuses: []placementv1beta1.ResourcePlacementStatus{
+						{
+							ClusterName: memberCluster1EastProdName,
+							FailedPlacements: []placementv1beta1.FailedResourcePlacement{
+								{
+									ResourceIdentifier: placementv1beta1.ResourceIdentifier{
+										Group:     "dummy",
+										Version:   "v10",
+										Kind:      "Fake",
+										Namespace: workNamespaceName,
+										Name:      wrappedCMName1,
+										Envelope: &placementv1beta1.EnvelopeIdentifier{
+											Name:      wrapperCMName,
+											Namespace: workNamespaceName,
+											Type:      placementv1beta1.ConfigMapEnvelopeType,
+										},
+									},
+									Condition: metav1.Condition{
+										Type:               placementv1beta1.WorkConditionTypeApplied,
+										Status:             metav1.ConditionFalse,
+										Reason:             string(workapplier.ManifestProcessingApplyResultTypeDecodingErred),
+										ObservedGeneration: 0,
+									},
+								},
+							},
+							Conditions: resourcePlacementApplyFailedConditions(crp.Generation),
+						},
+					},
+					SelectedResources: []placementv1beta1.ResourceIdentifier{
+						{
+							Kind:    "Namespace",
+							Name:    workNamespaceName,
+							Version: "v1",
+						},
+						{
+							Kind:      "ConfigMap",
+							Name:      wrapperCMName,
+							Version:   "v1",
+							Namespace: workNamespaceName,
+						},
+					},
+					ObservedResourceIndex: "0",
+				}
+				if diff := cmp.Diff(crp.Status, wantStatus, crpStatusCmpOptions...); diff != "" {
+					return fmt.Errorf("CRP status diff (-got, +want): %s", diff)
+				}
+				return nil
+			}, eventuallyDuration*3, eventuallyInterval).Should(Succeed(), "Failed to update CRP status as expected")
+		})
+
+		It("should place some manifests on member clusters", func() {
+			Eventually(func() error {
+				return validateWorkNamespaceOnCluster(memberCluster1EastProd, types.NamespacedName{Name: workNamespaceName})
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to apply the namespace object")
+
+			Eventually(func() error {
+				cm := &corev1.ConfigMap{}
+				if err := memberCluster1EastProdClient.Get(ctx, types.NamespacedName{Name: wrappedCMName2, Namespace: workNamespaceName}, cm); err != nil {
+					return err
+				}
+
+				wantCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wrappedCMName2,
+						Namespace: workNamespaceName,
+					},
+					Data: map[string]string{
+						cmDataKey: cmDataVal2,
+					},
+				}
+				// Rebuild the configMap for ease of comparison.
+				rebuiltGotCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cm.Name,
+						Namespace: cm.Namespace,
+					},
+					Data: cm.Data,
+				}
+
+				if diff := cmp.Diff(wantCM, rebuiltGotCM); diff != "" {
+					return fmt.Errorf("configMap diff (-got, +want): %s", diff)
+				}
+				return nil
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to apply the configMap object #1")
+		})
+
+		AfterAll(func() {
+			// Remove the CRP and the namespace from the hub cluster.
+			cleanupCRP(crpName)
+			cleanupWorkResources()
+
+			// Clean the placed resources.
+			cleanWorkResourcesOnCluster(allMemberClusters[0])
+		})
+	})
+})


### PR DESCRIPTION
### Description of your changes

This PR fixes the bug where the work applier would stop processing manifests if one of them fails the pre-processing stage.

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- [x] Integration tests
- [x] E2E tests 

### Special notes for your reviewer


