### PR TITLE
fix: set updaterun progressing condition to false when finished

### DIFF
--- a/pkg/controllers/updaterun/controller.go
+++ b/pkg/controllers/updaterun/controller.go
@@ -214,7 +214,7 @@ func (r *Reconciler) recordUpdateRunFailed(ctx context.Context, updateRun *place
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: updateRun.Generation,
 		Reason:             condition.UpdateRunFailedReason,
-		Message:            "ClusterStagedUpdateRun aborted due to a non-recoverable error",
+		Message:            "The stages are aborted due to a non-recoverable error",
 	})
 	meta.SetStatusCondition(&updateRun.Status.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),

--- a/pkg/controllers/updaterun/controller.go
+++ b/pkg/controllers/updaterun/controller.go
@@ -197,7 +197,7 @@ func (r *Reconciler) recordUpdateRunSucceeded(ctx context.Context, updateRun *pl
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: updateRun.Generation,
 		Reason:             condition.UpdateRunSucceededReason,
-		Message:            "ClusterStagedUpdateRun completed successfully",
+		Message:            "All stages are completed successfully",
 	})
 	if updateErr := r.Client.Status().Update(ctx, updateRun); updateErr != nil {
 		klog.ErrorS(updateErr, "Failed to update the ClusterStagedUpdateRun status as succeeded", "clusterStagedUpdateRun", klog.KObj(updateRun))

--- a/pkg/controllers/updaterun/controller.go
+++ b/pkg/controllers/updaterun/controller.go
@@ -186,10 +186,18 @@ func (r *Reconciler) ensureFinalizer(ctx context.Context, updateRun *placementv1
 // recordUpdateRunSucceeded records the succeeded condition in the ClusterStagedUpdateRun status.
 func (r *Reconciler) recordUpdateRunSucceeded(ctx context.Context, updateRun *placementv1beta1.ClusterStagedUpdateRun) error {
 	meta.SetStatusCondition(&updateRun.Status.Conditions, metav1.Condition{
+		Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: updateRun.Generation,
+		Reason:             condition.UpdateRunSucceededReason,
+		Message:            "All stages are completed",
+	})
+	meta.SetStatusCondition(&updateRun.Status.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: updateRun.Generation,
 		Reason:             condition.UpdateRunSucceededReason,
+		Message:            "ClusterStagedUpdateRun completed successfully",
 	})
 	if updateErr := r.Client.Status().Update(ctx, updateRun); updateErr != nil {
 		klog.ErrorS(updateErr, "Failed to update the ClusterStagedUpdateRun status as succeeded", "clusterStagedUpdateRun", klog.KObj(updateRun))
@@ -201,6 +209,13 @@ func (r *Reconciler) recordUpdateRunSucceeded(ctx context.Context, updateRun *pl
 
 // recordUpdateRunFailed records the failed condition in the ClusterStagedUpdateRun status.
 func (r *Reconciler) recordUpdateRunFailed(ctx context.Context, updateRun *placementv1beta1.ClusterStagedUpdateRun, message string) error {
+	meta.SetStatusCondition(&updateRun.Status.Conditions, metav1.Condition{
+		Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: updateRun.Generation,
+		Reason:             condition.UpdateRunFailedReason,
+		Message:            "ClusterStagedUpdateRun aborted due to a non-recoverable error",
+	})
 	meta.SetStatusCondition(&updateRun.Status.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StagedUpdateRunConditionSucceeded),
 		Status:             metav1.ConditionFalse,

--- a/pkg/controllers/updaterun/controller_integration_test.go
+++ b/pkg/controllers/updaterun/controller_integration_test.go
@@ -559,6 +559,8 @@ func generateFalseCondition(obj client.Object, condType any) metav1.Condition {
 		switch cond {
 		case placementv1beta1.StageUpdatingConditionSucceeded:
 			reason = condition.StageUpdatingFailedReason
+		case placementv1beta1.StageUpdatingConditionProgressing:
+			reason = condition.StageUpdatingWaitingReason
 		}
 		typeStr = string(cond)
 	case placementv1beta1.ClusterUpdatingStatusConditionType:
@@ -580,4 +582,25 @@ func generateFalseCondition(obj client.Object, condType any) metav1.Condition {
 		ObservedGeneration: obj.GetGeneration(),
 		Reason:             reason,
 	}
+}
+
+func generateFalseProgressingCondition(obj client.Object, condType any, succeeded bool) metav1.Condition {
+	falseCond := generateFalseCondition(obj, condType)
+	reason := ""
+	switch condType {
+	case placementv1beta1.StagedUpdateRunConditionProgressing:
+		if succeeded {
+			reason = condition.UpdateRunSucceededReason
+		} else {
+			reason = condition.UpdateRunFailedReason
+		}
+	case placementv1beta1.StageUpdatingConditionProgressing:
+		if succeeded {
+			reason = condition.StageUpdatingSucceededReason
+		} else {
+			reason = condition.StageUpdatingFailedReason
+		}
+	}
+	falseCond.Reason = reason
+	return falseCond
 }

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -380,6 +380,7 @@ func (r *Reconciler) updateApprovalRequestAccepted(ctx context.Context, appReq *
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: appReq.Generation,
 		Reason:             condition.ApprovalRequestApprovalAcceptedReason,
+		Message:            "ClusterApprovalRequest approval accepted, approval cannot be reverted",
 	}
 	meta.SetStatusCondition(&appReq.Status.Conditions, cond)
 	if err := r.Client.Status().Update(ctx, appReq); err != nil {
@@ -443,6 +444,7 @@ func markUpdateRunStarted(updateRun *placementv1beta1.ClusterStagedUpdateRun) {
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: updateRun.Generation,
 		Reason:             condition.UpdateRunStartedReason,
+		Message:            "ClusterStagedUpdateRun started",
 	})
 }
 
@@ -456,6 +458,7 @@ func markStageUpdatingStarted(stageUpdatingStatus *placementv1beta1.StageUpdatin
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: generation,
 		Reason:             condition.StageUpdatingStartedReason,
+		Message:            "Clusters in the stage started updating",
 	})
 }
 
@@ -466,6 +469,7 @@ func markStageUpdatingWaiting(stageUpdatingStatus *placementv1beta1.StageUpdatin
 		Status:             metav1.ConditionFalse,
 		ObservedGeneration: generation,
 		Reason:             condition.StageUpdatingWaitingReason,
+		Message:            "All clusters in the stage are updated, waiting for after-stage tasks to complete",
 	})
 }
 
@@ -475,10 +479,18 @@ func markStageUpdatingSucceeded(stageUpdatingStatus *placementv1beta1.StageUpdat
 		stageUpdatingStatus.EndTime = &metav1.Time{Time: time.Now()}
 	}
 	meta.SetStatusCondition(&stageUpdatingStatus.Conditions, metav1.Condition{
+		Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: generation,
+		Reason:             condition.StageUpdatingSucceededReason,
+		Message:            "All clusters in the stage are updated and after-stage tasks are completed",
+	})
+	meta.SetStatusCondition(&stageUpdatingStatus.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: generation,
 		Reason:             condition.StageUpdatingSucceededReason,
+		Message:            "Stage update completed successfully",
 	})
 }
 
@@ -487,6 +499,13 @@ func markStageUpdatingFailed(stageUpdatingStatus *placementv1beta1.StageUpdating
 	if stageUpdatingStatus.EndTime == nil {
 		stageUpdatingStatus.EndTime = &metav1.Time{Time: time.Now()}
 	}
+	meta.SetStatusCondition(&stageUpdatingStatus.Conditions, metav1.Condition{
+		Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: generation,
+		Reason:             condition.StageUpdatingFailedReason,
+		Message:            "Stage update aborted due to a non-recoverable error",
+	})
 	meta.SetStatusCondition(&stageUpdatingStatus.Conditions, metav1.Condition{
 		Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
 		Status:             metav1.ConditionFalse,
@@ -503,6 +522,7 @@ func markClusterUpdatingStarted(clusterUpdatingStatus *placementv1beta1.ClusterU
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: generation,
 		Reason:             condition.ClusterUpdatingStartedReason,
+		Message:            "Cluster update started",
 	})
 }
 
@@ -513,6 +533,7 @@ func markClusterUpdatingSucceeded(clusterUpdatingStatus *placementv1beta1.Cluste
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: generation,
 		Reason:             condition.ClusterUpdatingSucceededReason,
+		Message:            "Cluster update completed successfully",
 	})
 }
 
@@ -534,6 +555,7 @@ func markAfterStageRequestCreated(afterStageTaskStatus *placementv1beta1.AfterSt
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: generation,
 		Reason:             condition.AfterStageTaskApprovalRequestCreatedReason,
+		Message:            "ClusterApprovalRequest is created",
 	})
 }
 
@@ -544,6 +566,7 @@ func markAfterStageRequestApproved(afterStageTaskStatus *placementv1beta1.AfterS
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: generation,
 		Reason:             condition.AfterStageTaskApprovalRequestApprovedReason,
+		Message:            "ClusterApprovalRequest is approved",
 	})
 }
 
@@ -554,5 +577,6 @@ func markAfterStageWaitTimeElapsed(afterStageTaskStatus *placementv1beta1.AfterS
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: generation,
 		Reason:             condition.AfterStageTaskWaitTimeElapsedReason,
+		Message:            "Wait time elapsed",
 	})
 }

--- a/pkg/controllers/updaterun/execution.go
+++ b/pkg/controllers/updaterun/execution.go
@@ -380,7 +380,7 @@ func (r *Reconciler) updateApprovalRequestAccepted(ctx context.Context, appReq *
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: appReq.Generation,
 		Reason:             condition.ApprovalRequestApprovalAcceptedReason,
-		Message:            "ClusterApprovalRequest approval accepted, approval cannot be reverted",
+		Message:            "The approval request has been approved and cannot be reverted",
 	}
 	meta.SetStatusCondition(&appReq.Status.Conditions, cond)
 	if err := r.Client.Status().Update(ctx, appReq); err != nil {
@@ -444,7 +444,7 @@ func markUpdateRunStarted(updateRun *placementv1beta1.ClusterStagedUpdateRun) {
 		Status:             metav1.ConditionTrue,
 		ObservedGeneration: updateRun.Generation,
 		Reason:             condition.UpdateRunStartedReason,
-		Message:            "ClusterStagedUpdateRun started",
+		Message:            "The stages started updating",
 	})
 }
 

--- a/pkg/controllers/updaterun/execution_integration_test.go
+++ b/pkg/controllers/updaterun/execution_integration_test.go
@@ -257,10 +257,8 @@ var _ = Describe("UpdateRun execution tests", func() {
 			Expect(k8sClient.Status().Update(ctx, binding)).Should(Succeed(), "failed to update the binding status")
 
 			By("Validating the 5th cluster has succeeded and stage waiting for AfterStageTasks")
-			stageWaitingCondition := generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing)
-			stageWaitingCondition.Reason = condition.StageUpdatingWaitingReason
 			wantStatus.StagesStatus[0].Clusters[4].Conditions = append(wantStatus.StagesStatus[0].Clusters[4].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
-			wantStatus.StagesStatus[0].Conditions[0] = stageWaitingCondition // The progressing condition now becomes false with waiting reason.
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing) // The progressing condition now becomes false with waiting reason.
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.AfterStageTaskConditionApprovalRequestCreated))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
@@ -307,7 +305,8 @@ var _ = Describe("UpdateRun execution tests", func() {
 			// Approval afterStageTask completed.
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[1].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.AfterStageTaskConditionApprovalRequestApproved))
-			// 1st stage completed.
+			// 1st stage completed, mark progressing condition reason as succeeded and add succeeded condition.
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, true)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// 2nd stage started.
 			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing))
@@ -403,9 +402,7 @@ var _ = Describe("UpdateRun execution tests", func() {
 
 			By("Validating the 5th cluster has succeeded and the stage waiting for AfterStageTask")
 			wantStatus.StagesStatus[1].Clusters[4].Conditions = append(wantStatus.StagesStatus[1].Clusters[4].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
-			stageWaitingCondition := generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing)
-			stageWaitingCondition.Reason = condition.StageUpdatingWaitingReason
-			wantStatus.StagesStatus[1].Conditions[0] = stageWaitingCondition // The progressing condition now becomes false with waiting reason.
+			wantStatus.StagesStatus[1].Conditions[0] = generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing) // The progressing condition now becomes false with waiting reason.
 			wantStatus.StagesStatus[1].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[1].AfterStageTaskStatus[0].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.AfterStageTaskConditionApprovalRequestCreated))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
@@ -450,6 +447,7 @@ var _ = Describe("UpdateRun execution tests", func() {
 				generateTrueCondition(updateRun, placementv1beta1.AfterStageTaskConditionApprovalRequestApproved))
 			wantStatus.StagesStatus[1].AfterStageTaskStatus[1].Conditions = append(wantStatus.StagesStatus[1].AfterStageTaskStatus[1].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.AfterStageTaskConditionWaitTimeElapsed))
+			wantStatus.StagesStatus[1].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, true)
 			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing))
@@ -500,7 +498,11 @@ var _ = Describe("UpdateRun execution tests", func() {
 			for i := range wantStatus.DeletionStageStatus.Clusters {
 				wantStatus.DeletionStageStatus.Clusters[i].Conditions = append(wantStatus.DeletionStageStatus.Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			}
+			// Mark the stage progressing condition as false with succeeded reason and add succeeded condition.
+			wantStatus.DeletionStageStatus.Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, true)
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
+			// Mark updateRun progressing condition as false with succeeded reason and add succeeded condition.
+			wantStatus.Conditions[1] = generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, true)
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 		})
@@ -595,10 +597,8 @@ var _ = Describe("UpdateRun execution tests", func() {
 			Expect(k8sClient.Status().Update(ctx, binding)).Should(Succeed(), "failed to update the binding status")
 
 			By("Validating the 5th cluster has succeeded and stage waiting for AfterStageTasks")
-			stageWaitingCondition := generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing)
-			stageWaitingCondition.Reason = condition.StageUpdatingWaitingReason
 			wantStatus.StagesStatus[0].Clusters[4].Conditions = append(wantStatus.StagesStatus[0].Clusters[4].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
-			wantStatus.StagesStatus[0].Conditions[0] = stageWaitingCondition // The progressing condition now becomes false with waiting reason.
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing) // The progressing condition now becomes false with waiting reason.
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 		})
 
@@ -608,6 +608,7 @@ var _ = Describe("UpdateRun execution tests", func() {
 			wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[0].AfterStageTaskStatus[0].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.AfterStageTaskConditionWaitTimeElapsed))
 			// 1st stage completed.
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, true)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 			// 2nd stage started.
 			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing))
@@ -699,9 +700,7 @@ var _ = Describe("UpdateRun execution tests", func() {
 
 			By("Validating the 5th cluster has succeeded and the stage waiting for AfterStageTask")
 			wantStatus.StagesStatus[1].Clusters[4].Conditions = append(wantStatus.StagesStatus[1].Clusters[4].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
-			stageWaitingCondition := generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing)
-			stageWaitingCondition.Reason = condition.StageUpdatingWaitingReason
-			wantStatus.StagesStatus[1].Conditions[0] = stageWaitingCondition // The progressing condition now becomes false with waiting reason.
+			wantStatus.StagesStatus[1].Conditions[0] = generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing) // The progressing condition now becomes false with waiting reason.
 			wantStatus.StagesStatus[1].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[1].AfterStageTaskStatus[0].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.AfterStageTaskConditionApprovalRequestCreated))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
@@ -744,6 +743,7 @@ var _ = Describe("UpdateRun execution tests", func() {
 			By("Validating the 2nd stage has completed and the delete stage has started")
 			wantStatus.StagesStatus[1].AfterStageTaskStatus[0].Conditions = append(wantStatus.StagesStatus[1].AfterStageTaskStatus[0].Conditions,
 				generateTrueCondition(updateRun, placementv1beta1.AfterStageTaskConditionApprovalRequestApproved))
+			wantStatus.StagesStatus[1].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, true)
 			wantStatus.StagesStatus[1].Conditions = append(wantStatus.StagesStatus[1].Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
 
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing))
@@ -784,7 +784,9 @@ var _ = Describe("UpdateRun execution tests", func() {
 			for i := range wantStatus.DeletionStageStatus.Clusters {
 				wantStatus.DeletionStageStatus.Clusters[i].Conditions = append(wantStatus.DeletionStageStatus.Clusters[i].Conditions, generateTrueCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
 			}
+			wantStatus.DeletionStageStatus.Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, true)
 			wantStatus.DeletionStageStatus.Conditions = append(wantStatus.DeletionStageStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
+			wantStatus.Conditions[1] = generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, true)
 			wantStatus.Conditions = append(wantStatus.Conditions, generateTrueCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 		})
@@ -826,7 +828,9 @@ var _ = Describe("UpdateRun execution tests", func() {
 
 			By("Validating the updateRun has failed")
 			wantStatus.StagesStatus[0].Clusters[0].Conditions = append(wantStatus.StagesStatus[0].Clusters[0].Conditions, generateFalseCondition(updateRun, placementv1beta1.ClusterUpdatingConditionSucceeded))
+			wantStatus.StagesStatus[0].Conditions[0] = generateFalseProgressingCondition(updateRun, placementv1beta1.StageUpdatingConditionProgressing, false)
 			wantStatus.StagesStatus[0].Conditions = append(wantStatus.StagesStatus[0].Conditions, generateFalseCondition(updateRun, placementv1beta1.StageUpdatingConditionSucceeded))
+			wantStatus.Conditions[1] = generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, false)
 			wantStatus.Conditions = append(wantStatus.Conditions, generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
 			validateClusterStagedUpdateRunStatus(ctx, updateRun, wantStatus, "")
 		})

--- a/pkg/controllers/updaterun/validation_integration_test.go
+++ b/pkg/controllers/updaterun/validation_integration_test.go
@@ -425,8 +425,9 @@ func validateClusterStagedUpdateRunStatusConsistently(
 
 func generateFailedValidationStatus(
 	updateRun *placementv1beta1.ClusterStagedUpdateRun,
-	initialized *placementv1beta1.StagedUpdateRunStatus,
+	started *placementv1beta1.StagedUpdateRunStatus,
 ) *placementv1beta1.StagedUpdateRunStatus {
-	initialized.Conditions = append(initialized.Conditions, generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
-	return initialized
+	started.Conditions[1] = generateFalseProgressingCondition(updateRun, placementv1beta1.StagedUpdateRunConditionProgressing, false)
+	started.Conditions = append(started.Conditions, generateFalseCondition(updateRun, placementv1beta1.StagedUpdateRunConditionSucceeded))
+	return started
 }

--- a/test/e2e/actuals_test.go
+++ b/test/e2e/actuals_test.go
@@ -1068,19 +1068,14 @@ func updateRunClusterRolloutSucceedConditions(generation int64) []metav1.Conditi
 	}
 }
 
-func updateRunStageRolloutSucceedConditions(generation int64, wait bool) []metav1.Condition {
-	startedCond := metav1.Condition{
-		Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
-		Status:             metav1.ConditionTrue,
-		Reason:             condition.StageUpdatingStartedReason,
-		ObservedGeneration: generation,
-	}
-	if wait {
-		startedCond.Status = metav1.ConditionFalse
-		startedCond.Reason = condition.StageUpdatingWaitingReason
-	}
+func updateRunStageRolloutSucceedConditions(generation int64) []metav1.Condition {
 	return []metav1.Condition{
-		startedCond,
+		{
+			Type:               string(placementv1beta1.StageUpdatingConditionProgressing),
+			Status:             metav1.ConditionFalse,
+			Reason:             condition.StageUpdatingSucceededReason,
+			ObservedGeneration: generation,
+		},
 		{
 			Type:               string(placementv1beta1.StageUpdatingConditionSucceeded),
 			Status:             metav1.ConditionTrue,
@@ -1127,8 +1122,8 @@ func updateRunSucceedConditions(generation int64) []metav1.Condition {
 		},
 		{
 			Type:               string(placementv1beta1.StagedUpdateRunConditionProgressing),
-			Status:             metav1.ConditionTrue,
-			Reason:             condition.UpdateRunStartedReason,
+			Status:             metav1.ConditionFalse,
+			Reason:             condition.UpdateRunSucceededReason,
 			ObservedGeneration: generation,
 		},
 		{
@@ -1181,7 +1176,7 @@ func updateRunStatusSucceededActual(
 				}
 				stagesStatus[i].AfterStageTaskStatus[j].Conditions = updateRunAfterStageTaskSucceedConditions(updateRun.Generation, task.Type)
 			}
-			stagesStatus[i].Conditions = updateRunStageRolloutSucceedConditions(updateRun.Generation, true)
+			stagesStatus[i].Conditions = updateRunStageRolloutSucceedConditions(updateRun.Generation)
 		}
 
 		deleteStageStatus := &placementv1beta1.StageUpdatingStatus{
@@ -1192,7 +1187,7 @@ func updateRunStatusSucceededActual(
 			deleteStageStatus.Clusters[i].ClusterName = wantUnscheduledClusters[i]
 			deleteStageStatus.Clusters[i].Conditions = updateRunClusterRolloutSucceedConditions(updateRun.Generation)
 		}
-		deleteStageStatus.Conditions = updateRunStageRolloutSucceedConditions(updateRun.Generation, false)
+		deleteStageStatus.Conditions = updateRunStageRolloutSucceedConditions(updateRun.Generation)
 
 		wantStatus.StagesStatus = stagesStatus
 		wantStatus.DeletionStageStatus = deleteStageStatus


### PR DESCRIPTION
### Description of your changes
When updateRun or a stage completes (either succeeds or fails), set progressing condition to false.
Also add missing condition messages.

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
