### PR TITLE
fix: bump go version to 1.23.6 for CVE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
     paths-ignore: [docs/**, "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
   detect-noop:

--- a/.github/workflows/code-lint.yml
+++ b/.github/workflows/code-lint.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,7 +18,7 @@ env:
   MEMBER_AGENT_IMAGE_NAME: member-agent
   REFRESH_TOKEN_IMAGE_NAME: refresh-token
 
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
   export-registry:

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -20,7 +20,7 @@ on:
     paths-ignore: [docs/**, "**.md", "**.mdx", "**.png", "**.jpg"]
 
 env:
-  GO_VERSION: '1.23.1'
+  GO_VERSION: '1.23.6'
 
 jobs:
   detect-noop:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 15m
-  go: '1.23.1'
+  go: '1.23.6'
 
 linters-settings:
   stylecheck:

--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the hubagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.1 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.6 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/member-agent.Dockerfile
+++ b/docker/member-agent.Dockerfile
@@ -1,5 +1,5 @@
 # Build the memberagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.1 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.6 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -1,5 +1,5 @@
 # Build the hubagent binary
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.1 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.6 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.goms.io/fleet
 
-go 1.23.1
+go 1.23.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0


### PR DESCRIPTION
### Description of your changes

Fixing CVEs,

- CVE-2024-45336
- CVE-2024-45341
- CVE-2025-22866

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer


