### PR TITLE
feat: add managed resource webhook

### DIFF
--- a/pkg/webhook/add_handler.go
+++ b/pkg/webhook/add_handler.go
@@ -6,6 +6,7 @@ import (
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacementdisruptionbudget"
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacementeviction"
 	"go.goms.io/fleet/pkg/webhook/fleetresourcehandler"
+	"go.goms.io/fleet/pkg/webhook/managedresource"
 	"go.goms.io/fleet/pkg/webhook/membercluster"
 	"go.goms.io/fleet/pkg/webhook/pod"
 	"go.goms.io/fleet/pkg/webhook/replicaset"
@@ -15,6 +16,8 @@ import (
 func init() {
 	// AddToManagerFleetResourceValidator is a function to register fleet guard rail resource validator to the webhook server
 	AddToManagerFleetResourceValidator = fleetresourcehandler.Add
+	// AddtoManagerManagedResource is a function to register managed resource validator to the webhook server
+	AddtoManagerManagedResource = managedresource.Add
 	// AddToManagerFuncs is a list of functions to register webhook validators to the webhook server
 	AddToManagerFuncs = append(AddToManagerFuncs, clusterresourceplacement.AddV1Alpha1)
 	AddToManagerFuncs = append(AddToManagerFuncs, clusterresourceplacement.Add)

--- a/pkg/webhook/managedresource/managedresource_validating_webhook.go
+++ b/pkg/webhook/managedresource/managedresource_validating_webhook.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	managedByArmKey      = "managed-by"
-	managedByArmValue    = "arm"
+	ManagedByArmKey      = "managed-by"
+	ManagedByArmValue    = "arm"
 	deniedResource       = "denied admission for managed resource"
 	resourceDeniedFormat = "the operation on the managed resource type '%s' name '%s' in namespace '%s' is not allowed"
 )
@@ -33,7 +33,6 @@ const (
 // ValidationPath is the webhook service path which admission requests are routed to.
 var (
 	ValidationPath = fmt.Sprintf(utils.ValidationPathFmt, "arm", "managed", "resources")
-	metaAccessor   = meta.NewAccessor()
 )
 
 // Add registers the webhook for K8s bulit-in object types.
@@ -81,7 +80,7 @@ func managedByArm(m map[string]string) bool {
 	if len(m) == 0 {
 		return false
 	}
-	if v, ok := m[managedByArmKey]; ok && v == managedByArmValue {
+	if v, ok := m[ManagedByArmKey]; ok && v == ManagedByArmValue {
 		return true
 	}
 	return false

--- a/pkg/webhook/managedresource/managedresource_validating_webhook.go
+++ b/pkg/webhook/managedresource/managedresource_validating_webhook.go
@@ -1,17 +1,6 @@
 /*
-Copyright 2025 The KubeFleet Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
 */
 
 package managedresource

--- a/pkg/webhook/managedresource/managedresource_validating_webhook.go
+++ b/pkg/webhook/managedresource/managedresource_validating_webhook.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package managedresource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"go.goms.io/fleet/pkg/utils"
+	"go.goms.io/fleet/pkg/webhook/validation"
+)
+
+const (
+	managedByArmKey      = "managed-by"
+	managedByArmValue    = "arm"
+	deniedResource       = "denied admission for managed resource"
+	resourceDeniedFormat = "the operation on the managed resource type '%s' name '%s' in namespace '%s' is not allowed"
+)
+
+// ValidationPath is the webhook service path which admission requests are routed to.
+var (
+	ValidationPath = fmt.Sprintf(utils.ValidationPathFmt, "arm", "managed", "resources")
+	metaAccessor   = meta.NewAccessor()
+)
+
+// Add registers the webhook for K8s bulit-in object types.
+func Add(mgr manager.Manager, whiteListedUsers []string) error {
+	hookServer := mgr.GetWebhookServer()
+	hookServer.Register(ValidationPath, &webhook.Admission{Handler: &managedResourceValidator{
+		whiteListedUsers: whiteListedUsers,
+	}})
+	return nil
+}
+
+type managedResourceValidator struct {
+	whiteListedUsers []string
+}
+
+// Handle denies the resource admission if the request target object has a label or annotation key "fleet.azure.com".
+func (v *managedResourceValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	namespacedName := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update, admissionv1.Delete:
+		klog.V(1).InfoS("handling resource", "operation", req.Operation, "subResource", req.SubResource, "namespacedName", namespacedName)
+		for _, obj := range []runtime.Object{req.OldObject.Object, req.Object.Object} {
+			labels, annotations, err := getLabelsAndAnnotations(obj)
+			if err != nil {
+				return admission.Errored(http.StatusInternalServerError, err)
+			}
+			if (managedByArm(labels) || managedByArm(annotations)) && !validation.IsAdminGroupUserOrWhiteListedUser(v.whiteListedUsers, req.UserInfo) {
+				klog.V(2).InfoS(deniedResource, "user", req.UserInfo.Username, "groups", req.UserInfo.Groups, "operation", req.Operation, "GVK", req.RequestKind, "subResource", req.SubResource, "namespacedName", namespacedName)
+				return admission.Denied(fmt.Sprintf(resourceDeniedFormat, req.Kind, req.Name, req.Namespace))
+			}
+		}
+	}
+	return admission.Allowed("")
+}
+
+func getLabelsAndAnnotations(obj runtime.Object) (map[string]string, map[string]string, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, nil, err
+	}
+	return accessor.GetLabels(), accessor.GetAnnotations(), nil
+}
+
+func managedByArm(m map[string]string) bool {
+	if len(m) == 0 {
+		return false
+	}
+	if v, ok := m[managedByArmKey]; ok && v == managedByArmValue {
+		return true
+	}
+	return false
+}

--- a/pkg/webhook/managedresource/managedresource_validating_webhook_test.go
+++ b/pkg/webhook/managedresource/managedresource_validating_webhook_test.go
@@ -1,0 +1,222 @@
+package managedresource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func Test_managedResourceValidzaator_Handle(t *testing.T) {
+	const fleet1p = "fleet1p"
+	validator := &managedResourceValidator{
+		whiteListedUsers: []string{fleet1p},
+	}
+
+	tests := []struct {
+		name           string
+		username       string
+		operation      admissionv1.Operation
+		oldLabels      map[string]string
+		oldAnnotations map[string]string
+		newLabels      map[string]string
+		newAnnotations map[string]string
+		expectedResp   admission.Response
+		modReq         func(*admission.Request)
+	}{
+		{
+			name:           "allowed when not managed by arm",
+			operation:      admissionv1.Update,
+			oldLabels:      map[string]string{"foo": "bar"},
+			oldAnnotations: map[string]string{"baz": "qux"},
+			newLabels:      map[string]string{"foo": "bar"},
+			newAnnotations: map[string]string{"baz": "qux"},
+			expectedResp:   admission.Allowed(""),
+		},
+		{
+			name:         "denied - error on getLabelsAndAnnotations failure",
+			operation:    admissionv1.Create,
+			expectedResp: admission.Errored(http.StatusInternalServerError, fmt.Errorf("object does not implement the Object interfaces")),
+			modReq: func(req *admission.Request) {
+				req.Object = runtime.RawExtension{Object: nil}
+			},
+		},
+		{
+			name:           "denied - managed by arm in labels, not whitelisted",
+			operation:      admissionv1.Create,
+			oldLabels:      nil,
+			oldAnnotations: nil,
+			newLabels:      map[string]string{managedByArmKey: managedByArmValue},
+			newAnnotations: nil,
+			expectedResp:   admission.Denied(fmt.Sprintf(resourceDeniedFormat, metav1.GroupVersionKind{Kind: "TestKind"}, "test-resource", "default")),
+		},
+		{
+			name:           "denied - managed by arm in annotations, not whitelisted",
+			operation:      admissionv1.Update,
+			oldLabels:      nil,
+			oldAnnotations: nil,
+			newLabels:      nil,
+			newAnnotations: map[string]string{managedByArmKey: managedByArmValue},
+			expectedResp:   admission.Denied(fmt.Sprintf(resourceDeniedFormat, metav1.GroupVersionKind{Kind: "TestKind"}, "test-resource", "default")),
+		},
+		{
+			name:           "allowed for other operations",
+			operation:      admissionv1.Connect,
+			oldLabels:      nil,
+			oldAnnotations: nil,
+			newLabels:      nil,
+			newAnnotations: nil,
+			expectedResp:   admission.Allowed(""),
+		},
+		{
+			name:           "allowed for other operations - managed by arm, but user whitelisted",
+			username:       "fleet1p",
+			operation:      admissionv1.Update,
+			oldLabels:      map[string]string{"managedBy": managedByArmValue},
+			oldAnnotations: nil,
+			newLabels:      nil,
+			newAnnotations: nil,
+			expectedResp:   admission.Allowed(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldObj := makeUnstructured(tt.oldLabels, tt.oldAnnotations)
+			newObj := makeUnstructured(tt.newLabels, tt.newAnnotations)
+			req := admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation:   tt.operation,
+					Name:        "test-resource",
+					Namespace:   "default",
+					OldObject:   runtime.RawExtension{Object: oldObj},
+					Object:      runtime.RawExtension{Object: newObj},
+					Kind:        metav1.GroupVersionKind{Kind: "TestKind"},
+					RequestKind: &metav1.GroupVersionKind{Kind: "TestKind"},
+				},
+			}
+			req.UserInfo = authenticationv1.UserInfo{
+				Username: tt.username,
+			}
+			if tt.modReq != nil {
+				tt.modReq(&req)
+			}
+			resp := validator.Handle(context.Background(), req)
+			assert.Equal(t, tt.expectedResp.Allowed, resp.Allowed)
+			assert.Equal(t, tt.expectedResp.Result.Code, resp.Result.Code)
+			assert.Equal(t, tt.expectedResp.Result.Message, resp.Result.Message)
+		})
+	}
+}
+
+func Test_getLabelsAndAnnotations(t *testing.T) {
+	tests := []struct {
+		name            string
+		obj             runtime.Object
+		wantLabels      map[string]string
+		wantAnnotations map[string]string
+		expectError     bool
+	}{
+		{
+			name:            "nil object - error",
+			obj:             nil,
+			wantLabels:      nil,
+			wantAnnotations: nil,
+			expectError:     true,
+		},
+		{
+			name: "object with labels and annotations",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"foo": "bar"},
+					Annotations: map[string]string{"baz": "qux"},
+				},
+			},
+			wantLabels:      map[string]string{"foo": "bar"},
+			wantAnnotations: map[string]string{"baz": "qux"},
+			expectError:     false,
+		},
+		{
+			name: "object with no labels or annotations",
+			obj: &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			wantLabels:      nil,
+			wantAnnotations: nil,
+			expectError:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels, annotations, err := getLabelsAndAnnotations(tt.obj)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantLabels, labels)
+				assert.Equal(t, tt.wantAnnotations, annotations)
+			}
+		})
+	}
+}
+
+func Test_managedByArm(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]string
+		want bool
+	}{
+		{
+			name: "nil map",
+			m:    nil,
+			want: false,
+		},
+		{
+			name: "empty map",
+			m:    map[string]string{},
+			want: false,
+		},
+		{
+			name: "key missing",
+			m:    map[string]string{"foo": "bar"},
+			want: false,
+		},
+		{
+			name: "key present, not managed key",
+			m:    map[string]string{"managingBy": managedByArmValue},
+			want: false,
+		},
+		{
+			name: "key present, not managed value",
+			m:    map[string]string{managedByArmKey: "not-arm"},
+			want: false,
+		},
+		{
+			name: "key present, managed key and value",
+			m:    map[string]string{managedByArmKey: managedByArmValue},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, managedByArm(tt.m))
+		})
+	}
+}
+
+func makeUnstructured(labels, annotations map[string]string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetLabels(labels)
+	obj.SetAnnotations(annotations)
+	return obj
+}

--- a/pkg/webhook/managedresource/managedresource_validating_webhook_test.go
+++ b/pkg/webhook/managedresource/managedresource_validating_webhook_test.go
@@ -1,3 +1,8 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
 package managedresource
 
 import (
@@ -6,6 +11,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -110,9 +116,9 @@ func Test_managedResourceValidzaator_Handle(t *testing.T) {
 				tt.modReq(&req)
 			}
 			resp := validator.Handle(context.Background(), req)
-			assert.Equal(t, tt.expectedResp.Allowed, resp.Allowed)
-			assert.Equal(t, tt.expectedResp.Result.Code, resp.Result.Code)
-			assert.Equal(t, tt.expectedResp.Result.Message, resp.Result.Message)
+			if diff := cmp.Diff(tt.expectedResp.Result, resp.Result); diff != "" {
+				t.Errorf("managedResourceValidator Handle response (-want +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/webhook/validation/uservalidation.go
+++ b/pkg/webhook/validation/uservalidation.go
@@ -51,7 +51,7 @@ var (
 func ValidateUserForFleetCRD(req admission.Request, whiteListedUsers []string, group string) admission.Response {
 	namespacedName := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
 	userInfo := req.UserInfo
-	if checkCRDGroup(group) && !isAdminGroupUserOrWhiteListedUser(whiteListedUsers, userInfo) {
+	if checkCRDGroup(group) && !IsAdminGroupUserOrWhiteListedUser(whiteListedUsers, userInfo) {
 		klog.V(2).InfoS(deniedModifyResource, "user", userInfo.Username, "groups", userInfo.Groups, "operation", req.Operation, "GVK", req.RequestKind, "subResource", req.SubResource, "namespacedName", namespacedName)
 		return admission.Denied(fmt.Sprintf(ResourceDeniedFormat, userInfo.Username, utils.GenerateGroupString(userInfo.Groups), req.Operation, req.RequestKind, req.SubResource, namespacedName))
 	}
@@ -63,7 +63,7 @@ func ValidateUserForFleetCRD(req admission.Request, whiteListedUsers []string, g
 func ValidateUserForResource(req admission.Request, whiteListedUsers []string) admission.Response {
 	namespacedName := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
 	userInfo := req.UserInfo
-	if isAdminGroupUserOrWhiteListedUser(whiteListedUsers, userInfo) || isUserAuthenticatedServiceAccount(userInfo) || isUserKubeScheduler(userInfo) || isUserKubeControllerManager(userInfo) || isUserInGroup(userInfo, nodeGroup) || isAKSSupportUser(userInfo) {
+	if IsAdminGroupUserOrWhiteListedUser(whiteListedUsers, userInfo) || isUserAuthenticatedServiceAccount(userInfo) || isUserKubeScheduler(userInfo) || isUserKubeControllerManager(userInfo) || isUserInGroup(userInfo, nodeGroup) || isAKSSupportUser(userInfo) {
 		klog.V(3).InfoS(allowedModifyResource, "user", userInfo.Username, "groups", userInfo.Groups, "operation", req.Operation, "GVK", req.RequestKind, "subResource", req.SubResource, "namespacedName", namespacedName)
 		return admission.Allowed(fmt.Sprintf(ResourceAllowedFormat, userInfo.Username, utils.GenerateGroupString(userInfo.Groups), req.Operation, req.RequestKind, req.SubResource, namespacedName))
 	}
@@ -144,10 +144,10 @@ func ValidatedUpstreamMemberClusterUpdate(currentMC, oldMC clusterv1beta1.Member
 	return admission.Allowed(fmt.Sprintf(ResourceAllowedFormat, userInfo.Username, utils.GenerateGroupString(userInfo.Groups), req.Operation, req.RequestKind, req.SubResource, namespacedName))
 }
 
-// isAdminGroupUserOrWhiteListedUser returns true is user belongs to white listed users or user belongs to system:masters/kubeadm:cluster-admins group.
+// IsAdminGroupUserOrWhiteListedUser returns true is user belongs to white listed users or user belongs to system:masters/kubeadm:cluster-admins group.
 // In clusters using kubeadm, kubernetes-admin belongs to kubeadm:cluster-admins group and kubernetes-super-admin user belongs to system:masters group.
 // https://kubernetes.io/docs/reference/setup-tools/kubeadm/implementation-details/#generate-kubeconfig-files-for-control-plane-components
-func isAdminGroupUserOrWhiteListedUser(whiteListedUsers []string, userInfo authenticationv1.UserInfo) bool {
+func IsAdminGroupUserOrWhiteListedUser(whiteListedUsers []string, userInfo authenticationv1.UserInfo) bool {
 	return slices.Contains(whiteListedUsers, userInfo.Username) || slices.Contains(userInfo.Groups, mastersGroup) || slices.Contains(userInfo.Groups, kubeadmClusterAdminsGroup)
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -128,7 +128,6 @@ var (
 	sideEffortsNone     = admv1.SideEffectClassNone
 	namespacedScope     = admv1.NamespacedScope
 	clusterScope        = admv1.ClusterScope
-	allScopes           = admv1.AllScopes
 	shortWebhookTimeout = ptr.To(int32(1))
 	longWebhookTimeout  = ptr.To(int32(5))
 )
@@ -420,20 +419,58 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 					Rule: createRule(
 						[]string{
 							placementv1beta1.GroupVersion.Group,
-							corev1.SchemeGroupVersion.Group,
-							networkingv1.SchemeGroupVersion.Group,
 						},
 						[]string{
 							placementv1beta1.GroupVersion.Version,
-							corev1.SchemeGroupVersion.Version,
-							networkingv1.SchemeGroupVersion.Version,
 						},
 						[]string{
 							placementv1beta1.ClusterResourcePlacementResource,
+						}, &clusterScope),
+				},
+				{
+					Operations: []admv1.OperationType{
+						admv1.Create, admv1.Update, admv1.Delete,
+					},
+					Rule: createRule(
+						[]string{
+							corev1.SchemeGroupVersion.Group,
+						},
+						[]string{
+							corev1.SchemeGroupVersion.Version,
+						},
+						[]string{
 							namespaceResourceName,
+						}, &clusterScope),
+				},
+				{
+					Operations: []admv1.OperationType{
+						admv1.Create, admv1.Update, admv1.Delete,
+					},
+					Rule: createRule(
+						[]string{
+							corev1.SchemeGroupVersion.Group,
+						},
+						[]string{
+							corev1.SchemeGroupVersion.Version,
+						},
+						[]string{
 							resourceQuotaResourceName,
+						}, &namespacedScope),
+				},
+				{
+					Operations: []admv1.OperationType{
+						admv1.Create, admv1.Update, admv1.Delete,
+					},
+					Rule: createRule(
+						[]string{
+							networkingv1.SchemeGroupVersion.Group,
+						},
+						[]string{
+							networkingv1.SchemeGroupVersion.Version,
+						},
+						[]string{
 							networkPolicyResourceName,
-						}, &allScopes),
+						}, &namespacedScope),
 				},
 			},
 			TimeoutSeconds: longWebhookTimeout,

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -429,7 +429,7 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 							networkingv1.SchemeGroupVersion.Version,
 						},
 						[]string{
-							fleetv1alpha1.ClusterResourcePlacementResource,
+							placementv1beta1.ClusterResourcePlacementResource,
 							namespaceResourceName,
 							resourceQuotaResourceName,
 							networkPolicyResourceName,

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -413,64 +413,20 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 			AdmissionReviewVersions: admissionReviewVersions,
 			Rules: []admv1.RuleWithOperations{
 				{
-					Operations: []admv1.OperationType{
-						admv1.Create, admv1.Update, admv1.Delete,
-					},
-					Rule: createRule(
-						[]string{
-							placementv1beta1.GroupVersion.Group,
-						},
-						[]string{
-							placementv1beta1.GroupVersion.Version,
-						},
-						[]string{
-							placementv1beta1.ClusterResourcePlacementResource,
-						}, &clusterScope),
+					Operations: []admv1.OperationType{admv1.Create, admv1.Update, admv1.Delete},
+					Rule:       createRule([]string{placementv1beta1.GroupVersion.Group}, []string{placementv1beta1.GroupVersion.Version}, []string{placementv1beta1.ClusterResourcePlacementResource}, &clusterScope),
 				},
 				{
-					Operations: []admv1.OperationType{
-						admv1.Create, admv1.Update, admv1.Delete,
-					},
-					Rule: createRule(
-						[]string{
-							corev1.SchemeGroupVersion.Group,
-						},
-						[]string{
-							corev1.SchemeGroupVersion.Version,
-						},
-						[]string{
-							namespaceResourceName,
-						}, &clusterScope),
+					Operations: []admv1.OperationType{admv1.Create, admv1.Update, admv1.Delete},
+					Rule:       createRule([]string{corev1.SchemeGroupVersion.Group}, []string{corev1.SchemeGroupVersion.Version}, []string{namespaceResourceName}, &clusterScope),
 				},
 				{
-					Operations: []admv1.OperationType{
-						admv1.Create, admv1.Update, admv1.Delete,
-					},
-					Rule: createRule(
-						[]string{
-							corev1.SchemeGroupVersion.Group,
-						},
-						[]string{
-							corev1.SchemeGroupVersion.Version,
-						},
-						[]string{
-							resourceQuotaResourceName,
-						}, &namespacedScope),
+					Operations: []admv1.OperationType{admv1.Create, admv1.Update, admv1.Delete},
+					Rule:       createRule([]string{corev1.SchemeGroupVersion.Group}, []string{corev1.SchemeGroupVersion.Version}, []string{resourceQuotaResourceName}, &namespacedScope),
 				},
 				{
-					Operations: []admv1.OperationType{
-						admv1.Create, admv1.Update, admv1.Delete,
-					},
-					Rule: createRule(
-						[]string{
-							networkingv1.SchemeGroupVersion.Group,
-						},
-						[]string{
-							networkingv1.SchemeGroupVersion.Version,
-						},
-						[]string{
-							networkPolicyResourceName,
-						}, &namespacedScope),
+					Operations: []admv1.OperationType{admv1.Create, admv1.Update, admv1.Delete},
+					Rule:       createRule([]string{networkingv1.SchemeGroupVersion.Group}, []string{networkingv1.SchemeGroupVersion.Version}, []string{networkPolicyResourceName}, &namespacedScope),
 				},
 			},
 			TimeoutSeconds: longWebhookTimeout,

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -62,6 +62,7 @@ import (
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacementdisruptionbudget"
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacementeviction"
 	"go.goms.io/fleet/pkg/webhook/fleetresourcehandler"
+	"go.goms.io/fleet/pkg/webhook/managedresource"
 	"go.goms.io/fleet/pkg/webhook/membercluster"
 	"go.goms.io/fleet/pkg/webhook/pod"
 	"go.goms.io/fleet/pkg/webhook/replicaset"
@@ -127,12 +128,16 @@ var (
 	sideEffortsNone     = admv1.SideEffectClassNone
 	namespacedScope     = admv1.NamespacedScope
 	clusterScope        = admv1.ClusterScope
+	allScopes           = admv1.AllScopes
 	shortWebhookTimeout = ptr.To(int32(1))
 	longWebhookTimeout  = ptr.To(int32(5))
 )
 
-var AddToManagerFuncs []func(manager.Manager) error
-var AddToManagerFleetResourceValidator func(manager.Manager, []string, bool, bool) error
+var (
+	AddToManagerFuncs                  []func(manager.Manager) error
+	AddtoManagerManagedResource        func(manager.Manager, []string) error
+	AddToManagerFleetResourceValidator func(manager.Manager, []string, bool, bool) error
+)
 
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager, whiteListedUsers []string, isFleetV1Beta1API bool, denyModifyMemberClusterLabels bool) error {
@@ -140,6 +145,9 @@ func AddToManager(m manager.Manager, whiteListedUsers []string, isFleetV1Beta1AP
 		if err := f(m); err != nil {
 			return err
 		}
+	}
+	if err := AddtoManagerManagedResource(m, whiteListedUsers); err != nil {
+		return err
 	}
 	return AddToManagerFleetResourceValidator(m, whiteListedUsers, isFleetV1Beta1API, denyModifyMemberClusterLabels)
 }
@@ -398,6 +406,38 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 			},
 			TimeoutSeconds: longWebhookTimeout,
 		},
+		{
+			Name:                    "fleet.managedresource.validating",
+			ClientConfig:            w.createClientConfig(managedresource.ValidationPath),
+			FailurePolicy:           &failFailurePolicy,
+			SideEffects:             &sideEffortsNone,
+			AdmissionReviewVersions: admissionReviewVersions,
+			Rules: []admv1.RuleWithOperations{
+				{
+					Operations: []admv1.OperationType{
+						admv1.Create, admv1.Update, admv1.Delete,
+					},
+					Rule: createRule(
+						[]string{
+							placementv1beta1.GroupVersion.Group,
+							corev1.SchemeGroupVersion.Group,
+							networkingv1.SchemeGroupVersion.Group,
+						},
+						[]string{
+							placementv1beta1.GroupVersion.Version,
+							corev1.SchemeGroupVersion.Version,
+							networkingv1.SchemeGroupVersion.Version,
+						},
+						[]string{
+							fleetv1alpha1.ClusterResourcePlacementResource,
+							namespaceResourceName,
+							resourceQuotaResourceName,
+							networkPolicyResourceName,
+						}, &allScopes),
+				},
+			},
+			TimeoutSeconds: longWebhookTimeout,
+		},
 	}
 
 	return webHooks
@@ -452,15 +492,19 @@ func (w *Config) buildFleetGuardRailValidatingWebhooks() []admv1.ValidatingWebho
 		// TODO(ArvindThiru): not handling pods, replicasets as part of the fleet guard rail since they have validating webhooks, need to remove validating webhooks before adding these resources to fleet guard rail.
 		{
 			Operations: cuOperations,
-			Rule: createRule([]string{corev1.SchemeGroupVersion.Group}, []string{corev1.SchemeGroupVersion.Version}, []string{bindingResourceName, configMapResourceName, endPointResourceName,
+			Rule: createRule([]string{corev1.SchemeGroupVersion.Group}, []string{corev1.SchemeGroupVersion.Version}, []string{
+				bindingResourceName, configMapResourceName, endPointResourceName,
 				limitRangeResourceName, persistentVolumeClaimsName, persistentVolumeClaimsName + "/status", podTemplateResourceName,
 				replicationControllerResourceName, replicationControllerResourceName + "/status", resourceQuotaResourceName, resourceQuotaResourceName + "/status", secretResourceName,
-				serviceAccountResourceName, servicesResourceName, servicesResourceName + "/status"}, &namespacedScope),
+				serviceAccountResourceName, servicesResourceName, servicesResourceName + "/status",
+			}, &namespacedScope),
 		},
 		{
 			Operations: cuOperations,
-			Rule: createRule([]string{appsv1.SchemeGroupVersion.Group}, []string{appsv1.SchemeGroupVersion.Version}, []string{controllerRevisionResourceName, daemonSetResourceName, daemonSetResourceName + "/status",
-				deploymentResourceName, deploymentResourceName + "/status", statefulSetResourceName, statefulSetResourceName + "/status"}, &namespacedScope),
+			Rule: createRule([]string{appsv1.SchemeGroupVersion.Group}, []string{appsv1.SchemeGroupVersion.Version}, []string{
+				controllerRevisionResourceName, daemonSetResourceName, daemonSetResourceName + "/status",
+				deploymentResourceName, deploymentResourceName + "/status", statefulSetResourceName, statefulSetResourceName + "/status",
+			}, &namespacedScope),
 		},
 		{
 			Operations: cuOperations,

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -25,7 +25,7 @@ func TestBuildFleetValidatingWebhooks(t *testing.T) {
 				serviceURL:           "test-url",
 				clientConnectionType: &url,
 			},
-			wantLength: 9,
+			wantLength: 10,
 		},
 	}
 

--- a/test/e2e/resources_test.go
+++ b/test/e2e/resources_test.go
@@ -50,6 +50,7 @@ const (
 	crpEvictionNameTemplate           = "crpe-%d"
 	updateRunStrategyNameTemplate     = "curs-%d"
 	updateRunNameWithSubIndexTemplate = "cur-%d-%d"
+	managedNamespaceTemplate          = "managedns-%d"
 
 	customDeletionBlockerFinalizer = "kubernetes-fleet.io/custom-deletion-blocker-finalizer"
 	workNamespaceLabelName         = "process"

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -52,6 +52,7 @@ import (
 	"go.goms.io/fleet/pkg/propertyprovider/azure/trackers"
 	"go.goms.io/fleet/pkg/utils"
 	"go.goms.io/fleet/pkg/utils/condition"
+	"go.goms.io/fleet/pkg/webhook/managedresource"
 	testv1alpha1 "go.goms.io/fleet/test/apis/v1alpha1"
 	"go.goms.io/fleet/test/e2e/framework"
 )
@@ -706,6 +707,20 @@ func createWorkResources() {
 // cleanupWorkResources deletes the resources created by createWorkResources and waits until the resources are not found.
 func cleanupWorkResources() {
 	cleanWorkResourcesOnCluster(hubCluster)
+}
+
+func createManagedNamespace() corev1.Namespace {
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf(managedNamespaceTemplate, GinkgoParallelProcess()),
+			Labels: map[string]string{
+				managedresource.ManagedByArmKey: managedresource.ManagedByArmValue,
+			},
+		},
+	}
+
+	Expect(hubClient.Create(ctx, &ns)).To(Succeed(), "Failed to create namespace %s", ns.Name)
+	return ns
 }
 
 func cleanWorkResourcesOnCluster(cluster *framework.Cluster) {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -709,8 +709,8 @@ func cleanupWorkResources() {
 	cleanWorkResourcesOnCluster(hubCluster)
 }
 
-func createManagedNamespace() corev1.Namespace {
-	ns := corev1.Namespace{
+func managedNamespace() corev1.Namespace {
+	return corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf(managedNamespaceTemplate, GinkgoParallelProcess()),
 			Labels: map[string]string{
@@ -718,9 +718,11 @@ func createManagedNamespace() corev1.Namespace {
 			},
 		},
 	}
+}
 
+func createManagedNamespace() {
+	ns := managedNamespace()
 	Expect(hubClient.Create(ctx, &ns)).To(Succeed(), "Failed to create namespace %s", ns.Name)
-	return ns
 }
 
 func cleanWorkResourcesOnCluster(cluster *framework.Cluster) {
@@ -833,6 +835,7 @@ func checkIfRemovedWorkResourcesFromMemberClustersConsistently(clusters []*frame
 		Consistently(workResourcesRemovedActual, consistentlyDuration, consistentlyInterval).Should(Succeed(), "Failed to remove work resources from member cluster %s consistently", memberCluster.ClusterName)
 	}
 }
+
 func checkNamespaceExistsWithOwnerRefOnMemberCluster(nsName, crpName string) {
 	Consistently(func() error {
 		ns := &corev1.Namespace{}

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -1294,13 +1294,13 @@ var _ = Describe("webhook tests for ResourceOverride UPDATE operations", Ordered
 	})
 })
 
-var _ = Describe("webhook tests for operations on ARM managed resources", Ordered, func() {
-	BeforeAll(func() {
+var _ = Describe("webhook tests for operations on ARM managed resources", func() {
+	BeforeEach(func() {
 		By("creating a managed namespace")
 		createManagedNamespace()
 	})
 
-	AfterAll(func() {
+	AfterEach(func() {
 		By("deleting the managed namespace")
 		ns := managedNamespace()
 		Expect(hubClient.Delete(ctx, &ns)).Should(SatisfyAny(Succeed(), utils.NotFoundMatcher{}), "Failed to delete the managed namespace")
@@ -1309,7 +1309,7 @@ var _ = Describe("webhook tests for operations on ARM managed resources", Ordere
 				return fmt.Errorf("The managed namespace still exists or an unexpected error occurred: %w", err)
 			}
 			return nil
-		}, workloadEventuallyDuration, eventuallyInterval).Should(Succeed(), "Failed to remove the managed namespace %s", ns.Name)
+		}, testutils.PollTimeout, testutils.PollInterval).Should(Succeed(), "Failed to remove the managed namespace %s", ns.Name)
 	})
 
 	It("should deny create a managed resource namespace", func() {
@@ -1349,7 +1349,7 @@ var _ = Describe("webhook tests for operations on ARM managed resources", Ordere
 		unmanaged := managedNamespace()
 		unmanaged.Name = "this-should-be-allowed"
 		delete(unmanaged.Labels, managedresource.ManagedByArmKey)
-		Expect(impersonateHubClient.Create(ctx, &unmanaged)).Should(SatisfyAny(Succeed(), utils.NotFoundMatcher{}), "Failed to create the unmanaged namespace")
+		Expect(impersonateHubClient.Create(ctx, &unmanaged)).Should(SatisfyAny(Succeed()), "Failed to create the unmanaged namespace")
 		Eventually(func(g Gomega) error {
 			g.Expect(impersonateHubClient.Get(ctx, types.NamespacedName{Name: unmanaged.Name}, &unmanaged)).To(BeNil(), "Failed to get the created unmanaged namespace")
 			unmanaged.Labels["foo"] = "NotManaged"


### PR DESCRIPTION
### Description of your changes

Fixes :
Enable the fleet dataplane to deny any create/update/delete operations on ARM managed resources.  At the moment, CRP, Namespace, ResourceQuota, and NetworkPolicy can be managed resources.

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`make local-unit-test` ran successfully

### Special notes for your reviewer