### PR TITLE
fix: Update Helm Chart Version in Chart.yaml

### DIFF
--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -64,30 +64,30 @@ jobs:
         run: |
           az login --identity 
           az acr login -n ${{ secrets.AZURE_REGISTRY }}
-      # - name: Build and publish hub-agent
-      #   run: |
-      #     make docker-build-hub-agent
-      #   env:
-      #     HUB_AGENT_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
-      #     REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
-      # - name: Build and publish member-agent
-      #   run: |
-      #     make docker-build-member-agent
-      #   env:
-      #     MEMBER_AGENT_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
-      #     REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
-      # - name: Build and publish refresh-token
-      #   run: |
-      #     make docker-build-refresh-token
-      #   env:
-      #     REFRESH_TOKEN_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
-      #     REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
-      # - name: Build and publish crd-installer
-      #   run: |
-      #     make docker-build-crd-installer
-      #   env:
-      #     CRD_INSTALLER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
-      #     REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+      - name: Build and publish hub-agent
+        run: |
+          make docker-build-hub-agent
+        env:
+          HUB_AGENT_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
+          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+      - name: Build and publish member-agent
+        run: |
+          make docker-build-member-agent
+        env:
+          MEMBER_AGENT_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
+          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+      - name: Build and publish refresh-token
+        run: |
+          make docker-build-refresh-token
+        env:
+          REFRESH_TOKEN_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
+          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+      - name: Build and publish crd-installer
+        run: |
+          make docker-build-crd-installer
+        env:
+          CRD_INSTALLER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
+          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
       # Build Arc Extension for member clusters
       # Arc-connected clusters can join fleets as member clusters through an Arc Extension.
       # An Arc Extension is a packaged Helm chart that gets deployed to Arc clusters.

--- a/.github/workflows/build-publish-mcr.yml
+++ b/.github/workflows/build-publish-mcr.yml
@@ -64,30 +64,30 @@ jobs:
         run: |
           az login --identity 
           az acr login -n ${{ secrets.AZURE_REGISTRY }}
-      - name: Build and publish hub-agent
-        run: |
-          make docker-build-hub-agent
-        env:
-          HUB_AGENT_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
-          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
-      - name: Build and publish member-agent
-        run: |
-          make docker-build-member-agent
-        env:
-          MEMBER_AGENT_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
-          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
-      - name: Build and publish refresh-token
-        run: |
-          make docker-build-refresh-token
-        env:
-          REFRESH_TOKEN_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
-          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
-      - name: Build and publish crd-installer
-        run: |
-          make docker-build-crd-installer
-        env:
-          CRD_INSTALLER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
-          REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+      # - name: Build and publish hub-agent
+      #   run: |
+      #     make docker-build-hub-agent
+      #   env:
+      #     HUB_AGENT_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
+      #     REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+      # - name: Build and publish member-agent
+      #   run: |
+      #     make docker-build-member-agent
+      #   env:
+      #     MEMBER_AGENT_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
+      #     REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+      # - name: Build and publish refresh-token
+      #   run: |
+      #     make docker-build-refresh-token
+      #   env:
+      #     REFRESH_TOKEN_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
+      #     REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
+      # - name: Build and publish crd-installer
+      #   run: |
+      #     make docker-build-crd-installer
+      #   env:
+      #     CRD_INSTALLER_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.release_tag }}
+      #     REGISTRY: ${{ secrets.AZURE_REGISTRY }}/${{ env.REGISTRY_REPO}}
       # Build Arc Extension for member clusters
       # Arc-connected clusters can join fleets as member clusters through an Arc Extension.
       # An Arc Extension is a packaged Helm chart that gets deployed to Arc clusters.

--- a/Makefile
+++ b/Makefile
@@ -343,6 +343,8 @@ helm-package-arc-member-cluster-agents:
 	# Update Chart.yaml version
 	sed -i.bak "s/^version:.*/version: $(ARC_MEMBER_AGENT_IMAGE_VERSION)/" charts/member-agent-arc/Chart.yaml
 
+	cat charts/member-agent-arc/Chart.yaml
+	 
 	envsubst < charts/member-agent-arc/values.yaml > charts/member-agent-arc/values.yaml.tmp && \
 	mv charts/member-agent-arc/values.yaml.tmp charts/member-agent-arc/values.yaml && \
 

--- a/Makefile
+++ b/Makefile
@@ -339,12 +339,16 @@ docker-build-crd-installer: docker-buildx-builder
 
 # Fleet Agents and Networking Agents are packaged and pushed to MCR for Arc Extension.
 .PHONY: helm-package-arc-member-cluster-agents
-helm-package-arc-member-cluster-agents:
+helm-package-arc-member-agent:
+	# Update Chart.yaml version
+	sed -i.bak "s/^version:.*/version: $(ARC_MEMBER_AGENT_IMAGE_VERSION)/" charts/member-agent-arc/Chart.yaml
+
 	envsubst < charts/member-agent-arc/values.yaml > charts/member-agent-arc/values.yaml.tmp && \
 	mv charts/member-agent-arc/values.yaml.tmp charts/member-agent-arc/values.yaml && \
-	helm package charts/member-agent-arc/ --version $(ARC_MEMBER_AGENT_HELMCHART_VERSION)
-	
-	helm push $(ARC_MEMBER_AGENT_HELMCHART_NAME)-$(ARC_MEMBER_AGENT_HELMCHART_VERSION).tgz oci://$(REGISTRY)
+
+	helm package charts/member-agent-arc/ --version $(ARC_MEMBER_AGENT_IMAGE_VERSION)
+
+	helm push $(ARC_MEMBER_AGENT_IMAGE_NAME)-$(ARC_MEMBER_AGENT_IMAGE_VERSION).tgz oci://$(REGISTRY)
 
 ## -----------------------------------
 ## Cleanup

--- a/Makefile
+++ b/Makefile
@@ -340,11 +340,8 @@ docker-build-crd-installer: docker-buildx-builder
 # Fleet Agents and Networking Agents are packaged and pushed to MCR for Arc Extension.
 .PHONY: helm-package-arc-member-cluster-agents
 helm-package-arc-member-cluster-agents:
-	# Update Chart.yaml version
-	sed -i.bak "s/^version:.*/version: $(ARC_MEMBER_AGENT_IMAGE_VERSION)/" charts/member-agent-arc/Chart.yaml
-
-	cat charts/member-agent-arc/Chart.yaml
-	 
+	# Update Chart.yaml version & environment variables in values.yaml
+	sed -i.bak "s/^version:.*/version: $(ARC_MEMBER_AGENT_IMAGE_VERSION)/" charts/member-agent-arc/Chart.yaml && \
 	envsubst < charts/member-agent-arc/values.yaml > charts/member-agent-arc/values.yaml.tmp && \
 	mv charts/member-agent-arc/values.yaml.tmp charts/member-agent-arc/values.yaml && \
 

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ docker-build-crd-installer: docker-buildx-builder
 
 # Fleet Agents and Networking Agents are packaged and pushed to MCR for Arc Extension.
 .PHONY: helm-package-arc-member-cluster-agents
-helm-package-arc-member-agent:
+helm-package-arc-member-cluster-agents:
 	# Update Chart.yaml version
 	sed -i.bak "s/^version:.*/version: $(ARC_MEMBER_AGENT_IMAGE_VERSION)/" charts/member-agent-arc/Chart.yaml
 

--- a/charts/member-agent-arc/Chart.yaml
+++ b/charts/member-agent-arc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: HELM_CHART_VERSION
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
### Description of your changes

In this PR, the mcr publish Github Action is modified to update the chart version when pushing helm charts to MCR. There is a mismatch in the version when the helm charts are packaged using `helm package charts/member-agent-arc/ --version $(ARC_MEMBER_AGENT_IMAGE_VERSION)` and the version in Chart.yaml file. This PR ensures the versions match the ones provided in the input.


Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
