### PR TITLE
fix: add validation for CRP and PickFixed cluster names

### DIFF
--- a/pkg/utils/validator/clusterresourceplacement.go
+++ b/pkg/utils/validator/clusterresourceplacement.go
@@ -194,9 +194,12 @@ func validatePolicyForPickFixedPlacementType(policy *placementv1beta1.PlacementP
 	}
 	uniqueClusterNames := make(map[string]bool)
 	for _, name := range policy.ClusterNames {
-		nameErr := validation.IsDNS1123Label(name)
+		nameErr := validation.IsDNS1123Subdomain(name)
 		if nameErr != nil {
 			allErr = append(allErr, fmt.Errorf("PickFixed cluster name %s is not a valid member name: %s", name, strings.Join(nameErr, "; ")))
+		}
+		if len(name) > validation.DNS1035LabelMaxLength {
+			allErr = append(allErr, fmt.Errorf("PickFixed cluster name %s cannot have length exceeding %d", name, validation.DNS1035LabelMaxLength))
 		}
 		if _, ok := uniqueClusterNames[name]; ok {
 			allErr = append(allErr, fmt.Errorf("cluster names must be unique for policy type %s", placementv1beta1.PickFixedPlacementType))

--- a/pkg/utils/validator/clusterresourceplacement_test.go
+++ b/pkg/utils/validator/clusterresourceplacement_test.go
@@ -517,10 +517,18 @@ func TestValidateClusterResourcePlacement_PickFixedPlacementPolicy(t *testing.T)
 		"invalid placement policy - PickFixed with invalid cluster names": {
 			policy: &placementv1beta1.PlacementPolicy{
 				PlacementType: placementv1beta1.PickFixedPlacementType,
-				ClusterNames:  []string{"test@,cluster1", "test$cluster2"},
+				ClusterNames:  []string{"test@,cluster1"},
 			},
 			wantErr:    true,
-			wantErrMsg: "PickFixed cluster name test@,cluster1 is not a valid member name: a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), PickFixed cluster name test$cluster2 is not a valid member name: a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')",
+			wantErrMsg: "PickFixed cluster name test@,cluster1 is not a valid member name: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')",
+		},
+		"invalid placement policy - PickFixed with too long cluster name": {
+			policy: &placementv1beta1.PlacementPolicy{
+				PlacementType: placementv1beta1.PickFixedPlacementType,
+				ClusterNames:  []string{"this-is-a-very-long-cluster-name-that-exceeds-the-maximum-allowed-length-for-dns-labels"},
+			},
+			wantErr:    true,
+			wantErrMsg: "PickFixed cluster name this-is-a-very-long-cluster-name-that-exceeds-the-maximum-allowed-length-for-dns-labels cannot have length exceeding 63",
 		},
 		"invalid placement policy - PickFixed with non nil number of clusters": {
 			policy: &placementv1beta1.PlacementPolicy{


### PR DESCRIPTION
### Description of your changes

As a result from the latest bug bash, we want to introduce validations for:
  - the CRP resource name, which currently only validates the length but not the characters in the name.
  - the cluster names for PickFixed policy.

I have:

- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
 
Run unit tests and add new test cases for negative validation scenarios.