### PR TITLE
fix: update vap to bypass openshift-kube-controller-manager on openshift clusters

### DIFF
--- a/pkg/webhook/managedresource/validatingadmissionpolicy.go
+++ b/pkg/webhook/managedresource/validatingadmissionpolicy.go
@@ -75,7 +75,7 @@ func mutateValidatingAdmissionPolicy(vap *admv1.ValidatingAdmissionPolicy, isHub
 		},
 		Validations: []admv1.Validation{
 			{
-				Expression: `"system:masters" in request.userInfo.groups || "system:serviceaccounts:kube-system" in request.userInfo.groups || "system:serviceaccounts:fleet-system" in request.userInfo.groups`,
+				Expression: `"system:masters" in request.userInfo.groups || "system:serviceaccounts:kube-system" in request.userInfo.groups || "system:serviceaccounts:fleet-system" in request.userInfo.groups || "system:serviceaccounts:openshift-kube-controller-manager" in request.userInfo.groups`,
 				Message:    "Create, Update, or Delete operations on ARM managed resources is forbidden",
 				Reason:     &forbidden,
 			},


### PR DESCRIPTION
### Description of your changes

update vap to bypass openshift-kube-controller-manager on ocp clusters to enable namespace-security-allocation-controller to add annotations to namespace objects as a part of SCC allocation process

```
    openshift.io/sa.scc.mcs:
    openshift.io/sa.scc.supplemental-groups: 
    openshift.io/sa.scc.uid-range:
```

Fixes #

I have:

- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
