### PR TITLE
feat: update hub-agent to use custom cluster affinity plugin in scheduler when property checker is enabled

### DIFF
--- a/cmd/hubagent/options/azureoptions.go
+++ b/cmd/hubagent/options/azureoptions.go
@@ -1,0 +1,31 @@
+//
+//Copyright (c) Microsoft Corporation.
+//Licensed under the MIT license.
+
+package options
+
+import (
+	"flag"
+)
+
+// AzurePropertyCheckerOptions holds the options for the Azure property checker.
+type AzurePropertyCheckerOptions struct {
+	// IsEnabled indicates whether the Azure property checker is enabled.
+	IsEnabled bool
+	// ComputeServiceAddressWithBasePath is the address of the Azure compute service with base path.
+	ComputeServiceAddressWithBasePath string
+}
+
+// NewAzurePropertyCheckerOptions creates a new AzurePropertyCheckerOptions with default values.
+func NewAzurePropertyCheckerOptions() AzurePropertyCheckerOptions {
+	return AzurePropertyCheckerOptions{
+		IsEnabled:                         false,
+		ComputeServiceAddressWithBasePath: "http://localhost:8421/compute",
+	}
+}
+
+// AddFlags adds flags for Azure Property Checker options to the given FlagSet.
+func (o AzurePropertyCheckerOptions) AddFlags(flags *flag.FlagSet) {
+	flags.BoolVar(&o.IsEnabled, "azure-property-checker-enabled", o.IsEnabled, "Enable Azure property checker for validating Azure-specific cluster properties.")
+	flags.StringVar(&o.ComputeServiceAddressWithBasePath, "azure-compute-server-address", o.ComputeServiceAddressWithBasePath, "The address of the Azure compute service with base path.")
+}

--- a/cmd/hubagent/options/options.go
+++ b/cmd/hubagent/options/options.go
@@ -112,6 +112,8 @@ type Options struct {
 	ResourceSnapshotCreationMinimumInterval time.Duration
 	// ResourceChangesCollectionDuration is the duration for collecting resource changes into one snapshot.
 	ResourceChangesCollectionDuration time.Duration
+	// AzurePropertyCheckerOpts contains options for Azure property checker
+	AzurePropertyCheckerOpts AzurePropertyCheckerOptions
 }
 
 // NewOptions builds an empty options.
@@ -134,6 +136,7 @@ func NewOptions() *Options {
 		PprofPort:                               6065,
 		ResourceSnapshotCreationMinimumInterval: 30 * time.Second,
 		ResourceChangesCollectionDuration:       15 * time.Second,
+		AzurePropertyCheckerOpts:                NewAzurePropertyCheckerOptions(),
 	}
 }
 
@@ -185,4 +188,5 @@ func (o *Options) AddFlags(flags *flag.FlagSet) {
 	flags.DurationVar(&o.ResourceChangesCollectionDuration, "resource-changes-collection-duration", 15*time.Second,
 		"The duration for collecting resource changes into one snapshot. The default is 15 seconds, which means that the controller will collect resource changes for 15 seconds before creating a resource snapshot.")
 	o.RateLimiterOpts.AddFlags(flags)
+	o.AzurePropertyCheckerOpts.AddFlags(flags)
 }


### PR DESCRIPTION
### Description of your changes

I have: 
- Hub agent reads in a Boolean to enable property checker functionalities and passes the compute service endpoint base url.
- Use newly added options to create scheduler with a custom cluster affinity plugin to use property checker.

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

- Tested in Standalone
Logs from hub agent used for testing:
```bash
I1106 19:15:29.423534       1 workload/setup.go:389] Setting up scheduler
I1106 19:15:29.423560       1 workload/setup.go:392] Azure property checker is enabled for cluster property validation
I1106 19:15:29.423626       1 workload/setup.go:408] Starting the scheduler
```
### Special notes for your reviewer

There are some copied files from [previous PR ](https://github.com/Azure/fleet/pull/1210) so that the setup could work.
