### PR TITLE
Remove explicit `GOEXPERIMENT=systemcrypto`

### DIFF
--- a/docker/crd-installer.Dockerfile
+++ b/docker/crd-installer.Dockerfile
@@ -16,9 +16,9 @@ RUN go mod download
 COPY cmd/crdinstaller/ cmd/crdinstaller/
 COPY pkg pkg
 
-# Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
+# Build with CGO enabled for internal usage
 RUN echo "Building for GOOS=$GOOS GOARCH=$GOARCH"
-RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o crdinstaller cmd/crdinstaller/main.go
+RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o crdinstaller cmd/crdinstaller/main.go
 
 # Use Azure Linux distroless base image to package the crdinstaller binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -17,7 +17,7 @@ COPY cmd/hubagent/  cmd/hubagent/
 COPY apis/ apis/
 COPY pkg/ pkg/
 
-# Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
+# Build with CGO enabled for internal usage
 RUN echo "Building for GOOS=$GOOS GOARCH=$GOARCH"
 RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o hubagent  cmd/hubagent/main.go
 

--- a/docker/hub-agent.Dockerfile
+++ b/docker/hub-agent.Dockerfile
@@ -19,7 +19,7 @@ COPY pkg/ pkg/
 
 # Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
 RUN echo "Building for GOOS=$GOOS GOARCH=$GOARCH"
-RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o hubagent  cmd/hubagent/main.go
+RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o hubagent  cmd/hubagent/main.go
 
 # Use Azure Linux distroless base image to package the hubagent binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/member-agent.Dockerfile
+++ b/docker/member-agent.Dockerfile
@@ -19,7 +19,7 @@ COPY pkg/ pkg/
 
 # Build
 RUN echo "Building images with GOOS=$GOOS GOARCH=$GOARCH"
-RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o memberagent cmd/memberagent/main.go
+RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o memberagent cmd/memberagent/main.go
 
 # Use Azure Linux distroless base image to package the memberagent binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details

--- a/docker/refresh-token.Dockerfile
+++ b/docker/refresh-token.Dockerfile
@@ -16,9 +16,9 @@ RUN go mod download
 COPY cmd/authtoken/main.go main.go
 COPY pkg/authtoken pkg/authtoken
 
-# Build with CGO enabled and GOEXPERIMENT=systemcrypto for internal usage
+# Build with CGO enabled for internal usage
 RUN echo "Building for GOOS=${GOOS} GOARCH=${GOARCH}"
-RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GOEXPERIMENT=systemcrypto GO111MODULE=on go build -o refreshtoken main.go
+RUN CGO_ENABLED=1 GOOS=$GOOS GOARCH=$GOARCH GO111MODULE=on go build -o refreshtoken main.go
 
 # Use Azure Linux distroless base image to package the refreshtoken binary
 # Refer to https://mcr.microsoft.com/en-us/artifact/mar/azurelinux/distroless/base/about for more details


### PR DESCRIPTION
### Description of your changes

Microsoft build of Go maintainer here. SystemCrypto is enabled by default since Go 1.25, no need to set it manually (see [docs](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/MigrationGuide.md#enable-systemcrypto)). That experiment will most likely disappear in Go 1.27, so removing it now will safe you from a build error once upgrading to Go 1.27.

