### PR TITLE
feat: add mutating webhook to label managed deploys created by aksService

### DIFF
--- a/pkg/utils/azure.go
+++ b/pkg/utils/azure.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"slices"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+)
+
+// This file contains constants and utility functions related to Azure-specific logic.
+// We define these in a separate file to avoid potential merge conflicts from the KubeFleet repository when backporting changes.
+const (
+	// ReconcileLabelKey is the label key added to resources that should be reconciled.
+	// The value indicates the reason the resource should be reconciled.
+	ReconcileLabelKey = "fleet.azure.com/reconcile"
+	// ReconcileLabelValue is the label value paired with ReconcileLabelKey,
+	// indicating the resource is managed and should be reconciled.
+	ReconcileLabelValue = "managed"
+
+	// AKSServiceUserName is the username whose deployment requests should be mutated.
+	AKSServiceUserName = "aksService"
+	// SystemMastersGroup is the Kubernetes group representing cluster administrators.
+	SystemMastersGroup = "system:masters"
+)
+
+// IsAKSService reports whether the user is the aksService user with
+// system:masters group membership.
+func IsAKSService(userInfo authenticationv1.UserInfo) bool {
+	return userInfo.Username == AKSServiceUserName && slices.Contains(userInfo.Groups, SystemMastersGroup)
+}
+
+// HasReconcileLabel reports whether the given labels contain the fleet reconcile
+// label key with a non-empty value.
+func HasReconcileLabel(labels map[string]string) bool {
+	return labels[ReconcileLabelKey] != ""
+}

--- a/pkg/webhook/add_handler.go
+++ b/pkg/webhook/add_handler.go
@@ -5,6 +5,7 @@ import (
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacement"
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacementdisruptionbudget"
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacementeviction"
+	"go.goms.io/fleet/pkg/webhook/deployment"
 	"go.goms.io/fleet/pkg/webhook/fleetresourcehandler"
 	"go.goms.io/fleet/pkg/webhook/membercluster"
 	"go.goms.io/fleet/pkg/webhook/pdb"
@@ -29,4 +30,6 @@ func init() {
 	AddToManagerFuncs = append(AddToManagerFuncs, resourceoverride.Add)
 	AddToManagerFuncs = append(AddToManagerFuncs, clusterresourceplacementeviction.Add)
 	AddToManagerFuncs = append(AddToManagerFuncs, clusterresourceplacementdisruptionbudget.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, deployment.AddMutating)
+	AddToManagerFuncs = append(AddToManagerFuncs, deployment.Add)
 }

--- a/pkg/webhook/deployment/mutating_webhook.go
+++ b/pkg/webhook/deployment/mutating_webhook.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"go.goms.io/fleet/pkg/utils"
+)
+
+// MutatingPath is the webhook service path for mutating Deployment resources.
+var MutatingPath = fmt.Sprintf(utils.MutatingPathFmt, appsv1.SchemeGroupVersion.Group, appsv1.SchemeGroupVersion.Version, "deployment")
+
+type deploymentMutator struct {
+	decoder webhook.AdmissionDecoder
+}
+
+// AddMutating registers the mutating webhook for Deployments with the manager.
+func AddMutating(mgr manager.Manager) error {
+	hookServer := mgr.GetWebhookServer()
+	hookServer.Register(MutatingPath, &webhook.Admission{Handler: &deploymentMutator{decoder: admission.NewDecoder(mgr.GetScheme())}})
+	return nil
+}
+
+// Handle injects the fleet.azure.com/reconcile=managed label onto the
+// Deployment and its pod template when the request originated from the aksService user.
+func (m *deploymentMutator) Handle(_ context.Context, req admission.Request) admission.Response {
+	klog.V(2).InfoS("handling deployment mutating webhook",
+		"operation", req.Operation, "namespace", req.Namespace, "name", req.Name, "user", req.UserInfo.Username)
+
+	// Pass through requests targeting reserved system namespaces.
+	if utils.IsReservedNamespace(req.Namespace) {
+		return admission.Allowed(fmt.Sprintf("namespace %s is a reserved system namespace, no mutation needed", req.Namespace))
+	}
+
+	// Only mutate when the request was made by the aksService user with
+	// system:masters group membership.
+	if !utils.IsAKSService(req.UserInfo) {
+		return admission.Allowed("user is not aksService, no mutation needed")
+	}
+
+	var deploy appsv1.Deployment
+	if err := m.decoder.Decode(req, &deploy); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Add the reconcile label on the Deployment metadata.
+	if deploy.Labels == nil {
+		deploy.Labels = map[string]string{}
+	}
+	deploy.Labels[utils.ReconcileLabelKey] = utils.ReconcileLabelValue
+
+	// Add the reconcile label on the pod template metadata.
+	if deploy.Spec.Template.Labels == nil {
+		deploy.Spec.Template.Labels = map[string]string{}
+	}
+	deploy.Spec.Template.Labels[utils.ReconcileLabelKey] = utils.ReconcileLabelValue
+
+	marshaled, err := json.Marshal(deploy)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	klog.V(2).InfoS("mutated deployment with reconcile label",
+		"operation", req.Operation, "namespace", req.Namespace, "name", req.Name)
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
+}

--- a/pkg/webhook/deployment/mutating_webhook_test.go
+++ b/pkg/webhook/deployment/mutating_webhook_test.go
@@ -1,0 +1,393 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"go.goms.io/fleet/pkg/utils"
+)
+
+const (
+	kubeSystemNamespace = "kube-system"
+)
+
+func TestMutatingPath(t *testing.T) {
+	want := "/mutate-apps-v1-deployment"
+	if MutatingPath != want {
+		t.Errorf("MutatingPath = %q, want %q", MutatingPath, want)
+	}
+}
+
+func TestHandle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("appsv1.AddToScheme() = %v, want nil", err)
+	}
+	decoder := admission.NewDecoder(scheme)
+
+	aksServiceUser := authenticationv1.UserInfo{
+		Username: utils.AKSServiceUserName,
+		Groups:   []string{utils.SystemMastersGroup},
+	}
+
+	aksServiceUserNoMasters := authenticationv1.UserInfo{
+		Username: utils.AKSServiceUserName,
+		Groups:   []string{"system:authenticated"},
+	}
+
+	regularUser := authenticationv1.UserInfo{
+		Username: "regular-user",
+		Groups:   []string{utils.SystemMastersGroup, "system:authenticated"},
+	}
+
+	// Deployment with no existing labels.
+	deployNoLabels := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "nginx"},
+					},
+				},
+			},
+		},
+	}
+
+	// Deployment with existing labels on both deployment and pod template.
+	deployWithLabels := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy-labels",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "myapp", "tier": "frontend"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "myapp"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "myapp", "tier": "frontend"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "myapp", Image: "myapp:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	// Deployment in kube-system namespace.
+	deployKubeSystem := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy",
+			Namespace: kubeSystemNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "nginx"},
+					},
+				},
+			},
+		},
+	}
+
+	// Deployment in fleet-system namespace.
+	deployFleetSystem := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy",
+			Namespace: utils.FleetSystemNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "nginx"},
+					},
+				},
+			},
+		},
+	}
+
+	// Deployment that already has the reconcile label.
+	deployAlreadyLabeled := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy-already-labeled",
+			Namespace: "default",
+			Labels:    map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue, "app": "myapp"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "myapp"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue, "app": "myapp"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "myapp", Image: "myapp:latest"},
+					},
+				},
+			},
+		},
+	}
+
+	deployNoLabelsBytes, err := json.Marshal(deployNoLabels)
+	if err != nil {
+		t.Fatalf("json.Marshal(deployNoLabels) = %v, want nil", err)
+	}
+	deployWithLabelsBytes, err := json.Marshal(deployWithLabels)
+	if err != nil {
+		t.Fatalf("json.Marshal(deployWithLabels) = %v, want nil", err)
+	}
+	deployKubeSystemBytes, err := json.Marshal(deployKubeSystem)
+	if err != nil {
+		t.Fatalf("json.Marshal(deployKubeSystem) = %v, want nil", err)
+	}
+	deployFleetSystemBytes, err := json.Marshal(deployFleetSystem)
+	if err != nil {
+		t.Fatalf("json.Marshal(deployFleetSystem) = %v, want nil", err)
+	}
+	deployAlreadyLabeledBytes, err := json.Marshal(deployAlreadyLabeled)
+	if err != nil {
+		t.Fatalf("json.Marshal(deployAlreadyLabeled) = %v, want nil", err)
+	}
+
+	testCases := map[string]struct {
+		req          admission.Request
+		wantResponse admission.Response
+	}{
+		"allow and skip mutation for kube-system namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: kubeSystemNamespace,
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    deployKubeSystemBytes,
+						Object: deployKubeSystem,
+					},
+					UserInfo: aksServiceUser,
+				},
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf("namespace %s is a reserved system namespace, no mutation needed", kubeSystemNamespace)),
+		},
+		"allow and skip mutation for fleet-system namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: utils.FleetSystemNamespace,
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    deployFleetSystemBytes,
+						Object: deployFleetSystem,
+					},
+					UserInfo: aksServiceUser,
+				},
+			},
+			wantResponse: admission.Allowed(fmt.Sprintf("namespace %s is a reserved system namespace, no mutation needed", utils.FleetSystemNamespace)),
+		},
+		"allow and skip mutation for non-aksService user": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    deployNoLabelsBytes,
+						Object: deployNoLabels,
+					},
+					UserInfo: regularUser,
+				},
+			},
+			wantResponse: admission.Allowed("user is not aksService, no mutation needed"),
+		},
+		"allow and skip mutation for aksService user not in system:masters group": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    deployNoLabelsBytes,
+						Object: deployNoLabels,
+					},
+					UserInfo: aksServiceUserNoMasters,
+				},
+			},
+			wantResponse: admission.Allowed("user is not aksService, no mutation needed"),
+		},
+		"mutate deployment with no labels by aksService user": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    deployNoLabelsBytes,
+						Object: deployNoLabels,
+					},
+					UserInfo: aksServiceUser,
+				},
+			},
+			wantResponse: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:   true,
+					PatchType: ptr.To(admissionv1.PatchTypeJSONPatch),
+				},
+				Patches: []jsonpatch.JsonPatchOperation{
+					{
+						Operation: "add",
+						Path:      "/metadata/labels",
+						Value: map[string]any{
+							utils.ReconcileLabelKey: utils.ReconcileLabelValue,
+						},
+					},
+					{
+						Operation: "add",
+						Path:      "/spec/template/metadata/labels",
+						Value: map[string]any{
+							utils.ReconcileLabelKey: utils.ReconcileLabelValue,
+						},
+					},
+				},
+			},
+		},
+		"mutate deployment with existing labels by aksService user": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy-labels",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    deployWithLabelsBytes,
+						Object: deployWithLabels,
+					},
+					UserInfo: aksServiceUser,
+				},
+			},
+			wantResponse: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:   true,
+					PatchType: ptr.To(admissionv1.PatchTypeJSONPatch),
+				},
+				Patches: []jsonpatch.JsonPatchOperation{
+					{
+						Operation: "add",
+						Path:      "/metadata/labels/fleet.azure.com~1reconcile",
+						Value:     utils.ReconcileLabelValue,
+					},
+					{
+						Operation: "add",
+						Path:      "/spec/template/metadata/labels/fleet.azure.com~1reconcile",
+						Value:     utils.ReconcileLabelValue,
+					},
+				},
+			},
+		},
+		"no-op patch when reconcile label already present": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy-already-labeled",
+					Namespace: "default",
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw:    deployAlreadyLabeledBytes,
+						Object: deployAlreadyLabeled,
+					},
+					UserInfo: aksServiceUser,
+				},
+			},
+			wantResponse: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+				},
+				Patches: []jsonpatch.JsonPatchOperation{},
+			},
+		},
+		"error on malformed request object": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte("not valid json"),
+					},
+					UserInfo: aksServiceUser,
+				},
+			},
+			// The exact error message from the decoder is implementation-defined;
+			// only the status code and allowed=false are compared.
+			wantResponse: admission.Errored(http.StatusBadRequest, errors.New("")),
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			m := &deploymentMutator{decoder: decoder}
+			gotResponse := m.Handle(context.Background(), tc.req)
+			cmpOptions := []cmp.Option{
+				cmpopts.IgnoreFields(metav1.Status{}, "Message"),
+				cmpopts.SortSlices(func(a, b jsonpatch.JsonPatchOperation) bool {
+					if a.Path == b.Path {
+						return a.Operation < b.Operation
+					}
+					return a.Path < b.Path
+				}),
+			}
+			if diff := cmp.Diff(tc.wantResponse, gotResponse, cmpOptions...); diff != "" {
+				t.Errorf("Handle() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/webhook/deployment/validating_webhook.go
+++ b/pkg/webhook/deployment/validating_webhook.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package deployment implements admission webhooks for Deployment resources.
+// The mutating webhook injects the "fleet.azure.com/reconcile=managed" label on
+// deployments created by the aksService user. The validating webhook prevents
+// non-aksService users from setting this label, which would otherwise bypass
+// pod and replicaset admission checks.
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"go.goms.io/fleet/pkg/utils"
+)
+
+const (
+	deniedReconcileLabelFmt = "the %s label is reserved for aksService and cannot be set by user %q"
+)
+
+// ValidationPath is the webhook service path for validating Deployment resources.
+var ValidationPath = fmt.Sprintf(utils.ValidationPathFmt, appsv1.SchemeGroupVersion.Group, appsv1.SchemeGroupVersion.Version, "deployment")
+
+type deploymentValidator struct {
+	decoder webhook.AdmissionDecoder
+}
+
+// Add registers the validating webhook for Deployments with the manager.
+func Add(mgr manager.Manager) error {
+	hookServer := mgr.GetWebhookServer()
+	hookServer.Register(ValidationPath, &webhook.Admission{Handler: &deploymentValidator{decoder: admission.NewDecoder(mgr.GetScheme())}})
+	return nil
+}
+
+// Handle rejects deployments that carry the fleet reconcile label unless the
+// request was made by the aksService user with system:masters group membership.
+func (v *deploymentValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	namespacedName := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
+	klog.V(2).InfoS("handling deployment validating webhook",
+		"operation", req.Operation, "namespacedName", namespacedName, "user", req.UserInfo.Username)
+
+	// Only validate CREATE and UPDATE operations.
+	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update {
+		return admission.Allowed("operation is not CREATE or UPDATE, no validation needed")
+	}
+
+	var deploy appsv1.Deployment
+	if err := v.decoder.Decode(req, &deploy); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Check whether the reconcile label is present on either the Deployment
+	// metadata or the pod template metadata.
+	hasLabelOnDeploy := utils.HasReconcileLabel(deploy.Labels)
+	hasLabelOnPodTemplate := utils.HasReconcileLabel(deploy.Spec.Template.Labels)
+
+	if !hasLabelOnDeploy && !hasLabelOnPodTemplate {
+		return admission.Allowed("deployment does not have the reconcile label, no validation needed")
+	}
+
+	// The reconcile label is present — only aksService with system:masters is
+	// allowed to set it.
+	if utils.IsAKSService(req.UserInfo) {
+		klog.V(2).InfoS("aksService user allowed to set reconcile label",
+			"namespacedName", namespacedName)
+		return admission.Allowed("aksService user is allowed to set the reconcile label")
+	}
+
+	klog.V(2).InfoS("denied non-aksService user from setting reconcile label",
+		"user", req.UserInfo.Username, "groups", req.UserInfo.Groups, "namespacedName", namespacedName)
+	return admission.Denied(fmt.Sprintf(deniedReconcileLabelFmt, utils.ReconcileLabelKey, req.UserInfo.Username))
+}

--- a/pkg/webhook/deployment/validating_webhook_test.go
+++ b/pkg/webhook/deployment/validating_webhook_test.go
@@ -1,0 +1,436 @@
+/*
+Copyright 2025 The KubeFleet Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"go.goms.io/fleet/pkg/utils"
+)
+
+func TestValidationPath(t *testing.T) {
+	want := "/validate-apps-v1-deployment"
+	if ValidationPath != want {
+		t.Errorf("ValidationPath = %q, want %q", ValidationPath, want)
+	}
+}
+
+func TestValidatingHandle(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("appsv1.AddToScheme() = %v, want nil", err)
+	}
+	decoder := admission.NewDecoder(scheme)
+
+	aksServiceUser := authenticationv1.UserInfo{
+		Username: utils.AKSServiceUserName,
+		Groups:   []string{utils.SystemMastersGroup},
+	}
+
+	aksServiceUserNoMasters := authenticationv1.UserInfo{
+		Username: utils.AKSServiceUserName,
+		Groups:   []string{"system:authenticated"},
+	}
+
+	regularUser := authenticationv1.UserInfo{
+		Username: "regular-user",
+		Groups:   []string{"system:authenticated"},
+	}
+
+	regularUserWithMasters := authenticationv1.UserInfo{
+		Username: "regular-user",
+		Groups:   []string{utils.SystemMastersGroup, "system:authenticated"},
+	}
+
+	// Deployment without the reconcile label.
+	deployNoReconcileLabel := newTestDeployment("test-deploy", "default", nil, nil)
+
+	// Deployment with reconcile label on deployment metadata only.
+	deployWithReconcileLabelOnDeploy := newTestDeployment("test-deploy", "default",
+		map[string]string{"app": "myapp", utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+		map[string]string{"app": "myapp"},
+	)
+
+	// Deployment with reconcile label on pod template only.
+	deployWithReconcileLabelOnPodTemplate := newTestDeployment("test-deploy", "default",
+		map[string]string{"app": "myapp"},
+		map[string]string{"app": "myapp", utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+	)
+
+	// Deployment with reconcile label on both.
+	deployWithReconcileLabelOnBoth := newTestDeployment("test-deploy", "default",
+		map[string]string{"app": "myapp", utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+		map[string]string{"app": "myapp", utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+	)
+
+	// Deployment in kube-system with reconcile label.
+	deployKubeSystem := newTestDeployment("test-deploy", kubeSystemNamespace,
+		map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+		nil,
+	)
+
+	// Deployment in fleet-system with reconcile label.
+	deployFleetSystem := newTestDeployment("test-deploy", utils.FleetSystemNamespace,
+		map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+		nil,
+	)
+
+	marshalOrFatal := func(t *testing.T, obj interface{}) []byte {
+		t.Helper()
+		b, err := json.Marshal(obj)
+		if err != nil {
+			t.Fatalf("json.Marshal() = %v, want nil", err)
+		}
+		return b
+	}
+
+	deployNoReconcileLabelBytes := marshalOrFatal(t, deployNoReconcileLabel)
+	deployWithReconcileLabelOnDeployBytes := marshalOrFatal(t, deployWithReconcileLabelOnDeploy)
+	deployWithReconcileLabelOnPodTemplateBytes := marshalOrFatal(t, deployWithReconcileLabelOnPodTemplate)
+	deployWithReconcileLabelOnBothBytes := marshalOrFatal(t, deployWithReconcileLabelOnBoth)
+	deployKubeSystemBytes := marshalOrFatal(t, deployKubeSystem)
+	deployFleetSystemBytes := marshalOrFatal(t, deployFleetSystem)
+
+	testCases := map[string]struct {
+		req         admission.Request
+		wantAllowed bool
+		wantErrCode int32
+	}{
+		"allow deployment without reconcile label from regular user on CREATE": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployNoReconcileLabelBytes, Object: deployNoReconcileLabel},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: true,
+		},
+		"allow deployment without reconcile label from regular user on UPDATE": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Update,
+					Object:    runtime.RawExtension{Raw: deployNoReconcileLabelBytes, Object: deployNoReconcileLabel},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: true,
+		},
+		"deny regular user from setting reconcile label in kube-system namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: kubeSystemNamespace,
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployKubeSystemBytes, Object: deployKubeSystem},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: false,
+		},
+		"deny regular user from setting reconcile label in fleet-system namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: utils.FleetSystemNamespace,
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployFleetSystemBytes, Object: deployFleetSystem},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: false,
+		},
+		"allow aksService user with reconcile label in kube-system namespace": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: kubeSystemNamespace,
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployKubeSystemBytes, Object: deployKubeSystem},
+					UserInfo:  aksServiceUser,
+				},
+			},
+			wantAllowed: true,
+		},
+		"allow DELETE operation even with reconcile label from regular user": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Delete,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnBothBytes, Object: deployWithReconcileLabelOnBoth},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: true,
+		},
+		"allow CONNECT operation even with reconcile label from regular user": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Connect,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnBothBytes, Object: deployWithReconcileLabelOnBoth},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: true,
+		},
+		"allow aksService user with system:masters to set reconcile label on deployment metadata": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnDeployBytes, Object: deployWithReconcileLabelOnDeploy},
+					UserInfo:  aksServiceUser,
+				},
+			},
+			wantAllowed: true,
+		},
+		"allow aksService user with system:masters to set reconcile label on pod template": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnPodTemplateBytes, Object: deployWithReconcileLabelOnPodTemplate},
+					UserInfo:  aksServiceUser,
+				},
+			},
+			wantAllowed: true,
+		},
+		"allow aksService user with system:masters to set reconcile label on both on UPDATE": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Update,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnBothBytes, Object: deployWithReconcileLabelOnBoth},
+					UserInfo:  aksServiceUser,
+				},
+			},
+			wantAllowed: true,
+		},
+		"deny aksService user without system:masters group from setting reconcile label": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnDeployBytes, Object: deployWithReconcileLabelOnDeploy},
+					UserInfo:  aksServiceUserNoMasters,
+				},
+			},
+			wantAllowed: false,
+		},
+		"deny regular user from setting reconcile label on deployment metadata": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnDeployBytes, Object: deployWithReconcileLabelOnDeploy},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: false,
+		},
+		"deny regular user from setting reconcile label on pod template only": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnPodTemplateBytes, Object: deployWithReconcileLabelOnPodTemplate},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: false,
+		},
+		"deny regular user from setting reconcile label on both deployment and pod template via UPDATE": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Update,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnBothBytes, Object: deployWithReconcileLabelOnBoth},
+					UserInfo:  regularUser,
+				},
+			},
+			wantAllowed: false,
+		},
+		"deny regular user with system:masters but wrong username from setting reconcile label": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object:    runtime.RawExtension{Raw: deployWithReconcileLabelOnDeployBytes, Object: deployWithReconcileLabelOnDeploy},
+					UserInfo:  regularUserWithMasters,
+				},
+			},
+			wantAllowed: false,
+		},
+		"error on malformed request object": {
+			req: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Name:      "test-deploy",
+					Namespace: "default",
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw: []byte("not valid json"),
+					},
+					UserInfo: aksServiceUser,
+				},
+			},
+			wantAllowed: false,
+			wantErrCode: http.StatusBadRequest,
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			v := &deploymentValidator{decoder: decoder}
+			gotResponse := v.Handle(context.Background(), tc.req)
+
+			if gotResponse.Allowed != tc.wantAllowed {
+				t.Errorf("Handle() Allowed = %v, want %v, reason = %v", gotResponse.Allowed, tc.wantAllowed, gotResponse.Result)
+			}
+
+			if tc.wantErrCode != 0 {
+				wantResponse := admission.Errored(tc.wantErrCode, errors.New(""))
+				cmpOptions := []cmp.Option{
+					cmpopts.IgnoreFields(metav1.Status{}, "Message"),
+				}
+				if diff := cmp.Diff(wantResponse, gotResponse, cmpOptions...); diff != "" {
+					t.Errorf("Handle() error response mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			// Denied responses should include a non-empty reason message.
+			if !tc.wantAllowed && tc.wantErrCode == 0 && gotResponse.Result != nil {
+				if gotResponse.Result.Message == "" {
+					t.Error("Handle() denied response should include a non-empty reason message")
+				}
+			}
+		})
+	}
+}
+
+func TestIsAKSService(t *testing.T) {
+	testCases := map[string]struct {
+		userInfo authenticationv1.UserInfo
+		want     bool
+	}{
+		"aksService with system:masters": {
+			userInfo: authenticationv1.UserInfo{
+				Username: utils.AKSServiceUserName,
+				Groups:   []string{utils.SystemMastersGroup},
+			},
+			want: true,
+		},
+		"aksService with system:masters and other groups": {
+			userInfo: authenticationv1.UserInfo{
+				Username: utils.AKSServiceUserName,
+				Groups:   []string{"system:authenticated", utils.SystemMastersGroup, "custom-group"},
+			},
+			want: true,
+		},
+		"aksService without system:masters": {
+			userInfo: authenticationv1.UserInfo{
+				Username: utils.AKSServiceUserName,
+				Groups:   []string{"system:authenticated"},
+			},
+			want: false,
+		},
+		"aksService with empty groups": {
+			userInfo: authenticationv1.UserInfo{
+				Username: utils.AKSServiceUserName,
+				Groups:   []string{},
+			},
+			want: false,
+		},
+		"regular user with system:masters": {
+			userInfo: authenticationv1.UserInfo{
+				Username: "regular-user",
+				Groups:   []string{utils.SystemMastersGroup},
+			},
+			want: false,
+		},
+		"empty username with system:masters": {
+			userInfo: authenticationv1.UserInfo{
+				Username: "",
+				Groups:   []string{utils.SystemMastersGroup},
+			},
+			want: false,
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			got := utils.IsAKSService(tc.userInfo)
+			if got != tc.want {
+				t.Errorf("isAKSService(%+v) = %v, want %v", tc.userInfo, got, tc.want)
+			}
+		})
+	}
+}
+
+// newTestDeployment creates a Deployment for testing with the given labels.
+func newTestDeployment(name, namespace string, deployLabels, podTemplateLabels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    deployLabels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podTemplateLabels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test", Image: "nginx"},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/webhook/pod/pod_validating_webhook.go
+++ b/pkg/webhook/pod/pod_validating_webhook.go
@@ -64,8 +64,8 @@ func (v *podValidator) Handle(_ context.Context, req admission.Request) admissio
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if !utils.IsReservedNamespace(pod.Namespace) {
-			klog.V(2).InfoS(deniedPodResource, "user", req.UserInfo.Username, "groups", req.UserInfo.Groups, "operation", req.Operation, "GVK", req.RequestKind, "subResource", req.SubResource, "namespacedName", namespacedName)
+		if !utils.IsReservedNamespace(pod.Namespace) && !utils.HasReconcileLabel(pod.Labels) {
+			klog.V(2).InfoS(deniedPodResource, "user", req.UserInfo.Username, "groups", req.UserInfo.Groups, "operation", req.Operation, "GVK", req.RequestKind, "subResource", req.SubResource, "namespacedName", namespacedName, "hasReconcileLabel", utils.HasReconcileLabel(pod.Labels))
 			return admission.Denied(fmt.Sprintf(podDeniedFormat, pod.Namespace, pod.Name))
 		}
 	}

--- a/pkg/webhook/replicaset/replicaset_validating_webhook.go
+++ b/pkg/webhook/replicaset/replicaset_validating_webhook.go
@@ -63,8 +63,8 @@ func (v *replicaSetValidator) Handle(_ context.Context, req admission.Request) a
 		if err := v.decoder.Decode(req, rs); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if !utils.IsReservedNamespace(rs.Namespace) {
-			klog.V(2).InfoS(deniedReplicaSetResource, "user", req.UserInfo.Username, "groups", req.UserInfo.Groups, "operation", req.Operation, "GVK", req.RequestKind, "subResource", req.SubResource, "namespacedName", namespacedName)
+		if !utils.IsReservedNamespace(rs.Namespace) && !utils.HasReconcileLabel(rs.Labels) {
+			klog.V(2).InfoS(deniedReplicaSetResource, "user", req.UserInfo.Username, "groups", req.UserInfo.Groups, "operation", req.Operation, "GVK", req.RequestKind, "subResource", req.SubResource, "namespacedName", namespacedName, "hasReconcileLabel", utils.HasReconcileLabel(rs.Labels))
 			return admission.Denied(fmt.Sprintf(replicaSetDeniedFormat, rs.Namespace, rs.Name))
 		}
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -59,6 +59,7 @@ import (
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacement"
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacementdisruptionbudget"
 	"go.goms.io/fleet/pkg/webhook/clusterresourceplacementeviction"
+	"go.goms.io/fleet/pkg/webhook/deployment"
 	"go.goms.io/fleet/pkg/webhook/fleetresourcehandler"
 	"go.goms.io/fleet/pkg/webhook/membercluster"
 	"go.goms.io/fleet/pkg/webhook/pdb"
@@ -413,6 +414,23 @@ func (w *Config) buildFleetMutatingWebhooks() []admv1.MutatingWebhook {
 			},
 			TimeoutSeconds: longWebhookTimeout,
 		},
+		{
+			Name:                    "fleet.deployment.mutating",
+			ClientConfig:            w.createClientConfig(deployment.MutatingPath),
+			FailurePolicy:           &ignoreFailurePolicy,
+			SideEffects:             &sideEffortsNone,
+			AdmissionReviewVersions: admissionReviewVersions,
+			Rules: []admv1.RuleWithOperations{
+				{
+					Operations: []admv1.OperationType{
+						admv1.Create,
+						admv1.Update,
+					},
+					Rule: createRule([]string{appsv1.SchemeGroupVersion.Group}, []string{appsv1.SchemeGroupVersion.Version}, []string{deploymentResourceName}, &namespacedScope),
+				},
+			},
+			TimeoutSeconds: longWebhookTimeout,
+		},
 	}
 	return webHooks
 }
@@ -587,6 +605,19 @@ func (w *Config) buildFleetValidatingWebhooks() []admv1.ValidatingWebhook {
 			TimeoutSeconds: longWebhookTimeout,
 		},
 	)
+
+	webHooks = append(webHooks, admv1.ValidatingWebhook{
+		Name:                    "fleet.deployment.validating",
+		ClientConfig:            w.createClientConfig(deployment.ValidationPath),
+		FailurePolicy:           &failFailurePolicy,
+		SideEffects:             &sideEffortsNone,
+		AdmissionReviewVersions: admissionReviewVersions,
+		Rules: []admv1.RuleWithOperations{{
+			Operations: []admv1.OperationType{admv1.Create, admv1.Update},
+			Rule:       createRule([]string{appsv1.SchemeGroupVersion.Group}, []string{appsv1.SchemeGroupVersion.Version}, []string{deploymentResourceName}, &namespacedScope),
+		}},
+		TimeoutSeconds: longWebhookTimeout,
+	})
 
 	return webHooks
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -33,7 +33,7 @@ func TestBuildFleetMutatingWebhooks(t *testing.T) {
 				serviceURL:           "test-url",
 				clientConnectionType: &url,
 			},
-			wantLength: 1,
+			wantLength: 2,
 		},
 	}
 
@@ -60,7 +60,7 @@ func TestBuildFleetValidatingWebhooks(t *testing.T) {
 				serviceURL:           "test-url",
 				clientConnectionType: &url,
 			},
-			wantLength: 9,
+			wantLength: 10,
 		},
 		"enable workload": {
 			config: Config{
@@ -70,7 +70,7 @@ func TestBuildFleetValidatingWebhooks(t *testing.T) {
 				clientConnectionType: &url,
 				enableWorkload:       true,
 			},
-			wantLength: 7,
+			wantLength: 8,
 		},
 		"enable PDBs": {
 			config: Config{
@@ -80,7 +80,7 @@ func TestBuildFleetValidatingWebhooks(t *testing.T) {
 				clientConnectionType: &url,
 				enablePDBs:           true,
 			},
-			wantLength: 8,
+			wantLength: 9,
 		},
 	}
 

--- a/test/e2e/fleet_guard_rail_test.go
+++ b/test/e2e/fleet_guard_rail_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
@@ -1302,5 +1303,307 @@ var _ = Describe("fleet guard rail restrict internal fleet resources from being 
 	It("should deny CREATE operation on internal service export resource in kube-system namespace for invalid user", func() {
 		ise := internalServiceExport("test-ise", "kube-system")
 		Expect(checkIfStatusErrorWithMessage(notMasterUser.Create(ctx, &ise), fmt.Sprintf(validation.ResourceDeniedFormat, testUser, utils.GenerateGroupString(testGroups), admissionv1.Create, &iseGVK, "", types.NamespacedName{Name: ise.Name, Namespace: ise.Namespace}))).Should(Succeed())
+	})
+})
+
+var _ = Describe("fleet deployment webhook tests for validating and mutating deployments", Serial, Ordered, func() {
+	const (
+		testNS = "default"
+	)
+
+	newDeployment := func(name, namespace string, deployLabels, podTemplateLabels map[string]string) *appsv1.Deployment {
+		mergeMaps := func(ms ...map[string]string) map[string]string {
+			result := make(map[string]string)
+			for _, m := range ms {
+				for k, v := range m {
+					result[k] = v
+				}
+			}
+			return result
+		}
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    deployLabels,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(1)),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": name},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: mergeMaps(map[string]string{"app": name}, podTemplateLabels),
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test-container",
+								Image: "nginx:latest",
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	Context("validating webhook - deny regular user from setting reconcile label", func() {
+		It("should deny regular user from creating a deployment with reconcile label on deployment metadata", func() {
+			deploy := newDeployment("test-deploy-val-1", testNS,
+				map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+				nil,
+			)
+			// Deployment creation should be denied; no cleanup needed.
+			err := notMasterUser.Create(ctx, deploy)
+			var statusErr *k8sErrors.StatusError
+			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create deployment call produced error %s, want StatusError", fmt.Sprintf("%T", err)))
+			Expect(statusErr.ErrStatus.Message).Should(ContainSubstring(utils.ReconcileLabelKey))
+		})
+
+		It("should deny regular user from creating a deployment with reconcile label on pod template", func() {
+			deploy := newDeployment("test-deploy-val-2", testNS,
+				nil,
+				map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+			)
+			// Deployment creation should be denied; no cleanup needed.
+			err := notMasterUser.Create(ctx, deploy)
+			var statusErr *k8sErrors.StatusError
+			Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Create deployment call produced error %s, want StatusError", fmt.Sprintf("%T", err)))
+			Expect(statusErr.ErrStatus.Message).Should(ContainSubstring(utils.ReconcileLabelKey))
+		})
+
+		It("should deny regular user from updating a deployment to add reconcile label", func() {
+			// First create a deployment without reconcile label as admin.
+			deploy := newDeployment("test-deploy-val-3", testNS, nil, nil)
+			Expect(hubClient.Create(ctx, deploy)).Should(Succeed())
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+
+			// Try to update as non-admin to add reconcile label.
+			Eventually(func(g Gomega) error {
+				var d appsv1.Deployment
+				err := hubClient.Get(ctx, types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, &d)
+				if err != nil {
+					return err
+				}
+				if d.Labels == nil {
+					d.Labels = map[string]string{}
+				}
+				d.Labels[utils.ReconcileLabelKey] = utils.ReconcileLabelValue
+				err = notMasterUser.Update(ctx, &d)
+				if k8sErrors.IsConflict(err) {
+					return err
+				}
+				var statusErr *k8sErrors.StatusError
+				g.Expect(errors.As(err, &statusErr)).To(BeTrue(), fmt.Sprintf("Update deployment call produced error %s, want StatusError", fmt.Sprintf("%T", err)))
+				g.Expect(statusErr.ErrStatus.Message).Should(ContainSubstring(utils.ReconcileLabelKey))
+				return nil
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed())
+		})
+	})
+
+	Context("validating webhook - allow aksService user to set reconcile label", func() {
+		It("should allow aksService user to create a deployment with reconcile label", func() {
+			deploy := newDeployment("test-deploy-val-aks-1", testNS,
+				map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+				map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+			)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+			Expect(sysMastersClient.Create(ctx, deploy)).Should(Succeed())
+		})
+
+		It("should allow aksService user to create a deployment with reconcile label in kube-system", func() {
+			deploy := newDeployment("test-deploy-val-aks-2", "kube-system",
+				map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+				map[string]string{utils.ReconcileLabelKey: utils.ReconcileLabelValue},
+			)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+			Expect(sysMastersClient.Create(ctx, deploy)).Should(Succeed())
+		})
+	})
+
+	Context("validating webhook - allow deployment without reconcile label", func() {
+		It("should allow regular user to create a deployment without reconcile label", func() {
+			deploy := newDeployment("test-deploy-val-norc", testNS, nil, nil)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+			Expect(notMasterUser.Create(ctx, deploy)).Should(Succeed())
+		})
+
+		It("should allow aksService user to create a deployment without reconcile label", func() {
+			deploy := newDeployment("test-deploy-val-norc", testNS, nil, nil)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+			Expect(sysMastersClient.Create(ctx, deploy)).Should(Succeed())
+		})
+	})
+
+	Context("mutating webhook - inject reconcile label for aksService user", func() {
+		It("should inject reconcile label when aksService creates a deployment", func() {
+			deploy := newDeployment("test-deploy-mut-1", testNS, nil, nil)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+			Expect(sysMastersClient.Create(ctx, deploy)).Should(Succeed())
+
+			// Verify the reconcile label was injected. The mutating webhook runs
+			// synchronously during admission, but Eventually is used defensively
+			// to handle brief etcd/cache propagation lag.
+			Eventually(func(g Gomega) {
+				var d appsv1.Deployment
+				g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, &d)).Should(Succeed())
+				g.Expect(d.Labels).Should(HaveKeyWithValue(utils.ReconcileLabelKey, utils.ReconcileLabelValue),
+					"deployment metadata should have reconcile label injected by mutating webhook")
+				g.Expect(d.Spec.Template.Labels).Should(HaveKeyWithValue(utils.ReconcileLabelKey, utils.ReconcileLabelValue),
+					"pod template should have reconcile label injected by mutating webhook")
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed())
+		})
+	})
+
+	Context("mutating webhook - no injection for regular user", func() {
+		It("should not inject reconcile label when regular user creates a deployment", func() {
+			deploy := newDeployment("test-deploy-mut-2", testNS, nil, nil)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+			Expect(notMasterUser.Create(ctx, deploy)).Should(Succeed())
+
+			// Verify the reconcile label was NOT injected.
+			Eventually(func(g Gomega) {
+				var d appsv1.Deployment
+				g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, &d)).Should(Succeed())
+				g.Expect(d.Labels).ShouldNot(HaveKey(utils.ReconcileLabelKey),
+					"deployment metadata should NOT have reconcile label for regular user")
+				g.Expect(d.Spec.Template.Labels).ShouldNot(HaveKey(utils.ReconcileLabelKey),
+					"pod template should NOT have reconcile label for regular user")
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed())
+		})
+	})
+
+	Context("mutating webhook - no injection in reserved namespaces", func() {
+		It("should not inject reconcile label for deployment in kube-system even for aksService", func() {
+			deploy := newDeployment("test-deploy-mut-3", "kube-system", nil, nil)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+			Expect(sysMastersClient.Create(ctx, deploy)).Should(Succeed())
+
+			// Verify the reconcile label was NOT injected for reserved namespace.
+			Eventually(func(g Gomega) {
+				var d appsv1.Deployment
+				g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: deploy.Name, Namespace: deploy.Namespace}, &d)).Should(Succeed())
+				g.Expect(d.Labels).ShouldNot(HaveKey(utils.ReconcileLabelKey),
+					"deployment in kube-system should NOT have reconcile label auto-injected")
+				g.Expect(d.Spec.Template.Labels).ShouldNot(HaveKey(utils.ReconcileLabelKey),
+					"pod template in kube-system should NOT have reconcile label auto-injected")
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed())
+		})
+	})
+
+	Context("end-to-end deployment lifecycle with webhook enforcement", func() {
+		It("should block RS and Pod creation when non-aksService user creates a deployment", func() {
+			deployName := "test-deploy-e2e-noaks"
+			deploy := newDeployment(deployName, testNS, nil, nil)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+
+			By("creating deployment as non-aksService user")
+			Expect(notMasterUser.Create(ctx, deploy)).Should(Succeed())
+
+			By("waiting for deployment to appear in the cache")
+			Eventually(func(g Gomega) {
+				var d appsv1.Deployment
+				g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: deployName, Namespace: testNS}, &d)).Should(Succeed())
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed())
+
+			By("verifying deployment exists but has no available replicas because RS creation is blocked")
+			Consistently(func(g Gomega) {
+				var d appsv1.Deployment
+				g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: deployName, Namespace: testNS}, &d)).Should(Succeed())
+				g.Expect(d.Status.AvailableReplicas).Should(Equal(int32(0)),
+					"deployment should have 0 available replicas because RS/Pod creation is blocked by validating webhooks")
+				g.Expect(d.Status.ReadyReplicas).Should(Equal(int32(0)),
+					"deployment should have 0 ready replicas")
+
+				// Verify no ReplicaSets exist for this deployment.
+				var rsList appsv1.ReplicaSetList
+				g.Expect(hubClient.List(ctx, &rsList, client.InNamespace(testNS), client.MatchingLabels{"app": deployName})).Should(Succeed())
+				g.Expect(rsList.Items).Should(BeEmpty(),
+					"no ReplicaSets should exist because the RS validating webhook blocks creation without the reconcile label")
+
+				// Verify no Pods exist for this deployment.
+				var podList corev1.PodList
+				g.Expect(hubClient.List(ctx, &podList, client.InNamespace(testNS), client.MatchingLabels{"app": deployName})).Should(Succeed())
+				g.Expect(podList.Items).Should(BeEmpty(),
+					"no Pods should exist because the Pod validating webhook blocks creation without the reconcile label")
+			}, consistentlyDuration, consistentlyInterval).Should(Succeed())
+		})
+
+		It("should allow RS and Pod creation when aksService user creates a deployment", func() {
+			deployName := "test-deploy-e2e-aks"
+			deploy := newDeployment(deployName, testNS, nil, nil)
+			DeferCleanup(func() {
+				_ = hubClient.Delete(ctx, deploy)
+			})
+
+			By("creating deployment as aksService user (mutating webhook injects reconcile label)")
+			Expect(sysMastersClient.Create(ctx, deploy)).Should(Succeed())
+
+			By("verifying the mutating webhook injected the reconcile label")
+			Eventually(func(g Gomega) {
+				var d appsv1.Deployment
+				g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: deployName, Namespace: testNS}, &d)).Should(Succeed())
+				g.Expect(d.Labels).Should(HaveKeyWithValue(utils.ReconcileLabelKey, utils.ReconcileLabelValue),
+					"deployment metadata should have reconcile label injected by mutating webhook")
+				g.Expect(d.Spec.Template.Labels).Should(HaveKeyWithValue(utils.ReconcileLabelKey, utils.ReconcileLabelValue),
+					"pod template should have reconcile label injected by mutating webhook")
+			}, eventuallyDuration, eventuallyInterval).Should(Succeed())
+
+			By("verifying ReplicaSet is created with the reconcile label")
+			Eventually(func(g Gomega) {
+				var rsList appsv1.ReplicaSetList
+				g.Expect(hubClient.List(ctx, &rsList, client.InNamespace(testNS), client.MatchingLabels{"app": deployName})).Should(Succeed())
+				g.Expect(rsList.Items).ShouldNot(BeEmpty(),
+					"at least one ReplicaSet should be created for the deployment")
+
+				rs := rsList.Items[0]
+				g.Expect(rs.Labels).Should(HaveKeyWithValue(utils.ReconcileLabelKey, utils.ReconcileLabelValue),
+					"ReplicaSet should inherit the reconcile label from the pod template")
+			}, workloadEventuallyDuration, eventuallyInterval).Should(Succeed())
+
+			By("verifying Pods are running with the reconcile label")
+			Eventually(func(g Gomega) {
+				var podList corev1.PodList
+				g.Expect(hubClient.List(ctx, &podList, client.InNamespace(testNS), client.MatchingLabels{"app": deployName})).Should(Succeed())
+				g.Expect(podList.Items).ShouldNot(BeEmpty(),
+					"at least one Pod should be created for the deployment")
+
+				pod := podList.Items[0]
+				g.Expect(pod.Labels).Should(HaveKeyWithValue(utils.ReconcileLabelKey, utils.ReconcileLabelValue),
+					"Pod should inherit the reconcile label from the pod template")
+				g.Expect(pod.Status.Phase).Should(Equal(corev1.PodRunning),
+					"Pod should be in Running phase")
+			}, workloadEventuallyDuration, eventuallyInterval).Should(Succeed())
+
+			By("verifying deployment reports available replicas")
+			Eventually(func(g Gomega) {
+				var d appsv1.Deployment
+				g.Expect(hubClient.Get(ctx, types.NamespacedName{Name: deployName, Namespace: testNS}, &d)).Should(Succeed())
+				g.Expect(d.Status.AvailableReplicas).Should(Equal(int32(1)),
+					"deployment should have 1 available replica")
+				g.Expect(d.Status.ReadyReplicas).Should(Equal(int32(1)),
+					"deployment should have 1 ready replica")
+			}, workloadEventuallyDuration, eventuallyInterval).Should(Succeed())
+		})
 	})
 })

--- a/test/e2e/setup.sh
+++ b/test/e2e/setup.sh
@@ -148,11 +148,11 @@ helm install hub-agent ../../charts/hub-agent/ \
     --set crdInstaller.image.pullPolicy=Never \
     --set namespace=fleet-system \
     --set logVerbosity=5 \
-    --set replicaCount=3 \
-    --set useCertManager=true \
+    --set replicaCount=1 \
+    --set useCertManager=false \
     --set webhookCertSecretName=fleet-webhook-server-cert \
     --set enableWebhook=true \
-    --set enableWorkload=true \
+    --set enableWorkload=false \
     --set webhookClientConnectionType=service \
     --set forceDeleteWaitTime="1m0s" \
     --set clusterUnhealthyThreshold="3m0s" \


### PR DESCRIPTION



### Description of your changes

<!--

Briefly describe what this pull request does. We love pull requests that have a clear purpose. If yours fix an issue,
please uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
1. Add a mutating webhook to add reconcile label on deploy and deploy pod template created by user aksService on hub cluster.
2. Do not block pod/rs creation/update with this label.
3. Add a validating webhook to prevent regular user from being able to add the label to their template.
4. Disable `enableWorkload` flag in e2e.
Fixes #

I have:

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

<!--

Be sure to direct your reviewers' attention to anything that needs special consideration.

-->
