### PR TITLE
fix: allow capacity http errors to requeue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/Azure/karpenter-provider-azure v1.5.1
 	github.com/crossplane/crossplane-runtime/v2 v2.1.0
 	github.com/evanphx/json-patch/v5 v5.9.11
-	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/go-logr/logr v1.4.3
+	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/pkg/clients/azure/compute/vmsizerecommenderclient.go
+++ b/pkg/clients/azure/compute/vmsizerecommenderclient.go
@@ -23,6 +23,7 @@ import (
 	computev1 "go.goms.io/fleet/apis/protos/azure/compute/v1"
 	"go.goms.io/fleet/pkg/clients/httputil"
 	"go.goms.io/fleet/pkg/utils/controller"
+	fleetErrors "go.goms.io/fleet/pkg/utils/errors"
 )
 
 const (
@@ -136,9 +137,14 @@ func (c *AttributeBasedVMSizeRecommenderClient) GenerateAttributeBasedRecommenda
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	// Check status code
+	// Check status code - categorize based on transient vs non-transient errors
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, httputil.NewHTTPError(resp)
+		desc := fmt.Sprintf("request failed with status %d: %s %s", resp.StatusCode, httpReq.Method, url)
+		if httputil.IsTransientStatusCode(resp.StatusCode) {
+			return nil, fleetErrors.NewTransientError(nil, desc)
+		}
+		// Non-transient errors (4xx client errors) should not be retried.
+		return nil, fleetErrors.NewUnexpectedError(nil, desc)
 	}
 
 	// Unmarshal response using protojson for proper proto3 support

--- a/pkg/clients/azure/compute/vmsizerecommenderclient.go
+++ b/pkg/clients/azure/compute/vmsizerecommenderclient.go
@@ -68,12 +68,10 @@ func NewAttributeBasedVMSizeRecommenderClient(
 }
 
 // GenerateAttributeBasedRecommendations generates VM size recommendations based on attributes.
-// Transient HTTP errors (429, 500, 502, 503, 504) are wrapped with ErrExpectedBehavior so that
-// the scheduler can requeue the placement for later retry.
 func (c *AttributeBasedVMSizeRecommenderClient) GenerateAttributeBasedRecommendations(
 	ctx context.Context,
 	req *computev1.GenerateAttributeBasedRecommendationsRequest,
-) (*computev1.GenerateAttributeBasedRecommendationsResponse, error) {
+) (response *computev1.GenerateAttributeBasedRecommendationsResponse, err error) {
 	if req == nil {
 		return nil, controller.NewUnexpectedBehaviorError(errors.New("request cannot be nil"))
 	}
@@ -117,11 +115,17 @@ func (c *AttributeBasedVMSizeRecommenderClient) GenerateAttributeBasedRecommenda
 	// Execute the request
 	startTime := time.Now()
 	klog.V(2).InfoS("Generating VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID)
+	defer func() {
+		latency := time.Since(startTime).Milliseconds()
+		if err != nil {
+			klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
+		} else {
+			klog.V(2).InfoS("Generated VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
+		}
+	}()
 
 	resp, err := c.httpClient.Do(httpReq)
-	latency := time.Since(startTime).Milliseconds()
 	if err != nil {
-		klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
@@ -129,27 +133,22 @@ func (c *AttributeBasedVMSizeRecommenderClient) GenerateAttributeBasedRecommenda
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	// Check status code
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		httpErr := httputil.NewHTTPError(resp)
-		klog.ErrorS(httpErr, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
-		return nil, httpErr
+		return nil, httputil.NewHTTPError(resp)
 	}
 
 	// Unmarshal response using protojson for proper proto3 support
-	response := &computev1.GenerateAttributeBasedRecommendationsResponse{}
+	response = &computev1.GenerateAttributeBasedRecommendationsResponse{}
 	unmarshaler := protojson.UnmarshalOptions{
 		DiscardUnknown: true,
 	}
-	if err := unmarshaler.Unmarshal(respBody, response); err != nil {
-		klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
+	if err = unmarshaler.Unmarshal(respBody, response); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
-	klog.V(2).InfoS("Generated VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
 	return response, nil
 }

--- a/pkg/clients/azure/compute/vmsizerecommenderclient.go
+++ b/pkg/clients/azure/compute/vmsizerecommenderclient.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/gofrs/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
 	"k8s.io/klog/v2"
@@ -69,10 +68,12 @@ func NewAttributeBasedVMSizeRecommenderClient(
 }
 
 // GenerateAttributeBasedRecommendations generates VM size recommendations based on attributes.
+// Transient HTTP errors (429, 500, 502, 503, 504) are wrapped with ErrExpectedBehavior so that
+// the scheduler can requeue the placement for later retry.
 func (c *AttributeBasedVMSizeRecommenderClient) GenerateAttributeBasedRecommendations(
 	ctx context.Context,
 	req *computev1.GenerateAttributeBasedRecommendationsRequest,
-) (response *computev1.GenerateAttributeBasedRecommendationsResponse, err error) {
+) (*computev1.GenerateAttributeBasedRecommendationsResponse, error) {
 	if req == nil {
 		return nil, controller.NewUnexpectedBehaviorError(errors.New("request cannot be nil"))
 	}
@@ -116,17 +117,11 @@ func (c *AttributeBasedVMSizeRecommenderClient) GenerateAttributeBasedRecommenda
 	// Execute the request
 	startTime := time.Now()
 	klog.V(2).InfoS("Generating VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID)
-	defer func() {
-		latency := time.Since(startTime).Milliseconds()
-		if err != nil {
-			klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latency", latency)
-		} else {
-			klog.V(2).InfoS("Generated VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latency", latency)
-		}
-	}()
 
 	resp, err := c.httpClient.Do(httpReq)
+	latency := time.Since(startTime).Milliseconds()
 	if err != nil {
+		klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}
 	defer resp.Body.Close()
@@ -134,22 +129,27 @@ func (c *AttributeBasedVMSizeRecommenderClient) GenerateAttributeBasedRecommenda
 	// Read response body
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
+		klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	// Check status code
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("request failed with status %d: %w", resp.StatusCode, runtime.NewResponseError(resp))
+		httpErr := httputil.NewHTTPError(resp)
+		klog.ErrorS(httpErr, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
+		return nil, httpErr
 	}
 
 	// Unmarshal response using protojson for proper proto3 support
-	response = &computev1.GenerateAttributeBasedRecommendationsResponse{}
+	response := &computev1.GenerateAttributeBasedRecommendationsResponse{}
 	unmarshaler := protojson.UnmarshalOptions{
 		DiscardUnknown: true,
 	}
 	if err := unmarshaler.Unmarshal(respBody, response); err != nil {
+		klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
+	klog.V(2).InfoS("Generated VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
 	return response, nil
 }

--- a/pkg/clients/azure/compute/vmsizerecommenderclient.go
+++ b/pkg/clients/azure/compute/vmsizerecommenderclient.go
@@ -118,9 +118,9 @@ func (c *AttributeBasedVMSizeRecommenderClient) GenerateAttributeBasedRecommenda
 	defer func() {
 		latency := time.Since(startTime).Milliseconds()
 		if err != nil {
-			klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
+			klog.ErrorS(err, "Failed to generate VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latency", latency)
 		} else {
-			klog.V(2).InfoS("Generated VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latencyMs", latency)
+			klog.V(2).InfoS("Generated VM size recommendations", "subscriptionID", req.SubscriptionId, "location", req.Location, "clientRequestID", clientRequestID, "latency", latency)
 		}
 	}()
 

--- a/pkg/clients/azure/compute/vmsizerecommenderclient_test.go
+++ b/pkg/clients/azure/compute/vmsizerecommenderclient_test.go
@@ -7,7 +7,6 @@ package compute
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -16,7 +15,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	computev1 "go.goms.io/fleet/apis/protos/azure/compute/v1"
-	"go.goms.io/fleet/pkg/clients/httputil"
+	fleetErrors "go.goms.io/fleet/pkg/utils/errors"
 	"go.goms.io/fleet/test/utils/azure/compute"
 )
 
@@ -275,17 +274,17 @@ func TestClient_GenerateAttributeBasedRecommendations(t *testing.T) {
 				return
 			}
 
-			// Check if error is a transient HTTPError by checking IsRetryable.
+			// Check if error is retryable using fleetErrors.IsRetryable.
 			if tt.wantErr && tt.wantIsTransient {
-				var httpErr *httputil.HTTPError
-				if !errors.As(err, &httpErr) || !httpErr.IsRetryable() {
-					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, want retryable HTTPError", err)
+				retryable, found := fleetErrors.IsRetryable(err)
+				if !found || !retryable {
+					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, want retryable error", err)
 				}
 			}
 			if tt.wantErr && !tt.wantIsTransient && tt.mockStatusCode >= 400 && tt.mockStatusCode < 500 {
-				var httpErr *httputil.HTTPError
-				if errors.As(err, &httpErr) && httpErr.IsRetryable() {
-					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, should NOT be retryable HTTPError for 4xx errors", err)
+				retryable, found := fleetErrors.IsRetryable(err)
+				if found && retryable {
+					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, should NOT be retryable for 4xx errors", err)
 				}
 			}
 

--- a/pkg/clients/azure/compute/vmsizerecommenderclient_test.go
+++ b/pkg/clients/azure/compute/vmsizerecommenderclient_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	computev1 "go.goms.io/fleet/apis/protos/azure/compute/v1"
+	"go.goms.io/fleet/pkg/clients/httputil"
 	"go.goms.io/fleet/test/utils/azure/compute"
 )
 
@@ -81,13 +82,14 @@ func TestNewAttributeBasedVMSizeRecommenderClient(t *testing.T) {
 
 func TestClient_GenerateAttributeBasedRecommendations(t *testing.T) {
 	tests := []struct {
-		name           string
-		request        *computev1.GenerateAttributeBasedRecommendationsRequest
-		mockStatusCode int
-		mockResponse   string
-		wantResponse   *computev1.GenerateAttributeBasedRecommendationsResponse
-		wantErr        bool
-		wantErrMsg     string
+		name            string
+		request         *computev1.GenerateAttributeBasedRecommendationsRequest
+		mockStatusCode  int
+		mockResponse    string
+		wantResponse    *computev1.GenerateAttributeBasedRecommendationsResponse
+		wantErr         bool
+		wantErrMsg      string
+		wantIsTransient bool // true if error should be a transient HTTPError
 	}{
 		{
 			name: "successful request with regular priority profile",
@@ -169,7 +171,7 @@ func TestClient_GenerateAttributeBasedRecommendations(t *testing.T) {
 			wantErrMsg: "either regular priority profile or spot priority profile must be provided",
 		},
 		{
-			name: "HTTP 400 error",
+			name: "HTTP 400 error is not transient",
 			request: &computev1.GenerateAttributeBasedRecommendationsRequest{
 				SubscriptionId: "sub-123",
 				Location:       "eastus",
@@ -177,13 +179,14 @@ func TestClient_GenerateAttributeBasedRecommendations(t *testing.T) {
 					TargetCapacity: 5,
 				},
 			},
-			mockStatusCode: http.StatusBadRequest,
-			mockResponse:   `{"error":"invalid request"}`,
-			wantErr:        true,
-			wantErrMsg:     "request failed with status 400",
+			mockStatusCode:  http.StatusBadRequest,
+			mockResponse:    `{"error":"invalid request"}`,
+			wantErr:         true,
+			wantErrMsg:      "request failed with status 400: POST",
+			wantIsTransient: false, // 400 is NOT transient
 		},
 		{
-			name: "HTTP 500 error",
+			name: "HTTP 500 error is transient",
 			request: &computev1.GenerateAttributeBasedRecommendationsRequest{
 				SubscriptionId: "sub-123",
 				Location:       "eastus",
@@ -191,10 +194,41 @@ func TestClient_GenerateAttributeBasedRecommendations(t *testing.T) {
 					TargetCapacity: 5,
 				},
 			},
-			mockStatusCode: http.StatusInternalServerError,
-			mockResponse:   `{"error":"internal server error"}`,
-			wantErr:        true,
-			wantErrMsg:     "request failed with status 500",
+			mockStatusCode:  http.StatusInternalServerError,
+			mockResponse:    `{"error":"internal server error"}`,
+			wantErr:         true,
+			wantErrMsg:      "request failed with status 500: POST",
+			wantIsTransient: true, // 500 IS transient
+		},
+		{
+			name: "HTTP 503 error is transient",
+			request: &computev1.GenerateAttributeBasedRecommendationsRequest{
+				SubscriptionId: "sub-123",
+				Location:       "eastus",
+				RegularPriorityProfile: &computev1.RegularPriorityProfile{
+					TargetCapacity: 5,
+				},
+			},
+			mockStatusCode:  http.StatusServiceUnavailable,
+			mockResponse:    `{"error":"service unavailable"}`,
+			wantErr:         true,
+			wantErrMsg:      "request failed with status 503: POST",
+			wantIsTransient: true, // 503 IS transient
+		},
+		{
+			name: "HTTP 429 error is transient",
+			request: &computev1.GenerateAttributeBasedRecommendationsRequest{
+				SubscriptionId: "sub-123",
+				Location:       "eastus",
+				RegularPriorityProfile: &computev1.RegularPriorityProfile{
+					TargetCapacity: 5,
+				},
+			},
+			mockStatusCode:  http.StatusTooManyRequests,
+			mockResponse:    `{"error":"too many requests"}`,
+			wantErr:         true,
+			wantErrMsg:      "request failed with status 429: POST",
+			wantIsTransient: true, // 429 IS transient
 		},
 		{
 			name: "invalid JSON response",
@@ -238,6 +272,18 @@ func TestClient_GenerateAttributeBasedRecommendations(t *testing.T) {
 			if tt.wantErr && !strings.Contains(err.Error(), tt.wantErrMsg) {
 				t.Errorf("GenerateAttributeBasedRecommendations() error = %v, want error containing %q", err, tt.wantErrMsg)
 				return
+			}
+
+			// Check if error is a transient HTTPError.
+			if tt.wantErr && tt.wantIsTransient {
+				if !httputil.IsTransientHTTPError(err) {
+					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, want transient HTTPError", err)
+				}
+			}
+			if tt.wantErr && !tt.wantIsTransient && tt.mockStatusCode >= 400 && tt.mockStatusCode < 500 {
+				if httputil.IsTransientHTTPError(err) {
+					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, should NOT be transient HTTPError for 4xx errors", err)
+				}
 			}
 
 			// Compare response.

--- a/pkg/clients/azure/compute/vmsizerecommenderclient_test.go
+++ b/pkg/clients/azure/compute/vmsizerecommenderclient_test.go
@@ -7,6 +7,7 @@ package compute
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -274,15 +275,17 @@ func TestClient_GenerateAttributeBasedRecommendations(t *testing.T) {
 				return
 			}
 
-			// Check if error is a transient HTTPError.
+			// Check if error is a transient HTTPError by checking IsRetryable.
 			if tt.wantErr && tt.wantIsTransient {
-				if !httputil.IsTransientHTTPError(err) {
-					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, want transient HTTPError", err)
+				var httpErr *httputil.HTTPError
+				if !errors.As(err, &httpErr) || !httpErr.IsRetryable() {
+					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, want retryable HTTPError", err)
 				}
 			}
 			if tt.wantErr && !tt.wantIsTransient && tt.mockStatusCode >= 400 && tt.mockStatusCode < 500 {
-				if httputil.IsTransientHTTPError(err) {
-					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, should NOT be transient HTTPError for 4xx errors", err)
+				var httpErr *httputil.HTTPError
+				if errors.As(err, &httpErr) && httpErr.IsRetryable() {
+					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, should NOT be retryable HTTPError for 4xx errors", err)
 				}
 			}
 

--- a/pkg/clients/azure/compute/vmsizerecommenderclient_test.go
+++ b/pkg/clients/azure/compute/vmsizerecommenderclient_test.go
@@ -274,16 +274,16 @@ func TestClient_GenerateAttributeBasedRecommendations(t *testing.T) {
 				return
 			}
 
-			// Check if error is retryable using fleetErrors.IsRetryable.
+			// Check if error has retry policy using fleetErrors.IsRetryable.
 			if tt.wantErr && tt.wantIsTransient {
-				retryable, found := fleetErrors.IsRetryable(err)
-				if !found || !retryable {
+				isRetryable, hasRetryPolicy := fleetErrors.IsRetryable(err)
+				if !hasRetryPolicy || !isRetryable {
 					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, want retryable error", err)
 				}
 			}
 			if tt.wantErr && !tt.wantIsTransient && tt.mockStatusCode >= 400 && tt.mockStatusCode < 500 {
-				retryable, found := fleetErrors.IsRetryable(err)
-				if found && retryable {
+				isRetryable, hasRetryPolicy := fleetErrors.IsRetryable(err)
+				if hasRetryPolicy && isRetryable {
 					t.Errorf("GenerateAttributeBasedRecommendations() error = %v, should NOT be retryable for 4xx errors", err)
 				}
 			}

--- a/pkg/clients/httputil/httputil.go
+++ b/pkg/clients/httputil/httputil.go
@@ -7,7 +7,6 @@ Licensed under the MIT license.
 package httputil
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -53,32 +52,8 @@ var transientHTTPStatusCodes = map[int]bool{
 	http.StatusGatewayTimeout:      true, // 504 - Gateway timeout
 }
 
-// HTTPError represents an HTTP error with a status code that can be checked
-// for transient error conditions. HTTPError implements the RetryableError interface
-// from pkg/utils/errors, allowing control loops to make retry decisions based on
-// HTTP status codes without format-specific inspection.
-type HTTPError struct {
-	StatusCode int
-	Method     string
-	URL        string
-}
-
-// Error implements the error interface for HTTPError.
-func (e *HTTPError) Error() string {
-	return fmt.Sprintf("request failed with status %d: %s %s", e.StatusCode, e.Method, e.URL)
-}
-
-// IsRetryable implements the RetryableError interface.
-// It returns true for transient HTTP errors (429, 5xx) that may succeed on retry.
-func (e *HTTPError) IsRetryable() bool {
-	return transientHTTPStatusCodes[e.StatusCode]
-}
-
-// NewHTTPError creates a new HTTPError from an HTTP response.
-func NewHTTPError(resp *http.Response) *HTTPError {
-	return &HTTPError{
-		StatusCode: resp.StatusCode,
-		Method:     resp.Request.Method,
-		URL:        resp.Request.URL.String(),
-	}
+// IsTransientStatusCode returns true if the HTTP status code indicates a transient
+// error that may succeed on retry (429, 5xx).
+func IsTransientStatusCode(statusCode int) bool {
+	return transientHTTPStatusCodes[statusCode]
 }

--- a/pkg/clients/httputil/httputil.go
+++ b/pkg/clients/httputil/httputil.go
@@ -7,6 +7,8 @@ Licensed under the MIT license.
 package httputil
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -41,3 +43,50 @@ var (
 	// DefaultClientForAzure is the default HTTP client to access Azure services.
 	DefaultClientForAzure = &http.Client{Timeout: HTTPTimeoutAzure}
 )
+
+// transientHTTPStatusCodes defines HTTP status codes that indicate transient errors
+// which may succeed on retry.
+var transientHTTPStatusCodes = map[int]bool{
+	http.StatusTooManyRequests:     true, // 429 - Rate limiting
+	http.StatusInternalServerError: true, // 500 - Server error
+	http.StatusBadGateway:          true, // 502 - Bad gateway
+	http.StatusServiceUnavailable:  true, // 503 - Service unavailable
+	http.StatusGatewayTimeout:      true, // 504 - Gateway timeout
+}
+
+// HTTPError represents an HTTP error with a status code that can be checked
+// for transient error conditions.
+type HTTPError struct {
+	StatusCode int
+	Method     string
+	URL        string
+}
+
+// Error implements the error interface for HTTPError.
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("request failed with status %d: %s %s", e.StatusCode, e.Method, e.URL)
+}
+
+// IsTransient returns true if this error represents a transient HTTP error
+// that may succeed on retry.
+func (e *HTTPError) IsTransient() bool {
+	return transientHTTPStatusCodes[e.StatusCode]
+}
+
+// NewHTTPError creates a new HTTPError from an HTTP response.
+func NewHTTPError(resp *http.Response) *HTTPError {
+	return &HTTPError{
+		StatusCode: resp.StatusCode,
+		Method:     resp.Request.Method,
+		URL:        resp.Request.URL.String(),
+	}
+}
+
+// IsTransientHTTPError checks if the given error is or wraps a transient HTTP error.
+func IsTransientHTTPError(err error) bool {
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.IsTransient()
+	}
+	return false
+}

--- a/pkg/clients/httputil/httputil.go
+++ b/pkg/clients/httputil/httputil.go
@@ -7,7 +7,6 @@ Licensed under the MIT license.
 package httputil
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -55,7 +54,9 @@ var transientHTTPStatusCodes = map[int]bool{
 }
 
 // HTTPError represents an HTTP error with a status code that can be checked
-// for transient error conditions.
+// for transient error conditions. HTTPError implements the RetryableError interface
+// from pkg/utils/errors, allowing control loops to make retry decisions based on
+// HTTP status codes without format-specific inspection.
 type HTTPError struct {
 	StatusCode int
 	Method     string
@@ -67,9 +68,9 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("request failed with status %d: %s %s", e.StatusCode, e.Method, e.URL)
 }
 
-// IsTransient returns true if this error represents a transient HTTP error
-// that may succeed on retry.
-func (e *HTTPError) IsTransient() bool {
+// IsRetryable implements the RetryableError interface.
+// It returns true for transient HTTP errors (429, 5xx) that may succeed on retry.
+func (e *HTTPError) IsRetryable() bool {
 	return transientHTTPStatusCodes[e.StatusCode]
 }
 
@@ -80,13 +81,4 @@ func NewHTTPError(resp *http.Response) *HTTPError {
 		Method:     resp.Request.Method,
 		URL:        resp.Request.URL.String(),
 	}
-}
-
-// IsTransientHTTPError checks if the given error is or wraps a transient HTTP error.
-func IsTransientHTTPError(err error) bool {
-	var httpErr *HTTPError
-	if errors.As(err, &httpErr) {
-		return httpErr.IsTransient()
-	}
-	return false
 }

--- a/pkg/clients/httputil/httputil_test.go
+++ b/pkg/clients/httputil/httputil_test.go
@@ -7,64 +7,30 @@ package httputil
 
 import (
 	"net/http"
-	"net/url"
 	"testing"
 )
 
-func TestHTTPError(t *testing.T) {
-	resp := &http.Response{
-		StatusCode: http.StatusServiceUnavailable,
-		Request: &http.Request{
-			Method: http.MethodPost,
-			URL: &url.URL{
-				Scheme: "https",
-				Host:   "example.com",
-				Path:   "/api/v1/resource",
-			},
-		},
-	}
-
-	httpErr := NewHTTPError(resp)
-
-	// Test fields are populated correctly.
-	if httpErr.StatusCode != http.StatusServiceUnavailable {
-		t.Errorf("HTTPError.StatusCode = %d, want %d", httpErr.StatusCode, http.StatusServiceUnavailable)
-	}
-	if httpErr.Method != http.MethodPost {
-		t.Errorf("HTTPError.Method = %q, want %q", httpErr.Method, http.MethodPost)
-	}
-	if httpErr.URL != "https://example.com/api/v1/resource" {
-		t.Errorf("HTTPError.URL = %q, want %q", httpErr.URL, "https://example.com/api/v1/resource")
-	}
-
-	// Test Error() method.
-	wantErrMsg := "request failed with status 503: POST https://example.com/api/v1/resource"
-	if got := httpErr.Error(); got != wantErrMsg {
-		t.Errorf("HTTPError.Error() = %q, want %q", got, wantErrMsg)
-	}
-}
-
-func TestHTTPErrorIsRetryable(t *testing.T) {
+func TestIsTransientStatusCode(t *testing.T) {
 	tests := []struct {
-		name string
-		err  *HTTPError
-		want bool
+		name       string
+		statusCode int
+		want       bool
 	}{
-		{"400 Bad Request", &HTTPError{StatusCode: http.StatusBadRequest}, false},
-		{"401 Unauthorized", &HTTPError{StatusCode: http.StatusUnauthorized}, false},
-		{"403 Forbidden", &HTTPError{StatusCode: http.StatusForbidden}, false},
-		{"404 Not Found", &HTTPError{StatusCode: http.StatusNotFound}, false},
-		{"429 Too Many Requests", &HTTPError{StatusCode: http.StatusTooManyRequests}, true},
-		{"500 Internal Server Error", &HTTPError{StatusCode: http.StatusInternalServerError}, true},
-		{"502 Bad Gateway", &HTTPError{StatusCode: http.StatusBadGateway}, true},
-		{"503 Service Unavailable", &HTTPError{StatusCode: http.StatusServiceUnavailable}, true},
-		{"504 Gateway Timeout", &HTTPError{StatusCode: http.StatusGatewayTimeout}, true},
+		{"400 Bad Request", http.StatusBadRequest, false},
+		{"401 Unauthorized", http.StatusUnauthorized, false},
+		{"403 Forbidden", http.StatusForbidden, false},
+		{"404 Not Found", http.StatusNotFound, false},
+		{"429 Too Many Requests", http.StatusTooManyRequests, true},
+		{"500 Internal Server Error", http.StatusInternalServerError, true},
+		{"502 Bad Gateway", http.StatusBadGateway, true},
+		{"503 Service Unavailable", http.StatusServiceUnavailable, true},
+		{"504 Gateway Timeout", http.StatusGatewayTimeout, true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.err.IsRetryable(); got != tt.want {
-				t.Errorf("HTTPError.IsRetryable() = %v, want %v", got, tt.want)
+			if got := IsTransientStatusCode(tt.statusCode); got != tt.want {
+				t.Errorf("IsTransientStatusCode(%d) = %v, want %v", tt.statusCode, got, tt.want)
 			}
 		})
 	}

--- a/pkg/clients/httputil/httputil_test.go
+++ b/pkg/clients/httputil/httputil_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
+*/
+
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestHTTPError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusServiceUnavailable,
+		Request: &http.Request{
+			Method: http.MethodPost,
+			URL: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+				Path:   "/api/v1/resource",
+			},
+		},
+	}
+
+	httpErr := NewHTTPError(resp)
+
+	// Test fields are populated correctly.
+	if httpErr.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("HTTPError.StatusCode = %d, want %d", httpErr.StatusCode, http.StatusServiceUnavailable)
+	}
+	if httpErr.Method != http.MethodPost {
+		t.Errorf("HTTPError.Method = %q, want %q", httpErr.Method, http.MethodPost)
+	}
+	if httpErr.URL != "https://example.com/api/v1/resource" {
+		t.Errorf("HTTPError.URL = %q, want %q", httpErr.URL, "https://example.com/api/v1/resource")
+	}
+
+	// Test Error() method.
+	wantErrMsg := "request failed with status 503: POST https://example.com/api/v1/resource"
+	if got := httpErr.Error(); got != wantErrMsg {
+		t.Errorf("HTTPError.Error() = %q, want %q", got, wantErrMsg)
+	}
+}
+
+func TestIsTransientHTTPError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"non-HTTP error", fmt.Errorf("some error"), false},
+		{"400 Bad Request", &HTTPError{StatusCode: http.StatusBadRequest}, false},
+		{"401 Unauthorized", &HTTPError{StatusCode: http.StatusUnauthorized}, false},
+		{"403 Forbidden", &HTTPError{StatusCode: http.StatusForbidden}, false},
+		{"404 Not Found", &HTTPError{StatusCode: http.StatusNotFound}, false},
+		{"429 Too Many Requests", &HTTPError{StatusCode: http.StatusTooManyRequests}, true},
+		{"500 Internal Server Error", &HTTPError{StatusCode: http.StatusInternalServerError}, true},
+		{"502 Bad Gateway", &HTTPError{StatusCode: http.StatusBadGateway}, true},
+		{"503 Service Unavailable", &HTTPError{StatusCode: http.StatusServiceUnavailable}, true},
+		{"504 Gateway Timeout", &HTTPError{StatusCode: http.StatusGatewayTimeout}, true},
+		{"wrapped transient error", fmt.Errorf("outer: %w", &HTTPError{StatusCode: http.StatusServiceUnavailable}), true},
+		{"wrapped non-transient error", fmt.Errorf("outer: %w", &HTTPError{StatusCode: http.StatusBadRequest}), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTransientHTTPError(tt.err); got != tt.want {
+				t.Errorf("IsTransientHTTPError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/clients/httputil/httputil_test.go
+++ b/pkg/clients/httputil/httputil_test.go
@@ -6,7 +6,6 @@ Licensed under the MIT license.
 package httputil
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -45,14 +44,12 @@ func TestHTTPError(t *testing.T) {
 	}
 }
 
-func TestIsTransientHTTPError(t *testing.T) {
+func TestHTTPErrorIsRetryable(t *testing.T) {
 	tests := []struct {
 		name string
-		err  error
+		err  *HTTPError
 		want bool
 	}{
-		{"nil error", nil, false},
-		{"non-HTTP error", fmt.Errorf("some error"), false},
 		{"400 Bad Request", &HTTPError{StatusCode: http.StatusBadRequest}, false},
 		{"401 Unauthorized", &HTTPError{StatusCode: http.StatusUnauthorized}, false},
 		{"403 Forbidden", &HTTPError{StatusCode: http.StatusForbidden}, false},
@@ -62,14 +59,12 @@ func TestIsTransientHTTPError(t *testing.T) {
 		{"502 Bad Gateway", &HTTPError{StatusCode: http.StatusBadGateway}, true},
 		{"503 Service Unavailable", &HTTPError{StatusCode: http.StatusServiceUnavailable}, true},
 		{"504 Gateway Timeout", &HTTPError{StatusCode: http.StatusGatewayTimeout}, true},
-		{"wrapped transient error", fmt.Errorf("outer: %w", &HTTPError{StatusCode: http.StatusServiceUnavailable}), true},
-		{"wrapped non-transient error", fmt.Errorf("outer: %w", &HTTPError{StatusCode: http.StatusBadRequest}), false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsTransientHTTPError(tt.err); got != tt.want {
-				t.Errorf("IsTransientHTTPError() = %v, want %v", got, tt.want)
+			if got := tt.err.IsRetryable(); got != tt.want {
+				t.Errorf("HTTPError.IsRetryable() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/propertychecker/azure/checker.go
+++ b/pkg/propertychecker/azure/checker.go
@@ -18,6 +18,7 @@ import (
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
 	computev1 "go.goms.io/fleet/apis/protos/azure/compute/v1"
 	"go.goms.io/fleet/pkg/clients/azure/compute"
+	fleetErrors "go.goms.io/fleet/pkg/utils/errors"
 	"go.goms.io/fleet/pkg/utils/labels"
 )
 
@@ -58,6 +59,10 @@ func NewPropertyChecker(vmSizeRecommenderClient compute.AttributeBasedVMSizeReco
 //
 // The cluster must have both Azure location and subscription ID labels configured.
 // Returns true if the SKU capacity requirement can be met, false otherwise.
+//
+// Errors returned implement the RetryableError interface to indicate whether the operation
+// can be retried. Configuration errors (missing labels, invalid capacity) are non-retryable,
+// while Azure API errors preserve the retryability of the underlying HTTP error.
 func (s *PropertyChecker) CheckIfMeetSKUCapacityRequirement(
 	cluster *clusterv1beta1.MemberCluster,
 	req placementv1beta1.PropertySelectorRequirement,
@@ -65,18 +70,24 @@ func (s *PropertyChecker) CheckIfMeetSKUCapacityRequirement(
 ) (bool, error) {
 	location, err := labels.ExtractLabelFromMemberCluster(cluster, labels.AzureLocationLabel)
 	if err != nil {
-		return false, fmt.Errorf("failed to extract Azure location label from cluster %s: %w", cluster.Name, err)
+		// Missing label is a configuration error; not retryable.
+		return false, fleetErrors.NewUserError(err,
+			fmt.Sprintf("failed to extract Azure location label from cluster %s", cluster.Name))
 	}
 
 	subID, err := labels.ExtractLabelFromMemberCluster(cluster, labels.AzureSubscriptionIDLabel)
 	if err != nil {
-		return false, fmt.Errorf("failed to extract Azure subscription ID label from cluster %s: %w", cluster.Name, err)
+		// Missing label is a configuration error; not retryable.
+		return false, fleetErrors.NewUserError(err,
+			fmt.Sprintf("failed to extract Azure subscription ID label from cluster %s", cluster.Name))
 	}
 
 	// Extract capacity requirements from the property selector requirement.
 	capacity, err := extractCapacityRequirements(req)
 	if err != nil {
-		return false, fmt.Errorf("failed to extract capacity requirements from property selector requirement: %w", err)
+		// Invalid capacity specification is a user error; not retryable.
+		return false, fleetErrors.NewUserError(err,
+			"failed to extract capacity requirements from property selector requirement")
 	}
 
 	// Request VM size recommendations to validate SKU availability and capacity.
@@ -101,7 +112,10 @@ func (s *PropertyChecker) CheckIfMeetSKUCapacityRequirement(
 
 	respObj, err := s.vmSizeRecommenderClient.GenerateAttributeBasedRecommendations(context.Background(), request)
 	if err != nil {
-		return false, fmt.Errorf("failed to generate VM size recommendations from Azure: %w", err)
+		// Wrap the error with context. The underlying HTTPError (if present) implements
+		// RetryableError, so fleetErrors.IsRetryable() will detect it in the error chain.
+		return false, fleetErrors.Wraps(err,
+			fmt.Sprintf("failed to generate VM size recommendations from Azure for SKU %s in cluster %s", sku, cluster.Name))
 	}
 
 	// This check is a defense mechanism; vmSizeRecommenderClient should return a VM size recommendation

--- a/pkg/propertychecker/azure/checker.go
+++ b/pkg/propertychecker/azure/checker.go
@@ -112,8 +112,9 @@ func (s *PropertyChecker) CheckIfMeetSKUCapacityRequirement(
 
 	respObj, err := s.vmSizeRecommenderClient.GenerateAttributeBasedRecommendations(context.Background(), request)
 	if err != nil {
-		// Wrap the error with context. The underlying HTTPError (if present) implements
-		// RetryableError, so fleetErrors.IsRetryable() will detect it in the error chain.
+		// Wrap the error with context. The underlying error already has the appropriate
+		// category set (transient for 429/5xx, API server error for other failures),
+		// so fleetErrors.IsRetryable() will detect it in the error chain.
 		return false, fleetErrors.Wraps(err,
 			fmt.Sprintf("failed to generate VM size recommendations from Azure for SKU %s in cluster %s", sku, cluster.Name))
 	}

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -40,12 +40,12 @@ import (
 
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
-	"go.goms.io/fleet/pkg/clients/httputil"
 	"go.goms.io/fleet/pkg/scheduler/clustereligibilitychecker"
 	"go.goms.io/fleet/pkg/scheduler/queue"
 	"go.goms.io/fleet/pkg/utils/annotations"
 	"go.goms.io/fleet/pkg/utils/condition"
 	"go.goms.io/fleet/pkg/utils/controller"
+	fleetErrors "go.goms.io/fleet/pkg/utils/errors"
 	"go.goms.io/fleet/pkg/utils/parallelizer"
 )
 
@@ -540,9 +540,11 @@ func (f *framework) runAllPluginsForPickAllPlacementType(
 	passed, filtered, err := f.runFilterPlugins(ctx, state, policy, clusters)
 	if err != nil {
 		klog.ErrorS(err, "Failed to run filter plugins", "policySnapshot", policyRef)
-		// If the error is a transient HTTP error (e.g., 503 from external service),
-		// return it as-is so the scheduler can requeue. Otherwise, wrap it as unexpected behavior.
-		if httputil.IsTransientHTTPError(err) {
+		// Check if the error is retryable using structured error semantics.
+		// If the error (or any error in its chain) implements RetryableError and indicates
+		// it's retryable, return it as-is so the scheduler can requeue.
+		// Otherwise, wrap it as unexpected behavior.
+		if retryable, found := fleetErrors.IsRetryable(err); found && retryable {
 			return nil, nil, err
 		}
 		return nil, nil, controller.NewUnexpectedBehaviorError(err)
@@ -1165,9 +1167,11 @@ func (f *framework) runAllPluginsForPickNPlacementType(
 	passed, filtered, err := f.runFilterPlugins(ctx, state, policy, clusters)
 	if err != nil {
 		klog.ErrorS(err, "Failed to run filter plugins", "policySnapshot", policyRef)
-		// If the error is a transient HTTP error (e.g., 503 from external service),
-		// return it as-is so the scheduler can requeue. Otherwise, wrap it as unexpected behavior.
-		if httputil.IsTransientHTTPError(err) {
+		// Check if the error is retryable using structured error semantics.
+		// If the error (or any error in its chain) implements RetryableError and indicates
+		// it's retryable, return it as-is so the scheduler can requeue.
+		// Otherwise, wrap it as unexpected behavior.
+		if retryable, found := fleetErrors.IsRetryable(err); found && retryable {
 			return nil, nil, err
 		}
 		return nil, nil, controller.NewUnexpectedBehaviorError(err)

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,10 @@ const (
 	FullyScheduledReason = "SchedulingPolicyFulfilled"
 	// NotFullyScheduledReason is the reason string of placement condition when the placement policy cannot be fully satisfied.
 	NotFullyScheduledReason = "SchedulingPolicyUnfulfilled"
+
+	// Event reasons for scheduling errors.
+	// SchedulingErrorReason is used when the scheduler encounters an error during scheduling.
+	SchedulingErrorReason = "SchedulingError"
 
 	fullyScheduledMessage    = "found all cluster needed as specified by the scheduling policy, found %d cluster(s)"
 	notFullyScheduledMessage = "could not find all clusters needed as specified by the scheduling policy, found %d cluster(s) instead"
@@ -540,6 +545,9 @@ func (f *framework) runAllPluginsForPickAllPlacementType(
 	passed, filtered, err := f.runFilterPlugins(ctx, state, policy, clusters)
 	if err != nil {
 		klog.ErrorS(err, "Failed to run filter plugins", "policySnapshot", policyRef)
+		// Emit an event to inform the user about the scheduling error.
+		f.eventRecorder.Event(policy, corev1.EventTypeWarning, SchedulingErrorReason,
+			fmt.Sprintf("Failed to run filter plugins: %v", err))
 		// Check if the error is retryable using structured error semantics.
 		// If the error (or any error in its chain) implements RetryableError and indicates
 		// it's retryable, return it as-is so the scheduler can requeue.
@@ -1167,6 +1175,9 @@ func (f *framework) runAllPluginsForPickNPlacementType(
 	passed, filtered, err := f.runFilterPlugins(ctx, state, policy, clusters)
 	if err != nil {
 		klog.ErrorS(err, "Failed to run filter plugins", "policySnapshot", policyRef)
+		// Emit an event to inform the user about the scheduling error.
+		f.eventRecorder.Event(policy, corev1.EventTypeWarning, SchedulingErrorReason,
+			fmt.Sprintf("Failed to run filter plugins: %v", err))
 		// Check if the error is retryable using structured error semantics.
 		// If the error (or any error in its chain) implements RetryableError and indicates
 		// it's retryable, return it as-is so the scheduler can requeue.

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -548,11 +548,11 @@ func (f *framework) runAllPluginsForPickAllPlacementType(
 		// Emit an event to inform the user about the scheduling error.
 		f.eventRecorder.Event(policy, corev1.EventTypeWarning, SchedulingErrorReason,
 			fmt.Sprintf("Failed to run filter plugins: %v", err))
-		// Check if the error is retryable using structured error semantics.
-		// If the error (or any error in its chain) implements RetryableError and indicates
+		// Check if the error has a retry policy configured.
+		// If the error (or any error in its chain) implements ErrorWithRetryPolicy and indicates
 		// it's retryable, return it as-is so the scheduler can requeue.
 		// Otherwise, wrap it as unexpected behavior.
-		if retryable, found := fleetErrors.IsRetryable(err); found && retryable {
+		if isRetryable, hasRetryPolicy := fleetErrors.IsRetryable(err); hasRetryPolicy && isRetryable {
 			return nil, nil, err
 		}
 		return nil, nil, controller.NewUnexpectedBehaviorError(err)
@@ -1178,11 +1178,11 @@ func (f *framework) runAllPluginsForPickNPlacementType(
 		// Emit an event to inform the user about the scheduling error.
 		f.eventRecorder.Event(policy, corev1.EventTypeWarning, SchedulingErrorReason,
 			fmt.Sprintf("Failed to run filter plugins: %v", err))
-		// Check if the error is retryable using structured error semantics.
-		// If the error (or any error in its chain) implements RetryableError and indicates
+		// Check if the error has a retry policy configured.
+		// If the error (or any error in its chain) implements ErrorWithRetryPolicy and indicates
 		// it's retryable, return it as-is so the scheduler can requeue.
 		// Otherwise, wrap it as unexpected behavior.
-		if retryable, found := fleetErrors.IsRetryable(err); found && retryable {
+		if isRetryable, hasRetryPolicy := fleetErrors.IsRetryable(err); hasRetryPolicy && isRetryable {
 			return nil, nil, err
 		}
 		return nil, nil, controller.NewUnexpectedBehaviorError(err)

--- a/pkg/scheduler/framework/framework.go
+++ b/pkg/scheduler/framework/framework.go
@@ -40,6 +40,7 @@ import (
 
 	clusterv1beta1 "go.goms.io/fleet/apis/cluster/v1beta1"
 	placementv1beta1 "go.goms.io/fleet/apis/placement/v1beta1"
+	"go.goms.io/fleet/pkg/clients/httputil"
 	"go.goms.io/fleet/pkg/scheduler/clustereligibilitychecker"
 	"go.goms.io/fleet/pkg/scheduler/queue"
 	"go.goms.io/fleet/pkg/utils/annotations"
@@ -539,6 +540,11 @@ func (f *framework) runAllPluginsForPickAllPlacementType(
 	passed, filtered, err := f.runFilterPlugins(ctx, state, policy, clusters)
 	if err != nil {
 		klog.ErrorS(err, "Failed to run filter plugins", "policySnapshot", policyRef)
+		// If the error is a transient HTTP error (e.g., 503 from external service),
+		// return it as-is so the scheduler can requeue. Otherwise, wrap it as unexpected behavior.
+		if httputil.IsTransientHTTPError(err) {
+			return nil, nil, err
+		}
 		return nil, nil, controller.NewUnexpectedBehaviorError(err)
 	}
 
@@ -1159,6 +1165,11 @@ func (f *framework) runAllPluginsForPickNPlacementType(
 	passed, filtered, err := f.runFilterPlugins(ctx, state, policy, clusters)
 	if err != nil {
 		klog.ErrorS(err, "Failed to run filter plugins", "policySnapshot", policyRef)
+		// If the error is a transient HTTP error (e.g., 503 from external service),
+		// return it as-is so the scheduler can requeue. Otherwise, wrap it as unexpected behavior.
+		if httputil.IsTransientHTTPError(err) {
+			return nil, nil, err
+		}
 		return nil, nil, controller.NewUnexpectedBehaviorError(err)
 	}
 

--- a/pkg/scheduler/framework/framework_test.go
+++ b/pkg/scheduler/framework/framework_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1323,8 +1324,9 @@ func TestRunAllPluginsForPickAllPlacementType(t *testing.T) {
 				profile.WithFilterPlugin(p)
 			}
 			f := &framework{
-				profile:      profile,
-				parallelizer: parallelizer.NewParallelizer(parallelizer.DefaultNumOfWorkers),
+				profile:       profile,
+				parallelizer:  parallelizer.NewParallelizer(parallelizer.DefaultNumOfWorkers),
+				eventRecorder: record.NewFakeRecorder(10),
 			}
 
 			ctx := context.Background()
@@ -6253,8 +6255,9 @@ func TestRunAllPluginsForPickNPlacementType(t *testing.T) {
 			}
 
 			f := &framework{
-				profile:      profile,
-				parallelizer: parallelizer.NewParallelizer(parallelizer.DefaultNumOfWorkers),
+				profile:       profile,
+				parallelizer:  parallelizer.NewParallelizer(parallelizer.DefaultNumOfWorkers),
+				eventRecorder: record.NewFakeRecorder(10),
 			}
 
 			ctx := context.Background()

--- a/pkg/scheduler/framework/status.go
+++ b/pkg/scheduler/framework/status.go
@@ -140,13 +140,13 @@ func (s *Status) String() string {
 	return strings.Join(desc, ", ")
 }
 
-// AsError returns a status as an error; it returns nil if the status is of the internalError code.
+// AsError returns a status as an error; it returns nil if the status is not of the internalError code.
 func (s *Status) AsError() error {
 	if !s.IsInteralError() {
 		return nil
 	}
 
-	return fmt.Errorf("plugin %s returned an error %s", s.sourcePlugin, s.String())
+	return fmt.Errorf("plugin %s returned an error %w", s.sourcePlugin, s.err)
 }
 
 // NewNonErrorStatus returns a Status with a non-error status code.

--- a/pkg/scheduler/framework/status_test.go
+++ b/pkg/scheduler/framework/status_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -155,5 +156,81 @@ func TestNilStatusMethods(t *testing.T) {
 	wantDesc := statusCodeNames[Success]
 	if !cmp.Equal(status.String(), wantDesc) {
 		t.Fatalf("String() = %s, want %s", status.String(), wantDesc)
+	}
+}
+
+// customError is a custom error type for testing error chain preservation.
+type customError struct {
+	code int
+}
+
+func (e *customError) Error() string {
+	return fmt.Sprintf("custom error with code %d", e.code)
+}
+
+func TestAsError(t *testing.T) {
+	testCases := []struct {
+		name        string
+		status      *Status
+		wantNil     bool
+		originalErr error
+	}{
+		{
+			name:    "nil status returns nil",
+			status:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "success status returns nil",
+			status:  NewNonErrorStatus(Success, dummyPlugin, "reason1"),
+			wantNil: true,
+		},
+		{
+			name:    "unschedulable status returns nil",
+			status:  NewNonErrorStatus(ClusterUnschedulable, dummyPlugin, "reason1"),
+			wantNil: true,
+		},
+		{
+			name:        "internal error preserves error chain",
+			status:      FromError(&customError{code: 503}, dummyPlugin, "reason1", "reason2"),
+			wantNil:     false,
+			originalErr: &customError{code: 503},
+		},
+		{
+			name:        "internal error with wrapped error preserves full chain",
+			status:      FromError(fmt.Errorf("outer error: %w", &customError{code: 429}), dummyPlugin, "rate limited"),
+			wantNil:     false,
+			originalErr: &customError{code: 429},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.status.AsError()
+
+			if tc.wantNil {
+				if err != nil {
+					t.Fatalf("AsError() = %v, want nil", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("AsError() = nil, want non-nil error")
+			}
+
+			// Verify error message contains plugin name
+			if !strings.Contains(err.Error(), dummyPlugin) {
+				t.Errorf("AsError().Error() = %q, want it to contain plugin name %q", err.Error(), dummyPlugin)
+			}
+
+			// Verify the error chain is preserved using errors.As
+			var customErr *customError
+			if !errors.As(err, &customErr) {
+				t.Errorf("AsError() error chain broken: errors.As() could not find *customError in chain")
+			} else if customErr.code != tc.originalErr.(*customError).code {
+				t.Errorf("AsError() error chain: customError.code = %d, want %d", customErr.code, tc.originalErr.(*customError).code)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/framework/status_test.go
+++ b/pkg/scheduler/framework/status_test.go
@@ -170,10 +170,10 @@ func (e *customError) Error() string {
 
 func TestAsError(t *testing.T) {
 	testCases := []struct {
-		name        string
-		status      *Status
-		wantNil     bool
-		originalErr error
+		name     string
+		status   *Status
+		wantNil  bool
+		wantCode int
 	}{
 		{
 			name:    "nil status returns nil",
@@ -191,16 +191,16 @@ func TestAsError(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			name:        "internal error preserves error chain",
-			status:      FromError(&customError{code: 503}, dummyPlugin, "reason1", "reason2"),
-			wantNil:     false,
-			originalErr: &customError{code: 503},
+			name:     "internal error preserves error chain",
+			status:   FromError(&customError{code: 503}, dummyPlugin, "reason1", "reason2"),
+			wantNil:  false,
+			wantCode: 503,
 		},
 		{
-			name:        "internal error with wrapped error preserves full chain",
-			status:      FromError(fmt.Errorf("outer error: %w", &customError{code: 429}), dummyPlugin, "rate limited"),
-			wantNil:     false,
-			originalErr: &customError{code: 429},
+			name:     "internal error with wrapped error preserves full chain",
+			status:   FromError(fmt.Errorf("outer error: %w", &customError{code: 429}), dummyPlugin, "rate limited"),
+			wantNil:  false,
+			wantCode: 429,
 		},
 	}
 
@@ -228,8 +228,8 @@ func TestAsError(t *testing.T) {
 			var customErr *customError
 			if !errors.As(err, &customErr) {
 				t.Errorf("AsError() error chain broken: errors.As() could not find *customError in chain")
-			} else if customErr.code != tc.originalErr.(*customError).code {
-				t.Errorf("AsError() error chain: customError.code = %d, want %d", customErr.code, tc.originalErr.(*customError).code)
+			} else if customErr.code != tc.wantCode {
+				t.Errorf("AsError() error chain: customError.code = %d, want %d", customErr.code, tc.wantCode)
 			}
 		})
 	}

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -54,7 +54,38 @@ const (
 	ErrCategoryUncategorized ErrCategory = "uncategorized"
 )
 
+// RetryableError is an interface that errors can implement to indicate whether the
+// operation that caused the error can be retried. This allows the control loop to
+// make retry decisions based on error semantics rather than inspecting error formats.
+type RetryableError interface {
+	error
+	// IsRetryable returns true if the error is transient and the operation may succeed
+	// on retry. Returns false if the error is permanent and retrying would not help.
+	IsRetryable() bool
+}
+
+// IsRetryable checks if the given error (or any error in its chain) indicates that the
+// operation can be retried. It traverses the error chain using errors.As to find any
+// error that implements RetryableError interface.
+//
+// Returns:
+//   - (true, true) if a RetryableError is found and IsRetryable() returns true
+//   - (false, true) if a RetryableError is found and IsRetryable() returns false
+//   - (false, false) if no RetryableError is found in the chain
+func IsRetryable(err error) (retryable bool, found bool) {
+	if err == nil {
+		return false, false
+	}
+
+	var retryableErr RetryableError
+	if errors.As(err, &retryableErr) {
+		return retryableErr.IsRetryable(), true
+	}
+	return false, false
+}
+
 var _ error = &Error{}
+var _ RetryableError = &Error{}
 
 type Error struct {
 	// category is the category of the error.
@@ -75,6 +106,29 @@ func (e *Error) categoryWithDefault() ErrCategory {
 		return ErrCategoryUncategorized
 	}
 	return e.category
+}
+
+// IsRetryable implements the RetryableError interface.
+// It determines retryability based on the error category:
+//   - ErrCategoryTransient: retryable (will self-resolve)
+//   - ErrCategoryAPIServer: retryable (API server issues are often transient)
+//   - ErrCategoryUnexpected: not retryable (unknown state, cannot recover)
+//   - ErrCategoryUser: not retryable (requires user action to fix)
+//   - ErrCategoryUncategorized: retryable (default to retry when unknown)
+func (e *Error) IsRetryable() bool {
+	switch e.category {
+	case ErrCategoryTransient:
+		return true
+	case ErrCategoryAPIServer:
+		return true
+	case ErrCategoryUnexpected:
+		return false
+	case ErrCategoryUser:
+		return false
+	default:
+		// ErrCategoryUncategorized or unknown: default to retryable.
+		return true
+	}
 }
 
 // Error implements the error interface.

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -54,38 +54,38 @@ const (
 	ErrCategoryUncategorized ErrCategory = "uncategorized"
 )
 
-// RetryableError is an interface that errors can implement to indicate whether the
+// ErrorWithRetryPolicy is an interface that errors can implement to indicate whether the
 // operation that caused the error can be retried. This allows the control loop to
 // make retry decisions based on error semantics rather than inspecting error formats.
-type RetryableError interface {
+type ErrorWithRetryPolicy interface {
 	error
 	// IsRetryable returns true if the error is transient and the operation may succeed
 	// on retry. Returns false if the error is permanent and retrying would not help.
 	IsRetryable() bool
 }
 
-// IsRetryable checks if the given error (or any error in its chain) indicates that the
-// operation can be retried. It traverses the error chain using errors.As to find any
-// error that implements RetryableError interface.
+// IsRetryable checks if the given error (or any error in its chain) has a retry policy
+// configured. It traverses the error chain using errors.As to find any error that
+// implements ErrorWithRetryPolicy interface.
 //
 // Returns:
-//   - (true, true) if a RetryableError is found and IsRetryable() returns true
-//   - (false, true) if a RetryableError is found and IsRetryable() returns false
-//   - (false, false) if no RetryableError is found in the chain
-func IsRetryable(err error) (retryable bool, found bool) {
+//   - (true, true) if an ErrorWithRetryPolicy is found and IsRetryable() returns true
+//   - (false, true) if an ErrorWithRetryPolicy is found and IsRetryable() returns false
+//   - (false, false) if no ErrorWithRetryPolicy is found in the chain (no retry policy configured)
+func IsRetryable(err error) (isRetryable bool, hasRetryPolicy bool) {
 	if err == nil {
 		return false, false
 	}
 
-	var retryableErr RetryableError
-	if errors.As(err, &retryableErr) {
-		return retryableErr.IsRetryable(), true
+	var errWithPolicy ErrorWithRetryPolicy
+	if errors.As(err, &errWithPolicy) {
+		return errWithPolicy.IsRetryable(), true
 	}
 	return false, false
 }
 
 var _ error = &Error{}
-var _ RetryableError = &Error{}
+var _ ErrorWithRetryPolicy = &Error{}
 
 type Error struct {
 	// category is the category of the error.
@@ -108,7 +108,7 @@ func (e *Error) categoryWithDefault() ErrCategory {
 	return e.category
 }
 
-// IsRetryable implements the RetryableError interface.
+// IsRetryable implements the ErrorWithRetryPolicy interface.
 // It determines retryability based on the error category:
 //   - ErrCategoryTransient: retryable (will self-resolve)
 //   - ErrCategoryAPIServer: retryable (API server issues are often transient)

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -579,16 +579,16 @@ func readFromBuffer(t *testing.T, buf *bytes.Buffer) string {
 	return outputStr
 }
 
-// mockRetryableError is a test helper that implements the RetryableError interface.
-type mockRetryableError struct {
+// mockErrorWithRetryPolicy is a test helper that implements the ErrorWithRetryPolicy interface.
+type mockErrorWithRetryPolicy struct {
 	retryable bool
 }
 
-func (e *mockRetryableError) Error() string {
-	return "mock retryable error"
+func (e *mockErrorWithRetryPolicy) Error() string {
+	return "mock error with retry policy"
 }
 
-func (e *mockRetryableError) IsRetryable() bool {
+func (e *mockErrorWithRetryPolicy) IsRetryable() bool {
 	return e.retryable
 }
 
@@ -606,26 +606,26 @@ func TestIsRetryableFunction(t *testing.T) {
 			wantFound:     false,
 		},
 		{
-			name:          "plain error (no RetryableError in chain)",
+			name:          "plain error (no retry policy in chain)",
 			err:           fmt.Errorf("plain error"),
 			wantRetryable: false,
 			wantFound:     false,
 		},
 		{
-			name:          "mock retryable error (retryable=true)",
-			err:           &mockRetryableError{retryable: true},
+			name:          "error with retry policy (retryable=true)",
+			err:           &mockErrorWithRetryPolicy{retryable: true},
 			wantRetryable: true,
 			wantFound:     true,
 		},
 		{
-			name:          "mock retryable error (retryable=false)",
-			err:           &mockRetryableError{retryable: false},
+			name:          "error with retry policy (retryable=false)",
+			err:           &mockErrorWithRetryPolicy{retryable: false},
 			wantRetryable: false,
 			wantFound:     true,
 		},
 		{
-			name:          "wrapped mock retryable error",
-			err:           fmt.Errorf("wrapped: %w", &mockRetryableError{retryable: true}),
+			name:          "wrapped error with retry policy",
+			err:           fmt.Errorf("wrapped: %w", &mockErrorWithRetryPolicy{retryable: true}),
 			wantRetryable: true,
 			wantFound:     true,
 		},

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -578,3 +578,154 @@ func readFromBuffer(t *testing.T, buf *bytes.Buffer) string {
 	outputStr := string(output)
 	return outputStr
 }
+
+// mockRetryableError is a test helper that implements the RetryableError interface.
+type mockRetryableError struct {
+	retryable bool
+}
+
+func (e *mockRetryableError) Error() string {
+	return "mock retryable error"
+}
+
+func (e *mockRetryableError) IsRetryable() bool {
+	return e.retryable
+}
+
+func TestIsRetryableFunction(t *testing.T) {
+	testCases := []struct {
+		name          string
+		err           error
+		wantRetryable bool
+		wantFound     bool
+	}{
+		{
+			name:          "nil error",
+			err:           nil,
+			wantRetryable: false,
+			wantFound:     false,
+		},
+		{
+			name:          "plain error (no RetryableError in chain)",
+			err:           fmt.Errorf("plain error"),
+			wantRetryable: false,
+			wantFound:     false,
+		},
+		{
+			name:          "mock retryable error (retryable=true)",
+			err:           &mockRetryableError{retryable: true},
+			wantRetryable: true,
+			wantFound:     true,
+		},
+		{
+			name:          "mock retryable error (retryable=false)",
+			err:           &mockRetryableError{retryable: false},
+			wantRetryable: false,
+			wantFound:     true,
+		},
+		{
+			name:          "wrapped mock retryable error",
+			err:           fmt.Errorf("wrapped: %w", &mockRetryableError{retryable: true}),
+			wantRetryable: true,
+			wantFound:     true,
+		},
+		{
+			name:          "Error with ErrCategoryTransient (retryable)",
+			err:           &Error{category: ErrCategoryTransient},
+			wantRetryable: true,
+			wantFound:     true,
+		},
+		{
+			name:          "Error with ErrCategoryUser (not retryable)",
+			err:           &Error{category: ErrCategoryUser},
+			wantRetryable: false,
+			wantFound:     true,
+		},
+		{
+			name:          "Error with ErrCategoryUnexpected (not retryable)",
+			err:           &Error{category: ErrCategoryUnexpected},
+			wantRetryable: false,
+			wantFound:     true,
+		},
+		{
+			name:          "Error with ErrCategoryAPIServer (retryable)",
+			err:           &Error{category: ErrCategoryAPIServer},
+			wantRetryable: true,
+			wantFound:     true,
+		},
+		{
+			name:          "Error with ErrCategoryUncategorized (retryable by default)",
+			err:           &Error{category: ErrCategoryUncategorized},
+			wantRetryable: true,
+			wantFound:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRetryable, gotFound := IsRetryable(tc.err)
+			if gotRetryable != tc.wantRetryable {
+				t.Errorf("IsRetryable() retryable = %v, want %v", gotRetryable, tc.wantRetryable)
+			}
+			if gotFound != tc.wantFound {
+				t.Errorf("IsRetryable() found = %v, want %v", gotFound, tc.wantFound)
+			}
+		})
+	}
+}
+
+func TestErrorIsRetryable(t *testing.T) {
+	testCases := []struct {
+		name          string
+		err           *Error
+		wantRetryable bool
+	}{
+		{
+			name:          "ErrCategoryTransient is retryable",
+			err:           &Error{category: ErrCategoryTransient},
+			wantRetryable: true,
+		},
+		{
+			name:          "ErrCategoryAPIServer is retryable",
+			err:           &Error{category: ErrCategoryAPIServer},
+			wantRetryable: true,
+		},
+		{
+			name:          "ErrCategoryUnexpected is not retryable",
+			err:           &Error{category: ErrCategoryUnexpected},
+			wantRetryable: false,
+		},
+		{
+			name:          "ErrCategoryUser is not retryable",
+			err:           &Error{category: ErrCategoryUser},
+			wantRetryable: false,
+		},
+		{
+			name:          "ErrCategoryUncategorized is retryable by default",
+			err:           &Error{category: ErrCategoryUncategorized},
+			wantRetryable: true,
+		},
+		{
+			name:          "empty category defaults to retryable",
+			err:           &Error{},
+			wantRetryable: true,
+		},
+		{
+			name: "Error with wrapped error uses its own category",
+			err: &Error{
+				category: ErrCategoryUser,
+				wrapped:  fmt.Errorf("plain error"),
+			},
+			wantRetryable: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRetryable := tc.err.IsRetryable()
+			if gotRetryable != tc.wantRetryable {
+				t.Errorf("IsRetryable() = %v, want %v", gotRetryable, tc.wantRetryable)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

When a querying the vm size recommender client, there may be times the client can run into transient client errors that will resolve on retry. At the moment the scheduler only runs once and sees all errors as unexpected. Now the possibility of transient http errors is possible with the addition of using azure property checker as we query an azure client. Therefore, these should not be considered unexpected, and the scheduler should be able to requeue on these errors.

Fixes #

I have: 
- Updated the scheduler to requeue on http errors. 
- Simplified http error logging to be one line for easier debugging.

- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it needs to tested and shown to be correct.
Briefly describe the testing that has already been done or which is planned for this change.
-->


### Special notes for your reviewer

Simplified logging:

```
## BEFORE
E0612 02:18:53.167602 1 compute/vmsizerecommenderclient.go:122] "Failed to generate VM size re...
request failed with status 503: POST http://127.0.0.1:5859/compute/subscriptions/a5191316-d253-43e3...

## AFTER
E0623 12:38:21.725116  158733 vmsizerecommenderclient.go:121] "Failed to generate VM size recommendations" err="request failed with status 503: POST http://127.0.0.1:35911/subscriptions/sub-123/providers/Microsoft.Compute/locations/eastus/vmSizeRecommendations/vmAttributeBased/generate" subscriptionID="sub-123" location="eastus" clientRequestID="c68fbda3-fc22-400f-abd0-e15b4f7af56f" latencyMs=2
```

With this change the scheduler would be pending until the errors return other errors/status codes that we don't deem transient while it retries.

```yaml
status:
  conditions:
  - lastTransitionTime: "2026-06-24T22:49:33Z"
    message: Scheduling has not completed
    observedGeneration: 4
    reason: SchedulePending
    status: Unknown
    type: ClusterResourcePlacementScheduled
```

**Open Question:** Do we want to keep the status as not complete/pending? 
- I think we should update the status for these specific scenarios (http errors from trying to query the capacity) so that the user has more of an idea of what is happening without having to sift through the logs.
